### PR TITLE
Fix logic bug in UI update queue processing

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -231,13 +231,15 @@ def process_ui_queue() -> None:
     None
         This function schedules itself to run again via ``root.after``.
     """
-    while not ui_queue.empty():
-        func, args, kwargs = ui_queue.get()
-        try:
-            func(*args, **kwargs)
-        finally:
-            ui_queue.task_done()
-    root.after(50, process_ui_queue)
+    try:
+        while not ui_queue.empty():
+            func, args, kwargs = ui_queue.get()
+            try:
+                func(*args, **kwargs)
+            finally:
+                ui_queue.task_done()
+    finally:
+        root.after(50, process_ui_queue)
 
 
 def bind_hover_message(widget: tk.Widget, message: str) -> None:

--- a/tests/test_ui_queue_robustness.py
+++ b/tests/test_ui_queue_robustness.py
@@ -1,0 +1,29 @@
+import queue
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+
+def test_process_ui_queue_reschedules_on_error(monkeypatch):
+    """Verify that process_ui_queue reschedules itself even if a task raises an exception."""
+    mock_root = MagicMock()
+    mock_queue = queue.Queue()
+
+    # Setup mocks
+    monkeypatch.setattr(gptscan, "root", mock_root)
+    monkeypatch.setattr(gptscan, "ui_queue", mock_queue)
+
+    def buggy_func():
+        raise ValueError("Simulated UI update error")
+
+    # Add a buggy task and a normal task to the queue
+    mock_queue.put((buggy_func, (), {}))
+
+    # Running process_ui_queue should propagate the exception from buggy_func
+    with pytest.raises(ValueError, match="Simulated UI update error"):
+        gptscan.process_ui_queue()
+
+    # Verify that root.after was still called despite the exception
+    mock_root.after.assert_called_once_with(50, gptscan.process_ui_queue)
+    # Verify that task_done was called (via the finally block in the loop)
+    # Actually, the exception happens inside the try block, then finally: ui_queue.task_done() runs.
+    # But wait, if it propagates out of process_ui_queue, the while loop terminates.


### PR DESCRIPTION
This PR fixes a logic bug in the `process_ui_queue` function where an unhandled exception in a queued UI task would prevent the `root.after` call from being executed, effectively stopping all future UI updates (such as progress bars and status labels).

The fix involves wrapping the queue processing loop in a `try...finally` block to guarantee that `root.after` is always called for rescheduling.

A new test file `tests/test_ui_queue_robustness.py` has been added to verify that the UI update loop remains active even after an exception occurs.

---
*PR created automatically by Jules for task [13463719212373823691](https://jules.google.com/task/13463719212373823691) started by @RainRat*