### PR TITLE
Simplify scan result processing and fix empty snippet bug in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -839,8 +839,7 @@ def scan_files(
 
                 if file_size is not None:
                     total_bytes_scanned += file_size
-                    resultchecks: List[float] = []
-                    maxconf = 0.0
+                    maxconf = -1.0
                     max_window_bytes = b""
                     error_message: Optional[str] = None
 
@@ -851,14 +850,12 @@ def scan_files(
                                     break
                                 print("Scanning at:", offset if offset > 0 else 0, file=sys.stderr)
                                 result, padded_bytes = predict_window(window)
-                                resultchecks.append(result)
                                 if result > maxconf:
                                     maxconf = result
                                     max_window_bytes = padded_bytes
                     except OSError as err:
                         error_message = f"Error reading file: {err}"
 
-                    best_result = max(resultchecks, default=0)
                     if error_message is not None:
                         yield (
                             'result',
@@ -871,11 +868,11 @@ def scan_files(
                                 error_message,
                             )
                         )
-                    elif resultchecks:
+                    elif maxconf >= 0:
                         percent = f"{maxconf:.0%}"
                         snippet = ''.join(map(chr, max_window_bytes)).strip()
                         cleaned_snippet = ''.join([s for s in snippet.strip().splitlines(True) if s.strip()])
-                        if best_result > .5 and use_gpt and Config.GPT_ENABLED:
+                        if maxconf > .5 and use_gpt and Config.GPT_ENABLED:
                             gpt_requests.append(
                                 {
                                     "path": str(file_path),
@@ -884,7 +881,7 @@ def scan_files(
                                     "cleaned_snippet": cleaned_snippet,
                                 }
                             )
-                        elif best_result > .5 or show_all:
+                        elif maxconf > .5 or show_all:
                             yield (
                                 'result',
                                 (


### PR DESCRIPTION
This PR addresses a redundancy and a minor logic bug in `gptscan.py`.

Specifically:
- **Redundancy Removal**: The `resultchecks` list was used only to calculate the maximum confidence at the end of the `scan_files` loop. Since `maxconf` was already tracking this value during the loop, `resultchecks` and the subsequent `best_result = max(resultchecks)` calculation were redundant.
- **Bug Fix**: `maxconf` was previously initialized to `0.0`. If a file had a maximum confidence of `0.0` (i.e., it was "clean"), the condition `if result > maxconf` would never be true, and `max_window_bytes` would remain empty. This resulted in an empty snippet being reported for clean files when the "Show all files" option was enabled. Initializing `maxconf` to `-1.0` ensures the first window is always captured.

The changes were verified with a reproduction script and existing unit tests in `tests/test_scan_logic.py`.


---
*PR created automatically by Jules for task [17159523396148281721](https://jules.google.com/task/17159523396148281721) started by @RainRat*