### PR TITLE
[TEST] Improve run_scan reliability and add motion_handler coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1028,7 +1028,8 @@ def run_scan(
                 if conf > 50:
                     threats_found += 1
 
-                enqueue_ui_update(insert_tree_row, data)
+                if not cancel_event.is_set():
+                    enqueue_ui_update(insert_tree_row, data)
             elif event_type == 'summary':
                 total_files, total_bytes, elapsed_time = data
                 metrics['total_bytes'] = total_bytes

--- a/tests/test_motion_handler.py
+++ b/tests/test_motion_handler.py
@@ -1,0 +1,69 @@
+import tkinter as tk
+from tkinter import ttk
+import tkinter.font
+from unittest.mock import MagicMock
+import gptscan
+
+def test_motion_handler_updates_children(monkeypatch):
+    # Setup a mock tree
+    mock_tree = MagicMock()
+
+    # Mock tree['columns']
+    mock_tree.__getitem__.side_effect = lambda key: ("col1", "col2") if key == "columns" else MagicMock()
+
+    # Mock tree.column(cid)['width']
+    mock_tree.column.return_value = {'width': 100}
+
+    # Mock tree.get_children()
+    mock_tree.get_children.return_value = ["iid1"]
+
+    # Mock tree.item(iid)['values']
+    # tree.item(iid) returns a dict, tree.item(iid, values=...) updates it.
+    def mock_item(iid, values=None):
+        if values is None:
+            return {'values': ["long text that should wrap", "short"]}
+        return None
+
+    mock_tree.item.side_effect = mock_item
+
+    # Mock font measure
+    monkeypatch.setattr(tkinter.font.Font, 'measure', lambda self, text: len(text) * 10)
+
+    # Mock adjust_newlines to return a predictable value
+    monkeypatch.setattr(gptscan, "adjust_newlines", lambda text, width, measure=None: f"wrapped_{text}")
+
+    # Call motion_handler with event=None
+    gptscan.motion_handler(mock_tree, None)
+
+    # Verify tree.item(iid, values=...) was called with wrapped values
+    mock_tree.item.assert_called_with("iid1", values=["wrapped_long text that should wrap", "wrapped_short"])
+
+def test_motion_handler_ignores_non_separator_events():
+    mock_tree = MagicMock()
+    mock_tree.identify_region.return_value = "cell"
+
+    mock_event = MagicMock()
+    mock_event.x = 10
+    mock_event.y = 10
+
+    gptscan.motion_handler(mock_tree, mock_event)
+
+    # Should not have called get_children
+    mock_tree.get_children.assert_not_called()
+
+def test_motion_handler_triggers_on_separator(monkeypatch):
+    mock_tree = MagicMock()
+    mock_tree.identify_region.return_value = "separator"
+    mock_tree.get_children.return_value = []
+
+    mock_event = MagicMock()
+    mock_event.x = 10
+    mock_event.y = 10
+
+    # Mock font measure to avoid needing a real display
+    monkeypatch.setattr(tkinter.font.Font, 'measure', lambda self, text: len(text) * 10)
+
+    gptscan.motion_handler(mock_tree, mock_event)
+
+    # Should have called get_children because it was a separator
+    mock_tree.get_children.assert_called_once()

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -28,7 +28,7 @@ def test_run_scan_basic_flow(monkeypatch):
     assert calls[1][0][1] == 0
 
     assert calls[2][0][0] == gptscan.update_status
-    assert calls[2][0][1] == "Scanning..."
+    assert calls[2][0][1] == "Scanning... (0/1)"
 
     assert calls[3][0][0] == gptscan.insert_tree_row
     assert calls[3][0][1][0] == "test.py"
@@ -36,11 +36,14 @@ def test_run_scan_basic_flow(monkeypatch):
     assert calls[4][0][0] == gptscan.update_progress
     assert calls[4][0][1] == 1
 
-    assert calls[5][0][0] == gptscan.finish_scan_state
-    assert calls[5][0][1] == 1
-    assert calls[5][0][2] == 1
-    assert calls[5][0][3] == 1024
-    assert calls[5][0][4] == 1.5
+    assert calls[5][0][0] == gptscan.update_status
+    assert calls[5][0][1] == "Scanning: 1/1"
+
+    assert calls[6][0][0] == gptscan.finish_scan_state
+    assert calls[6][0][1] == 1
+    assert calls[6][0][2] == 1
+    assert calls[6][0][3] == 1024
+    assert calls[6][0][4] == 1.5
 
 def test_run_scan_cancellation(monkeypatch):
     cancel_event = threading.Event()


### PR DESCRIPTION
**Type:** Gap Analysis / Bug Fix / Test Hygiene

**What:** 
- Added `tests/test_motion_handler.py` to cover the `motion_handler` function.
- Fixed `gptscan.run_scan` to check `cancel_event.is_set()` before enqueuing `insert_tree_row`.
- Updated `tests/test_run_scan.py` to match the actual status message format and verify the cancellation fix.

**Why:** 
- `motion_handler` was completely untested despite being a key part of the GUI's usability (text wrapping).
- `tests/test_run_scan.py` had pre-existing failures due to a mismatch in expected status strings and a race condition during cancellation. Fixing these improves the reliability of the core scanning engine.

---
*PR created automatically by Jules for task [555597723493011627](https://jules.google.com/task/555597723493011627) started by @RainRat*