### PR TITLE
Redirect informational and error messages to stderr to prevent CLI stdout pollution

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -92,9 +92,9 @@ class Config:
     @classmethod
     def initialize(cls) -> None:
         if not cls.apikey:
-            print(cls.apikey_missing_message)
+            print(cls.apikey_missing_message, file=sys.stderr)
         if not cls.taskdesc:
-            print(cls.task_missing_message)
+            print(cls.task_missing_message, file=sys.stderr)
 
         # Enable GPT if task description is present.
         # Specific provider requirements (like API key) are checked at runtime.
@@ -103,7 +103,7 @@ class Config:
         loaded_extensions = load_file('extensions.txt', mode='multi_line')
         if not loaded_extensions:
             cls.set_extensions(cls.DEFAULT_EXTENSIONS, missing=True)
-            print(cls.extensions_missing_message)
+            print(cls.extensions_missing_message, file=sys.stderr)
         else:
             cls.set_extensions(loaded_extensions)
 
@@ -383,13 +383,13 @@ async def async_handle_gpt_response(
                 retries += 1
                 await asyncio.sleep(backoff)
                 continue
-            print(f"An unexpected error occurred: {err}")
+            print(f"An unexpected error occurred: {err}", file=sys.stderr)
             break
 
         if isinstance(extracted_data, dict):
             json_data = extracted_data
         else:
-            print(extracted_data)
+            print(extracted_data, file=sys.stderr)
             messages.append({"role": "assistant", "content": response.choices[0].message.content})
             messages.append({"role": "user", "content": f"I encountered an issue: {extracted_data}. Could you correct your response?"})
             retries += 1
@@ -398,7 +398,7 @@ async def async_handle_gpt_response(
         Config.gpt_cache[cache_key] = json_data
         return json_data
 
-    print("Failed to obtain a valid response from GPT after multiple retries.")
+    print("Failed to obtain a valid response from GPT after multiple retries.", file=sys.stderr)
     return None
 
 
@@ -758,7 +758,7 @@ def scan_files(
                     )
                 )
             else:
-                print(file_path)
+                print(file_path, file=sys.stderr)
                 try:
                     file_size = file_path.stat().st_size
                 except OSError as err:
@@ -786,7 +786,7 @@ def scan_files(
                             for offset, window in iter_windows(f, file_size, deep_scan):
                                 if cancel_event.is_set():
                                     break
-                                print("Scanning at:", offset if offset > 0 else 0)
+                                print("Scanning at:", offset if offset > 0 else 0, file=sys.stderr)
                                 result, padded_bytes = predict_window(window)
                                 resultchecks.append(result)
                                 if result > maxconf:
@@ -951,7 +951,7 @@ def run_scan(
                     last_total = total
                 enqueue_ui_update(update_progress, current)
                 if status:
-                    print(status)
+                    print(status, file=sys.stderr)
                     enqueue_ui_update(update_status, status)
             elif event_type == 'result':
                 # data format: (path, own_conf, admin, user, gpt_conf, snippet)

--- a/tests/test_config_initialization.py
+++ b/tests/test_config_initialization.py
@@ -33,7 +33,7 @@ def test_initialize_missing_api_key(capsys):
         Config.initialize()
 
     captured = capsys.readouterr()
-    assert Config.apikey_missing_message in captured.out
+    assert Config.apikey_missing_message in captured.err
     # GPT should still be enabled if task is present (since local LLMs don't need API key)
     assert Config.GPT_ENABLED is True
 
@@ -46,7 +46,7 @@ def test_initialize_missing_task_file(capsys):
         Config.initialize()
 
     captured = capsys.readouterr()
-    assert Config.task_missing_message in captured.out
+    assert Config.task_missing_message in captured.err
     assert Config.GPT_ENABLED is False
 
 def test_initialize_missing_extensions_file(capsys):
@@ -59,7 +59,7 @@ def test_initialize_missing_extensions_file(capsys):
         Config.initialize()
 
     captured = capsys.readouterr()
-    assert Config.extensions_missing_message in captured.out
+    assert Config.extensions_missing_message in captured.err
     assert Config.extensions_set == set(Config.DEFAULT_EXTENSIONS)
     assert Config.extensions_missing is True
 
@@ -73,9 +73,9 @@ def test_initialize_all_present(capsys):
         Config.initialize()
 
     captured = capsys.readouterr()
-    assert Config.apikey_missing_message not in captured.out
-    assert Config.task_missing_message not in captured.out
-    assert Config.extensions_missing_message not in captured.out
+    assert Config.apikey_missing_message not in captured.err
+    assert Config.task_missing_message not in captured.err
+    assert Config.extensions_missing_message not in captured.err
 
     assert Config.GPT_ENABLED is True
     assert Config.extensions_set == set(custom_exts)


### PR DESCRIPTION
**What:** Updated `gptscan.py` to ensure all non-data `print()` statements (configuration warnings, scan progress, and API errors) use `file=sys.stderr`. Correspondingly updated unit tests in `tests/test_config_initialization.py` to verify these messages are captured in the error stream.
**Why:** When running in CLI mode with structured output formats (JSON, CSV, SARIF, HTML), informational messages previously polluted the `stdout` stream, resulting in invalid or corrupted output files. Redirecting these to `stderr` maintains a clean data stream while still providing feedback to the user in the terminal. No breaking changes were introduced to the application logic.

---
*PR created automatically by Jules for task [13641388798635221376](https://jules.google.com/task/13641388798635221376) started by @RainRat*