### PR TITLE
[FEAT] Add 'Git changes only' scanning to GUI

### DIFF
--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -1,0 +1,84 @@
+import os
+import threading
+from unittest.mock import MagicMock, patch
+import pytest
+import gptscan
+
+def test_button_click_with_git_changes_enabled(monkeypatch):
+    # Setup mocks
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "/some/repo"
+    monkeypatch.setattr(gptscan, 'textbox', mock_textbox, raising=False)
+
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+
+    mock_git_var = MagicMock()
+    mock_git_var.get.return_value = True
+    monkeypatch.setattr(gptscan, 'git_var', mock_git_var, raising=False)
+
+    # Mock other vars
+    monkeypatch.setattr(gptscan, 'deep_var', MagicMock(get=lambda: False), raising=False)
+    monkeypatch.setattr(gptscan, 'all_var', MagicMock(get=lambda: False), raising=False)
+    monkeypatch.setattr(gptscan, 'gpt_var', MagicMock(get=lambda: False), raising=False)
+    monkeypatch.setattr(gptscan, 'dry_var', MagicMock(get=lambda: True), raising=False) # Dry run to avoid model load
+
+    # Mock tree
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree, raising=False)
+
+    # Mock status_label and progress_bar
+    monkeypatch.setattr(gptscan, 'status_label', MagicMock(), raising=False)
+    monkeypatch.setattr(gptscan, 'progress_bar', MagicMock(), raising=False)
+    monkeypatch.setattr(gptscan, 'root', MagicMock(), raising=False)
+
+    # Mock buttons
+    monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
+    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
+
+    # Mock get_git_changed_files
+    mock_get_git = MagicMock(return_value=["/some/repo/file1.py", "/some/repo/file2.py"])
+    monkeypatch.setattr(gptscan, 'get_git_changed_files', mock_get_git)
+
+    # Mock Thread
+    mock_thread = MagicMock()
+    monkeypatch.setattr(gptscan.threading, 'Thread', mock_thread)
+
+    # Action
+    gptscan.button_click()
+
+    # Assert
+    mock_get_git.assert_called_once_with("/some/repo")
+    mock_thread.assert_called_once()
+    _, kwargs = mock_thread.call_args
+    assert kwargs['args'][0] == ["/some/repo/file1.py", "/some/repo/file2.py"]
+
+def test_button_click_with_git_changes_no_changes(monkeypatch):
+    # Setup mocks
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "/some/repo"
+    monkeypatch.setattr(gptscan, 'textbox', mock_textbox, raising=False)
+
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+
+    mock_git_var = MagicMock()
+    mock_git_var.get.return_value = True
+    monkeypatch.setattr(gptscan, 'git_var', mock_git_var, raising=False)
+
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, 'messagebox', mock_msgbox)
+
+    # Mock get_git_changed_files to return empty list
+    mock_get_git = MagicMock(return_value=[])
+    monkeypatch.setattr(gptscan, 'get_git_changed_files', mock_get_git)
+
+    # Mock Thread (should not be called)
+    mock_thread = MagicMock()
+    monkeypatch.setattr(gptscan.threading, 'Thread', mock_thread)
+
+    # Action
+    gptscan.button_click()
+
+    # Assert
+    mock_get_git.assert_called_once_with("/some/repo")
+    mock_msgbox.showinfo.assert_called_once_with("Git Scan", "No git changes detected in the selected directory.")
+    mock_thread.assert_not_called()

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -45,7 +45,7 @@ def test_changes_detected():
 
         # Result should be unique list of all 3 files
         assert len(files) == 3
-        assert set(files) == {"staged.py", "unstaged.py", "untracked.py"}
+        assert set(files) == {os.path.join(".", "staged.py"), os.path.join(".", "unstaged.py"), os.path.join(".", "untracked.py")}
         assert mock_check_output.call_count == 2
 
 def test_file_does_not_exist():
@@ -65,16 +65,20 @@ def test_file_does_not_exist():
 
         files = get_git_changed_files()
 
-        assert files == ["existing.py"]
-        assert "deleted.py" not in files
+        assert files == [os.path.join(".", "existing.py")]
+        assert os.path.join(".", "deleted.py") not in files
 
 def test_path_argument_passed():
     """Test that the path argument is correctly passed to git command cwd."""
-    with patch("subprocess.check_output") as mock_check_output:
-        mock_check_output.side_effect = ["", ""]
+    with patch("subprocess.check_output") as mock_check_output, \
+         patch("os.path.exists") as mock_exists:
+        mock_check_output.side_effect = ["changed.py", ""]
+        mock_exists.return_value = True
 
         target_dir = "/some/path"
-        get_git_changed_files(target_dir)
+        files = get_git_changed_files(target_dir)
+
+        assert files == [os.path.join(target_dir, "changed.py")]
 
         # Verify cwd was set correctly in both calls
         args1, kwargs1 = mock_check_output.call_args_list[0]

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -116,6 +116,10 @@ def test_button_click_missing_model(monkeypatch):
     mock_dry.get.return_value = False
     monkeypatch.setattr(gptscan, 'dry_var', mock_dry, raising=False)
 
+    mock_git = MagicMock()
+    mock_git.get.return_value = False
+    monkeypatch.setattr(gptscan, 'git_var', mock_git, raising=False)
+
     # Mock os.path.exists to fail for scripts.h5
     monkeypatch.setattr(gptscan.os.path, 'exists', lambda p: False)
 
@@ -151,6 +155,10 @@ def test_button_click_starts_scan(monkeypatch):
     mock_dry = MagicMock()
     mock_dry.get.return_value = False
     monkeypatch.setattr(gptscan, 'dry_var', mock_dry, raising=False)
+
+    mock_git = MagicMock()
+    mock_git.get.return_value = False
+    monkeypatch.setattr(gptscan, 'git_var', mock_git, raising=False)
 
     # Mock os.path.exists
     monkeypatch.setattr(gptscan.os.path, 'exists', lambda p: True)


### PR DESCRIPTION
Implemented the 'Git changes only' feature in the GUI, providing symmetry with the existing CLI functionality and improving the developer workflow. Fixed a path handling bug in `get_git_changed_files` to ensure reliability across different directories.

---
*PR created automatically by Jules for task [16791177406500487996](https://jules.google.com/task/16791177406500487996) started by @RainRat*