### PR TITLE
Fix untracked file detection in new Git repositories

### DIFF
--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -13,7 +13,8 @@ def test_git_not_found_or_error():
 
         # Should return empty list and handle exception gracefully
         assert files == []
-        mock_check_output.assert_called_once()
+        # Both diff and ls-files are attempted
+        assert mock_check_output.call_count == 2
 
 def test_no_changes():
     """Test when git reports no changed files."""


### PR DESCRIPTION
Resolved a logic bug where `get_git_changed_files` failed to return untracked files in newly initialized repositories. Separated the execution of `git diff` and `git ls-files` into independent blocks so that a failure in one does not halt the entire file collection process. Verified with a reproduction script and updated existing unit tests.

---
*PR created automatically by Jules for task [46660982487145675](https://jules.google.com/task/46660982487145675) started by @RainRat*