### PR TITLE
[FEAT] Scan Performance Metrics (Timing and Throughput)

### DIFF
--- a/tests/test_scan_logic.py
+++ b/tests/test_scan_logic.py
@@ -88,7 +88,8 @@ def test_scan_files_handles_permission_error(monkeypatch, tmp_path, mock_scan_de
     # results[0] is progress (0, 1, None)
     # results[1] is result
     # results[2] is progress (1, 1, None)
-    assert len(results) == 3
+    # results[3] is summary
+    assert len(results) == 4
     res_type, res_data = results[1]
     assert res_type == 'result'
     assert res_data[1] == 'Error'
@@ -118,8 +119,8 @@ def test_scan_files_metadata_error(monkeypatch, tmp_path, mock_scan_dependencies
     ))
 
     # Verify we get an Error result
-    # Sequence: Progress(start), Result(Error), Progress(update)
-    assert len(results) == 3
+    # Sequence: Progress(start), Result(Error), Progress(update), Summary
+    assert len(results) == 4
 
     # Check result item
     event_type, event_data = results[1]

--- a/verify_summary.py
+++ b/verify_summary.py
@@ -1,0 +1,46 @@
+
+import gptscan
+from unittest.mock import MagicMock
+import sys
+
+def test_summary_display():
+    # Mock data
+    total_scanned = 10
+    threats_found = 2
+    total_bytes = 1024 * 1024 * 5.5 # 5.5 MB
+    elapsed_time = 2.0
+
+    print("Testing finish_scan_state (GUI)...")
+    gptscan.status_label = MagicMock()
+    gptscan.finish_scan_state(total_scanned, threats_found, total_bytes, elapsed_time)
+    called_msg = gptscan.status_label.config.call_args[1]['text']
+    print(f"GUI Status: {called_msg}")
+    assert "5.5 MiB/s" in called_msg
+    assert "5.0 files/s" in called_msg
+
+    print("\nTesting run_cli summary (CLI)...")
+    # We can't easily run run_cli but we can test the summary printing logic if we extract it
+    # Or just mock scan_files to yield the summary
+
+    def mock_scan_files(*args, **kwargs):
+        yield ('progress', (10, 10, None))
+        yield ('summary', (10, total_bytes, elapsed_time))
+
+    gptscan.scan_files = mock_scan_files
+
+    import io
+    stderr_mock = io.StringIO()
+    sys.stderr = stderr_mock
+
+    try:
+        gptscan.run_cli(["."], False, True, False, 60)
+    finally:
+        sys.stderr = sys.__stderr__
+
+    output = stderr_mock.getvalue()
+    print(f"CLI Stderr:\n{output}")
+    assert "5.5 MiB/s" in output
+    assert "5.0 files/s" in output
+
+if __name__ == "__main__":
+    test_summary_display()


### PR DESCRIPTION
This PR introduces a new "Scan Performance Metrics" feature to the GPT Virus Scanner. It provides users with immediate feedback on the efficiency of their scans by reporting the total time taken, the average number of files scanned per second, and the data throughput (e.g., MB/s). 

Key changes include:
1.  **Metric Tracking:** The `scan_files` generator now records the start time and accumulates the total bytes of all files that matching the scan criteria.
2.  **Summary Event:** At the conclusion of a scan, the generator yields a new `summary` event containing the performance data.
3.  **UI/CLI Enhancements:** Both the graphical status label and the command-line stderr output have been updated to display these metrics in a professional, human-readable format.
4.  **Test Updates:** Existing unit tests in `tests/test_scan_logic.py` were updated to expect the additional event yielded by the generator, ensuring the test suite remains green.

This feature adds significant value for performance monitoring and diagnostic purposes without requiring any additional configuration or external dependencies.

---
*PR created automatically by Jules for task [7295510628477008917](https://jules.google.com/task/7295510628477008917) started by @RainRat*