### PR TITLE
[TEST] Ensure file extensions always include a leading dot

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -87,7 +87,11 @@ class Config:
     @classmethod
     def set_extensions(cls, extensions_list: List[str], missing: bool = False) -> None:
         cls.extensions_missing = missing
-        cls.extensions_set = {ext.strip().lower() for ext in extensions_list if ext.strip()}
+        cls.extensions_set = set()
+        for ext in extensions_list:
+            clean_ext = ext.strip().lower()
+            if clean_ext:
+                cls.extensions_set.add(clean_ext if clean_ext.startswith('.') else f".{clean_ext}")
 
     @classmethod
     def initialize(cls) -> None:

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -13,6 +13,12 @@ def test_config_set_extensions():
     assert Config.extensions_set == {".py", ".js", ".bat"}
     assert Config.extensions_missing is False
 
+def test_config_set_extensions_missing_dots():
+    extensions = ["py", "JS", ".bat", "  txt  "]
+    Config.set_extensions(extensions, missing=False)
+
+    assert Config.extensions_set == {".py", ".js", ".bat", ".txt"}
+
 def test_config_set_extensions_empty():
     Config.set_extensions([], missing=True)
     assert Config.extensions_set == set()


### PR DESCRIPTION
This PR addresses a functional gap in the scanner's configuration logic. Since `pathlib.Path.suffix` always includes a leading dot, any extensions provided by the user without a dot (e.g., via the CLI `--extensions py` flag) would previously fail to match any files. 

The fix ensures that all extensions are normalized to include a dot and are lowercase, improving the tool's robustness. Corresponding test coverage has been added and verified, following the repository's strict "no comments in tests" guideline.

---
*PR created automatically by Jules for task [7613255461060535539](https://jules.google.com/task/7613255461060535539) started by @RainRat*