### PR TITLE
Extract effective confidence calculation to ensure consistent fallback logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -515,6 +515,14 @@ def parse_percent(val: str, default: float = -1.0) -> float:
         return default
 
 
+def get_effective_confidence(own_conf_str: Any, gpt_conf_str: Any) -> float:
+    """Calculate the effective confidence score, prioritizing GPT over local AI."""
+    gpt_val = parse_percent(gpt_conf_str)
+    if gpt_val >= 0:
+        return gpt_val
+    return parse_percent(own_conf_str)
+
+
 def sort_column(tv: ttk.Treeview, col: str, reverse: bool) -> None:
     """Sort a Treeview column, toggling sort order on subsequent clicks.
 
@@ -548,9 +556,7 @@ def insert_tree_row(values: Tuple[Any, ...]) -> None:
 
     # Determine risk level based on confidence scores
     # data format: (path, own_conf, admin, user, gpt_conf, snippet)
-    gpt_conf = parse_percent(values[4])
-    own_conf = parse_percent(values[1])
-    conf = gpt_conf if gpt_conf >= 0 else own_conf
+    conf = get_effective_confidence(values[1], values[4])
 
     tag = ''
     if conf > 80:
@@ -959,9 +965,7 @@ def run_scan(
                     enqueue_ui_update(update_status, status)
             elif event_type == 'result':
                 # data format: (path, own_conf, admin, user, gpt_conf, snippet)
-                gpt_conf = parse_percent(data[4])
-                own_conf = parse_percent(data[1])
-                conf = gpt_conf if gpt_conf >= 0 else own_conf
+                conf = get_effective_confidence(data[1], data[4])
 
                 if conf > 50:
                     threats_found += 1
@@ -988,8 +992,7 @@ def generate_sarif(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     for r in results:
         # Convert confidence strings to levels
         level = "note"
-        conf_str = r.get("gpt_conf", "") or r.get("own_conf", "")
-        conf = parse_percent(conf_str)
+        conf = get_effective_confidence(r.get("own_conf", ""), r.get("gpt_conf", ""))
         if conf > 80:
             level = "error"
         elif conf > 50:
@@ -1066,7 +1069,7 @@ def generate_html(results: List[Dict[str, Any]]) -> str:
         user = r.get("end-user_desc", "")
         snippet = r.get("snippet", "")
 
-        conf_val = parse_percent(gpt_conf) if gpt_conf else parse_percent(own_conf)
+        conf_val = get_effective_confidence(own_conf, gpt_conf)
 
         row_class = ""
         if conf_val > 80:
@@ -1176,9 +1179,7 @@ def run_cli(targets: Union[str, List[str]], deep: bool, show_all: bool, use_gpt:
     ):
         if event_type == 'result':
             # data format: (path, own_conf, admin, user, gpt_conf, snippet)
-            gpt_conf = parse_percent(data[4])
-            own_conf = parse_percent(data[1])
-            conf = gpt_conf if gpt_conf >= 0 else own_conf
+            conf = get_effective_confidence(data[1], data[4])
             if conf > 50:
                 threats_found += 1
 

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -1,7 +1,7 @@
 import tkinter.font
 import pytest
 from unittest.mock import MagicMock
-from gptscan import Config, load_file, parse_percent, adjust_newlines, sort_column
+from gptscan import Config, load_file, parse_percent, get_effective_confidence, adjust_newlines, sort_column
 
 
 # --- Config Tests ---
@@ -85,6 +85,20 @@ def test_parse_percent(input_val, expected):
 
 def test_parse_percent_custom_default():
     assert parse_percent("invalid", default=0.0) == 0.0
+
+# --- get_effective_confidence Tests ---
+
+@pytest.mark.parametrize("own, gpt, expected", [
+    ("50%", "80%", 80.0),    # GPT prioritized
+    ("50%", "", 50.0),      # Fallback to local
+    ("50%", "invalid", 50.0), # Fallback to local on GPT error
+    ("50%", "0%", 0.0),     # GPT prioritized even if 0
+    ("", "80%", 80.0),      # GPT prioritized even if local missing
+    ("", "", -1.0),         # Both missing
+    ("invalid", "invalid", -1.0), # Both invalid
+])
+def test_get_effective_confidence(own, gpt, expected):
+    assert get_effective_confidence(own, gpt) == expected
 
 # --- adjust_newlines Tests ---
 


### PR DESCRIPTION
Extracted the logic for determining the effective confidence score into a reusable helper function `get_effective_confidence`. This removes duplication and fixes a logic bug in `generate_sarif` and `generate_html` where they previously failed to fall back to the local model's confidence if the GPT analysis resulted in an error string (e.g., "JSON Parse Error"). Behavior in other parts of the application remains identical. All 150 tests pass.

---
*PR created automatically by Jules for task [1450943628295256199](https://jules.google.com/task/1450943628295256199) started by @RainRat*