### PR TITLE
[FEAT] Adaptive Result Columns in GUI

### DIFF
--- a/tests/test_adaptive_columns.py
+++ b/tests/test_adaptive_columns.py
@@ -1,0 +1,87 @@
+import tkinter as tk
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+def test_update_tree_columns_hides_ai_when_disabled_and_no_data(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    mock_tree.get_children.return_value = []
+
+    mock_gpt_var = MagicMock()
+    mock_gpt_var.get.return_value = False
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'gpt_var', mock_gpt_var)
+
+    # Run
+    gptscan.update_tree_columns()
+
+    # Verify
+    expected_cols = ("path", "own_conf", "snippet")
+    mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
+
+def test_update_tree_columns_shows_ai_when_enabled(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+    mock_tree.get_children.return_value = []
+
+    mock_gpt_var = MagicMock()
+    mock_gpt_var.get.return_value = True
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'gpt_var', mock_gpt_var)
+
+    # Run
+    gptscan.update_tree_columns()
+
+    # Verify
+    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
+
+def test_update_tree_columns_shows_ai_when_data_present_even_if_disabled(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+
+    # Mock some children data
+    item_id = "item1"
+    mock_tree.get_children.return_value = [item_id]
+    # values[4] is gpt_conf. We set it to something non-empty.
+    # The code calls tree.item(item_id, 'values')
+    mock_tree.item.return_value = ("file.py", "10%", "Admin says bad", "User avoid", "90%", "snippet")
+
+    mock_gpt_var = MagicMock()
+    mock_gpt_var.get.return_value = False
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'gpt_var', mock_gpt_var)
+
+    # Run
+    gptscan.update_tree_columns()
+
+    # Verify
+    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
+
+def test_update_tree_columns_hides_ai_when_disabled_and_data_is_empty(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+
+    item_id = "item1"
+    mock_tree.get_children.return_value = [item_id]
+    # values[4] is gpt_conf. We set it to empty string.
+    mock_tree.item.return_value = ("file.py", "10%", "", "", "", "snippet")
+
+    mock_gpt_var = MagicMock()
+    mock_gpt_var.get.return_value = False
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'gpt_var', mock_gpt_var)
+
+    # Run
+    gptscan.update_tree_columns()
+
+    # Verify
+    expected_cols = ("path", "own_conf", "snippet")
+    mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)


### PR DESCRIPTION
### [FEAT] Adaptive Result Columns in GUI

**What:**
This change introduces dynamic column visibility for the Results Treeview in the GPT Virus Scanner GUI. The AI-specific columns (`Admin Notes`, `User Notes`, and `AI Conf.`) are now automatically shown or hidden based on the "Use AI Analysis" setting and the presence of AI data in the current result set.

**Why:**
The AI Analysis columns were previously always visible, even when AI analysis was disabled or unavailable (e.g., when `task.txt` is missing). This cluttered the interface with empty columns and reduced the space available for the file path and code snippet. By making these columns adaptive, the tool provides a cleaner, more focused user experience that responds to the user's active configuration.

**Key Changes:**
1.  Added `update_tree_columns()` to `gptscan.py` to manage `tree["displaycolumns"]`.
2.  Hooked `update_tree_columns()` into the GUI lifecycle (initialization, setting toggles, scan completion, and data import).
3.  Added `tests/test_adaptive_columns.py` to verify the show/hide logic across different application states.

Note: This PR focuses strictly on the adaptive columns feature to adhere to the "exactly one new feature" constraint. Pre-existing test failures in `tests/test_run_scan.py` (related to status message formatting) were identified but left unchanged to maintain a clean feature-specific diff.

---
*PR created automatically by Jules for task [1528552683669743308](https://jules.google.com/task/1528552683669743308) started by @RainRat*