### PR TITLE
[UI/UX] Consolidate scan controls and optimize visual hierarchy

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1672,7 +1672,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     # Configure grid weights to ensure resizing behaves correctly
     root.columnconfigure(0, weight=1)
-    root.rowconfigure(5, weight=1)  # The row containing the Treeview
+    root.rowconfigure(3, weight=1)  # The row containing the Treeview (tree_frame)
 
     # --- Input Frame ---
     input_frame = ttk.Frame(root)
@@ -1699,6 +1699,14 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     select_dir_btn = ttk.Button(input_frame, text="Select Directory...", command=browse_button_click)
     select_dir_btn.grid(row=0, column=2, sticky="e", padx=(5, 0))
     bind_hover_message(select_dir_btn, "Browse for a directory to scan.")
+
+    scan_button = ttk.Button(input_frame, text="Scan now", command=button_click, default='active')
+    scan_button.grid(row=0, column=3, sticky="e", padx=(5, 0))
+    bind_hover_message(scan_button, "Start the scan.")
+
+    cancel_button = ttk.Button(input_frame, text="Cancel", command=cancel_scan, state="disabled")
+    cancel_button.grid(row=0, column=4, sticky="e", padx=(5, 0))
+    bind_hover_message(cancel_button, "Stop the current scan.")
 
     # --- Settings Container ---
     settings_frame = ttk.Frame(root)
@@ -1809,36 +1817,9 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
             f"extensions.txt not found. Using default extensions: {default_exts}"
         )
 
-    # --- Action Frame ---
-    action_frame = ttk.Frame(root)
-    action_frame.grid(row=2, column=0, sticky="ew", padx=10, pady=10)
-
-    scan_button = ttk.Button(action_frame, text="Scan now", command=button_click, default='active')
-    scan_button.pack(side=tk.LEFT, padx=5)
-    bind_hover_message(scan_button, "Start the scan.")
-
-    cancel_button = ttk.Button(action_frame, text="Cancel", command=cancel_scan, state="disabled")
-    cancel_button.pack(side=tk.LEFT, padx=5)
-    bind_hover_message(cancel_button, "Stop the current scan.")
-
-    export_button = ttk.Button(action_frame, text="Export Results...", command=export_results)
-    export_button.pack(side=tk.RIGHT, padx=5)
-    bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
-
-    import_button = ttk.Button(action_frame, text="Import Results...", command=import_results)
-    import_button.pack(side=tk.RIGHT, padx=5)
-    bind_hover_message(import_button, "Load results from a JSON or CSV file.")
-
-    clear_button = ttk.Button(action_frame, text="Clear Results", command=clear_results)
-    clear_button.pack(side=tk.RIGHT, padx=5)
-    bind_hover_message(clear_button, "Clear all results from the list.")
-
     # --- Progress Bar ---
     progress_bar = ttk.Progressbar(root, orient=tk.HORIZONTAL, mode='determinate')
-    progress_bar.grid(row=3, column=0, sticky="ew", padx=10, pady=5)
-
-    status_label = ttk.Label(root, text="Ready", anchor="w")
-    status_label.grid(row=4, column=0, sticky="ew", padx=10, pady=(0, 5))
+    progress_bar.grid(row=2, column=0, sticky="ew", padx=10, pady=5)
 
     # --- Treeview ---
     style = ttk.Style(root)
@@ -1847,7 +1828,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     # Configure tags for row highlighting
     # Note: 'alt' theme or similar might be needed for background colors to show in some environments
     tree_frame = ttk.Frame(root)
-    tree_frame.grid(row=5, column=0, sticky="nsew", padx=10, pady=5)
+    tree_frame.grid(row=3, column=0, sticky="nsew", padx=10, pady=5)
     tree_frame.columnconfigure(0, weight=1)
     tree_frame.rowconfigure(0, weight=1)
 
@@ -1884,6 +1865,26 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tree.bind('<Double-1>', open_file)
     tree.bind('<Return>', open_file)
     tree.grid(row=0, column=0, sticky="nsew")
+
+    # --- Footer Frame ---
+    footer_frame = ttk.Frame(root)
+    footer_frame.grid(row=4, column=0, sticky="ew", padx=10, pady=(0, 10))
+    footer_frame.columnconfigure(0, weight=1)
+
+    status_label = ttk.Label(footer_frame, text="Ready", anchor="w")
+    status_label.grid(row=0, column=0, sticky="ew")
+
+    import_button = ttk.Button(footer_frame, text="Import Results...", command=import_results)
+    import_button.grid(row=0, column=1, padx=2)
+    bind_hover_message(import_button, "Load results from a JSON or CSV file.")
+
+    export_button = ttk.Button(footer_frame, text="Export Results...", command=export_results)
+    export_button.grid(row=0, column=2, padx=2)
+    bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
+
+    clear_button = ttk.Button(footer_frame, text="Clear Results", command=clear_results)
+    clear_button.grid(row=0, column=3, padx=(2, 0))
+    bind_hover_message(clear_button, "Clear all results from the list.")
 
     # --- Context Menu ---
     global context_menu


### PR DESCRIPTION
This PR improves the GUI usability and aesthetics of the GPT Virus Scanner.

Context: GUI
Problem: The previous interface had a cluttered layout with a redundant 'action_frame' that sat between the settings and the progress bar. Primary actions (Scan/Cancel) were separated from the input tools, and the status bar was positioned awkwardly above the results.
Solution:
1. Consolidated the primary 'Scan now' and 'Cancel' buttons into the top 'input_frame' next to the 'Select Directory...' button. This reduces mouse travel and groups related actions.
2. Moved the 'status_label' to the bottom of the window, serving as a standard status bar.
3. Grouped secondary/management actions (Import, Export, Clear) into a discreet footer frame at the bottom. This keeps them accessible without cluttering the main scanning workflow.
4. Optimized the vertical space by ensuring the Results Treeview is the only expanding element in the middle of the window.

These changes adhere to 'Invisible Design' principles by using standard OS patterns (Status bar at bottom, primary actions at top) and reducing visual noise while maintaining 100% functional parity.

---
*PR created automatically by Jules for task [2902216831730869930](https://jules.google.com/task/2902216831730869930) started by @RainRat*