### PR TITLE
Remove unused variable in export_results

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1342,11 +1342,6 @@ def export_results() -> None:
     results = []
     for item_id in tree.get_children():
         values = list(tree.item(item_id)["values"])
-        # Simple unwrapping: replace single newlines that were likely added by adjust_newlines
-        # This isn't perfect but better than nothing for a quick export.
-        # Actually, for serious export, we'd want the raw data.
-        # But here we just use what's in the table.
-        cleaned_values = [str(v).replace('\n', ' ') if i != 5 else v for i, v in enumerate(values)]
         results.append(dict(zip(columns, values))) # Use original values for JSON/HTML/SARIF as they handle newlines better
 
     ext = os.path.splitext(file_path)[1].lower()


### PR DESCRIPTION
Removed a redundant variable assignment in the `export_results` function of `gptscan.py`. The variable `cleaned_values` was calculated but never used, as the original `values` list was passed to the result dictionary instead. Verified that this change has no impact on behavior and that all tests pass.

---
*PR created automatically by Jules for task [5240395145029294959](https://jules.google.com/task/5240395145029294959) started by @RainRat*