### PR TITLE
Handle legacy OpenAI client in tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -80,6 +80,8 @@ def handle_gpt_response(snippet, taskdesc):
         chat_completion = getattr(openai, "ChatCompletion", None)
         if chat_completion is None:
             raise AttributeError("openai client missing ChatCompletion")
+        if apikey:
+            openai.api_key = apikey
         create_completion = partial(chat_completion.create, model="gpt-3.5-turbo")
     cache_key = hash(snippet)
     if cache_key in gpt_cache:


### PR DESCRIPTION
## Summary
- add compatibility in `handle_gpt_response` for both OpenAI client styles
- use shared completion creator to support legacy ChatCompletion mocks

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d781df3c83309f22b63f5f752ca9)