### PR TITLE
[FEAT] Add threshold-based exit codes and CI/CD enhancements for CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ This security tool scans script files for malicious code using AI. It works in t
     If you want to use AI Analysis (OpenAI or OpenRouter), you need an API key:
     *   Create a file named `apikey.txt` in the same folder as `gptscan.py`.
     *   Paste your API key into that file. It should contain only the key as a single line of text.
+    *   **Alternatively:** You can set the `OPENAI_API_KEY` or `OPENROUTER_API_KEY` environment variable.
 
     *   **OpenAI:** Get a key from [OpenAI](https://platform.openai.com/).
     *   **OpenRouter:** Get a key from [OpenRouter](https://openrouter.ai/).
@@ -107,6 +108,8 @@ python gptscan.py ./my_scripts --cli --use-gpt --json --exclude "tests/*"
 *   `--provider <name>`: Choose 'openai', 'openrouter', or 'ollama'.
 *   `--model <name>`: Specify the model name (e.g., 'gpt-4o', 'llama3.2').
 *   `--api-base <url>`: Use a custom API URL.
+*   `--fail-threshold <number>`: Exit with a non-zero code if any file meets or exceeds this confidence threshold (0-100).
+*   `--version`: Show the tool's version and exit.
 
 ## Troubleshooting
 

--- a/tests/test_cli_exit_codes.py
+++ b/tests/test_cli_exit_codes.py
@@ -1,0 +1,92 @@
+import gptscan
+import pytest
+import sys
+import os
+
+def test_run_cli_returns_threat_count(monkeypatch):
+    def mock_scan_files(*args, **kwargs):
+        # We need to yield at least one result
+        # data format: (path, own_conf, admin, user, gpt_conf, snippet)
+        yield ('result', ("f1.py", "90%", "", "", "", ""))
+        yield ('result', ("f2.py", "40%", "", "", "", ""))
+        yield ('summary', (2, 100, 1.0))
+
+    monkeypatch.setattr(gptscan, "scan_files", mock_scan_files)
+
+    # Test with default threshold (50)
+    # Note: run_cli prints to stderr/stdout, we might want to suppress it
+    monkeypatch.setattr(sys.stderr, "write", lambda x: None)
+
+    count = gptscan.run_cli(["."], False, True, False, 60)
+    assert count == 1
+
+    # Test with custom threshold (30)
+    count = gptscan.run_cli(["."], False, True, False, 60, fail_threshold=30)
+    assert count == 2
+
+    # Test with custom threshold (95)
+    count = gptscan.run_cli(["."], False, True, False, 60, fail_threshold=95)
+    assert count == 0
+
+def test_main_exits_on_threshold(monkeypatch):
+    # Mock run_cli to return 1 threat
+    monkeypatch.setattr(gptscan, "run_cli", lambda *args, **kwargs: 1)
+
+    # Mock sys.exit
+    exit_codes = []
+    monkeypatch.setattr(sys, "exit", lambda code: exit_codes.append(code))
+
+    # Mock sys.argv
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--cli", "--fail-threshold", "50", "dummy_path"])
+
+    # Mock other things needed for main to run
+    monkeypatch.setattr(os.path, "exists", lambda x: True)
+    monkeypatch.setattr(gptscan, "get_git_changed_files", lambda path=".": [])
+
+    gptscan.main()
+
+    assert 1 in exit_codes
+
+def test_main_no_exit_if_no_threshold(monkeypatch):
+    # Mock run_cli to return 1 threat
+    monkeypatch.setattr(gptscan, "run_cli", lambda *args, **kwargs: 1)
+
+    # Mock sys.exit
+    exit_codes = []
+    monkeypatch.setattr(sys, "exit", lambda code: exit_codes.append(code))
+
+    # Mock sys.argv (no --fail-threshold)
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--cli", "dummy_path"])
+
+    # Mock other things
+    monkeypatch.setattr(os.path, "exists", lambda x: True)
+
+    gptscan.main()
+
+    assert 1 not in exit_codes
+
+def test_env_var_apikey(monkeypatch):
+    # Clear apikey if it was loaded
+    monkeypatch.setattr(gptscan.Config, "apikey", "")
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key-123")
+
+    # Mock load_file to return empty string for apikey.txt
+    original_load_file = gptscan.load_file
+    def mock_load_file(filename, mode='single_line'):
+        if filename == 'apikey.txt':
+            return ""
+        return original_load_file(filename, mode)
+    monkeypatch.setattr(gptscan, "load_file", mock_load_file)
+
+    gptscan.Config.initialize()
+    assert gptscan.Config.apikey == "env-key-123"
+
+def test_version_flag(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--version"])
+
+    with pytest.raises(SystemExit) as e:
+        gptscan.main()
+
+    assert e.value.code == 0
+    captured = capsys.readouterr()
+    assert "1.1.0" in captured.out or "1.1.0" in captured.err


### PR DESCRIPTION
Implemented threshold-based exit codes, environment variable support for API keys, and a version flag. This allows for better integration into automated tasks and CI/CD pipelines.

Changes:
- Added `Config.VERSION = "1.1.0"`.
- Updated `Config.initialize()` to check `OPENAI_API_KEY` and `OPENROUTER_API_KEY`.
- Updated `run_cli()` to take `fail_threshold` and return the number of threats found.
- Updated `main()` to handle `--version`, `--fail-threshold`, and exit with code 1 if the threshold is met.
- Updated `readme.md` with new options.
- Added `tests/test_cli_exit_codes.py`.

---
*PR created automatically by Jules for task [5384879773746991925](https://jules.google.com/task/5384879773746991925) started by @RainRat*