### PR TITLE
[TEST] Add coverage and fix PermissionError in load_file

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -37,7 +37,7 @@ def load_file(filename: str, mode: str = 'single_line') -> Union[str, List[str]]
                 return file.readline().strip()
             elif mode == 'multi_line':
                 return file.read().splitlines()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         return [] if mode == 'multi_line' else ''
 
 

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -42,6 +42,26 @@ def test_load_file_missing_multi_line():
     result = load_file("non_existent.txt", mode='multi_line')
     assert result == []
 
+def test_load_file_permission_error_single_line(tmp_path):
+    f = tmp_path / "protected.txt"
+    f.write_text("secret")
+    f.chmod(0o000)
+    try:
+        result = load_file(str(f), mode='single_line')
+        assert result == ""
+    finally:
+        f.chmod(0o644)
+
+def test_load_file_permission_error_multi_line(tmp_path):
+    f = tmp_path / "protected.txt"
+    f.write_text("line1\nline2")
+    f.chmod(0o000)
+    try:
+        result = load_file(str(f), mode='multi_line')
+        assert result == []
+    finally:
+        f.chmod(0o644)
+
 # --- parse_percent Tests ---
 
 @pytest.mark.parametrize("input_val, expected", [


### PR DESCRIPTION
Increased reliability and test coverage by handling and testing an edge case (permission errors) during file loading in the `load_file` utility function. Added comprehensive unit tests to ensure this behavior is preserved.

---
*PR created automatically by Jules for task [1067857462877724713](https://jules.google.com/task/1067857462877724713) started by @RainRat*