### PR TITLE
Refactor GPT JSON validation to ignore unexpected keys

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -324,8 +324,6 @@ def extract_data_from_gpt_response(response: Any) -> Union[Dict, str]:
         Parsed JSON dictionary when valid; otherwise, a human-readable error
         message describing the parsing failure.
     """
-    expected_keys = set(Config.EXPECTED_KEYS)
-
     content = response.choices[0].message.content
 
     try:
@@ -339,10 +337,6 @@ def extract_data_from_gpt_response(response: Any) -> Union[Dict, str]:
     missing_keys = [key for key in Config.EXPECTED_KEYS if key not in json_data]
     if missing_keys:
         return f"Missing keys: {', '.join(missing_keys)}"
-
-    extra_keys = set(json_data.keys()) - expected_keys
-    if extra_keys:
-        return f"Unexpected keys present: {', '.join(sorted(extra_keys))}"
 
     threat_level_value = json_data.get("threat-level")
     try:

--- a/tests/test_gpt_edge_cases.py
+++ b/tests/test_gpt_edge_cases.py
@@ -23,7 +23,8 @@ def test_extract_data_extra_keys(mock_response):
     content = '{"administrator": "a", "end-user": "b", "threat-level": 10, "extra": "x"}'
     response = mock_response(content)
     result = extract_data_from_gpt_response(response)
-    assert "Unexpected keys present: extra" in result
+    assert isinstance(result, dict)
+    assert result["extra"] == "x"
 
 def test_extract_data_threat_level_type_error(mock_response):
     content = '{"administrator": "a", "end-user": "b", "threat-level": "high"}'

--- a/tests/test_gptscan.py
+++ b/tests/test_gptscan.py
@@ -114,7 +114,7 @@ def test_extract_data_from_gpt_response_invalid_threat_level():
     assert "not a valid integer" in error
 
 
-def test_extract_data_from_gpt_response_rejects_extra_keys():
+def test_extract_data_from_gpt_response_accepts_extra_keys():
     response = _MockResponse(
         json.dumps(
             {
@@ -126,9 +126,10 @@ def test_extract_data_from_gpt_response_rejects_extra_keys():
         )
     )
 
-    error = gptscan.extract_data_from_gpt_response(response)
+    result = gptscan.extract_data_from_gpt_response(response)
 
-    assert "Unexpected keys" in error
+    assert isinstance(result, dict)
+    assert result["extra"] == "field"
 
 
 def test_extract_data_from_gpt_response_rejects_non_object():


### PR DESCRIPTION
* **What:** Removed the strict check for unexpected keys in the `extract_data_from_gpt_response` function and updated associated unit tests.
* **Why:** Improves robustness against non-deterministic AI outputs that may include extra keys, preventing unnecessary retry loops and failures. No breaking changes were introduced as mandatory keys are still strictly validated.

---
*PR created automatically by Jules for task [17305302856558990653](https://jules.google.com/task/17305302856558990653) started by @RainRat*