### PR TITLE
Implement async GPT rate limiting and stricter response parsing

### DIFF
--- a/tests/test_gpt_integration.py
+++ b/tests/test_gpt_integration.py
@@ -22,6 +22,8 @@ class _MockResponse:
 def test_handle_gpt_response_returns_cached_result(monkeypatch):
     gptscan.Config.gpt_cache = {}
     gptscan.Config.apikey = "dummy"
+    gptscan._openai_client = None
+    gptscan._async_openai_client = None
     responses = [_MockResponse('{"administrator": "Admin", "end-user": "User", "threat-level": 50}')]
     mock_completions = _MockCompletions(responses)
 
@@ -41,6 +43,8 @@ def test_handle_gpt_response_returns_cached_result(monkeypatch):
 def test_handle_gpt_response_retries_after_invalid_json(monkeypatch):
     gptscan.Config.gpt_cache = {}
     gptscan.Config.apikey = "dummy"
+    gptscan._openai_client = None
+    gptscan._async_openai_client = None
     invalid_response = _MockResponse('{"administrator": "Admin"}')
     valid_response = _MockResponse('{"administrator": "Admin", "end-user": "User", "threat-level": 70}')
     mock_completions = _MockCompletions([invalid_response, valid_response])


### PR DESCRIPTION
## Summary
- add async GPT client handling with reusable clients, rate limiting, and CLI rate-limit flag
- refactor scanning to batch GPT calls with concurrency limits and improved progress reporting
- harden GPT response parsing and expand tests for async behavior and edge cases

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b7c9c16d483309287db84a10513fa)