### PR TITLE
Add automated tests and CI for GPT virus scanner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-tk
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest openai
+
+      - name: Run tests
+        run: python -m pytest

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,15 @@ python gptscan.py
 - Deep scan: By default, the prefilter will scan the first and last 1024 bytes of each file. Deep scan will scan every byte of the file, top to bottom.
 - Use ChatGPT: Use ChatGPT to assess the interesting files.
 
+## Testing
+
+- Install development dependencies: `python -m pip install pytest openai` (and `python3-tk` from your package manager if Tkinter is missing).
+- Run the automated test suite:
+
+```bash
+python -m pytest
+```
+
 ## Contributing
 
 - Send a pull request, and I'll add reasonable changes.

--- a/tests/test_data/benign.txt
+++ b/tests/test_data/benign.txt
@@ -1,0 +1,1 @@
+safe content

--- a/tests/test_data/subdir/malicious.py
+++ b/tests/test_data/subdir/malicious.py
@@ -1,0 +1,1 @@
+suspicious_code()

--- a/tests/test_gpt_integration.py
+++ b/tests/test_gpt_integration.py
@@ -1,0 +1,48 @@
+import sys
+from types import SimpleNamespace
+
+import gptscan
+
+
+class _MockChatCompletion:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def create(self, model, messages):
+        self.calls += 1
+        return next(self.responses)
+
+
+class _MockResponse:
+    def __init__(self, content):
+        self.choices = [SimpleNamespace(message=SimpleNamespace(content=content))]
+
+
+def test_handle_gpt_response_returns_cached_result(monkeypatch):
+    gptscan.gpt_cache = {}
+    gptscan.apikey = "dummy"
+    responses = [_MockResponse('{"administrator": "Admin", "end-user": "User", "threat-level": 50}')]
+    mock_chat = _MockChatCompletion(responses)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(ChatCompletion=mock_chat))
+
+    result_first = gptscan.handle_gpt_response("snippet", "task")
+    result_second = gptscan.handle_gpt_response("snippet", "task")
+
+    assert result_first == result_second
+    assert mock_chat.calls == 1
+
+
+def test_handle_gpt_response_retries_after_invalid_json(monkeypatch):
+    gptscan.gpt_cache = {}
+    gptscan.apikey = "dummy"
+    invalid_response = _MockResponse('{"administrator": "Admin"}')
+    valid_response = _MockResponse('{"administrator": "Admin", "end-user": "User", "threat-level": 70}')
+    mock_chat = _MockChatCompletion([invalid_response, valid_response])
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(ChatCompletion=mock_chat))
+    monkeypatch.setattr(gptscan, "MAX_RETRIES", 3)
+
+    result = gptscan.handle_gpt_response("another snippet", "task")
+
+    assert result["threat-level"] == 70
+    assert mock_chat.calls == 2

--- a/tests/test_gptscan.py
+++ b/tests/test_gptscan.py
@@ -1,0 +1,129 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+import gptscan
+
+
+def test_load_file_single_line(tmp_path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("first line\nsecond line")
+
+    result = gptscan.load_file(str(file_path))
+
+    assert result == "first line"
+
+
+def test_load_file_multi_line(tmp_path):
+    file_path = tmp_path / "lines.txt"
+    file_path.write_text("line1\nline2\n")
+
+    result = gptscan.load_file(str(file_path), mode="multi_line")
+
+    assert result == ["line1", "line2"]
+
+
+def test_load_file_missing_returns_empty_string():
+    assert gptscan.load_file("non_existent_file.txt") == ""
+
+
+class _MockChoice:
+    def __init__(self, content: str):
+        self.message = SimpleNamespace(content=content)
+
+
+class _MockResponse:
+    def __init__(self, content: str):
+        self.choices = [_MockChoice(content)]
+
+
+def test_extract_data_from_gpt_response_parses_json():
+    response = _MockResponse(
+        json.dumps(
+            {
+                "administrator": "Admin",
+                "end-user": "User",
+                "threat-level": 75,
+            }
+        )
+    )
+
+    parsed = gptscan.extract_data_from_gpt_response(response)
+
+    assert parsed["administrator"] == "Admin"
+    assert parsed["end-user"] == "User"
+    assert parsed["threat-level"] == 75
+
+
+def test_extract_data_from_gpt_response_invalid_missing_keys():
+    response = _MockResponse(json.dumps({"administrator": "Only admin"}))
+
+    error = gptscan.extract_data_from_gpt_response(response)
+
+    assert "Missing keys" in error
+
+
+def test_extract_data_from_gpt_response_invalid_threat_level():
+    response = _MockResponse(
+        json.dumps(
+            {
+                "administrator": "Admin",
+                "end-user": "User",
+                "threat-level": "high",  # not an integer
+            }
+        )
+    )
+
+    error = gptscan.extract_data_from_gpt_response(response)
+
+    assert "not a valid integer" in error
+
+
+def test_list_files_returns_files_only(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "root.txt").write_text("root")
+    (nested / "child.txt").write_text("child")
+    (nested / "subdir").mkdir()
+
+    files = gptscan.list_files(tmp_path)
+
+    assert set(Path(f) for f in files) == {
+        tmp_path / "root.txt",
+        nested / "child.txt",
+    }
+
+
+def test_sort_column_orders_treeview():
+    class _FakeTree:
+        def __init__(self):
+            self.data = {
+                "item1": {"values": ("b", "10%")},
+                "item2": {"values": ("a", "30%")},
+            }
+            self.order = ["item1", "item2"]
+            self.heading_calls = {}
+
+        def set(self, iid, col):
+            columns = {"name": 0, "own_conf": 1}
+            return self.data[iid]["values"][columns[col]]
+
+        def get_children(self, *_):
+            return tuple(self.order)
+
+        def move(self, iid, _, index):
+            self.order.remove(iid)
+            self.order.insert(index, iid)
+
+        def heading(self, col, command=None):
+            self.heading_calls[col] = command
+
+    tree = _FakeTree()
+
+    gptscan.sort_column(tree, "name", False)
+    assert tree.get_children("") == ("item2", "item1")
+
+    gptscan.sort_column(tree, "own_conf", False)
+    assert tree.get_children("") == ("item1", "item2")


### PR DESCRIPTION
## Summary
- fix JSON parsing logic and gate GUI startup so the module can be safely imported in tests
- add unit and integration coverage for file loading, response parsing, sorting, and GPT handling with sample test data
- introduce GitHub Actions workflow and README instructions for running the automated test suite

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922cc77cda48330b621372967927370)