### PR TITLE
[UI/UX] Add "Select All" functionality to results tree

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1693,6 +1693,26 @@ def show_in_folder() -> None:
         messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
 
 
+def select_all_items(event: Optional[tk.Event] = None) -> str:
+    """Select all items in the Results Treeview.
+
+    Parameters
+    ----------
+    event : tk.Event, optional
+        The event that triggered this function (used for keyboard shortcuts).
+
+    Returns
+    -------
+    str
+        "break" to prevent default event propagation.
+    """
+    if tree:
+        items = tree.get_children()
+        if items:
+            tree.selection_set(items)
+    return "break"
+
+
 def show_context_menu(event: tk.Event) -> None:
     """Display the context menu at the location of the event."""
     if not tree or not context_menu:
@@ -1993,11 +2013,15 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     context_menu.add_separator()
     context_menu.add_command(label="Copy File Path", command=copy_path)
     context_menu.add_command(label="Copy Snippet", command=copy_snippet)
+    context_menu.add_separator()
+    context_menu.add_command(label="Select All", command=select_all_items)
 
     # Bind context menu to right-click and menu key
     tree.bind('<Button-3>', show_context_menu) # Windows/Linux
     tree.bind('<Button-2>', show_context_menu) # macOS
     tree.bind('<Menu>', show_context_menu)
+    tree.bind('<Control-a>', select_all_items)
+    tree.bind('<Command-a>', select_all_items)
 
     # Bind rescan keys
     tree.bind('<F5>', lambda event: rescan_selected())

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -164,3 +164,11 @@ def test_show_context_menu_no_item_no_selection(mock_tree, monkeypatch):
 
     mock_tree.selection_set.assert_not_called()
     mock_menu.post.assert_not_called()
+
+def test_select_all_items(mock_tree):
+    mock_tree.get_children.return_value = ["item1", "item2", "item3"]
+
+    result = gptscan.select_all_items()
+
+    mock_tree.selection_set.assert_called_with(["item1", "item2", "item3"])
+    assert result == "break"


### PR DESCRIPTION
**PR Title:** [UI/UX] [GUI] Add "Select All" functionality to results tree.

**Description:**
* **Context:** GUI
* **Problem:** Selecting all rows in the Results Treeview requires manual multi-selection (click and drag or Shift+Click), which is inefficient for bulk actions like "Rescan Selected".
* **Solution:** Added a "Select All" command to the context menu and bound standard keyboard shortcuts (Ctrl+A / Command+A) to the Treeview widget.

**Changes:**
- Modified `gptscan.py` to include `select_all_items` function.
- Updated `create_gui` to add the menu item and keyboard bindings.
- Added a new test case in `tests/test_context_menu.py`.

---
*PR created automatically by Jules for task [855191340165122646](https://jules.google.com/task/855191340165122646) started by @RainRat*