### PR TITLE
[TEST] Increase coverage for scan cancellation and UI utilities

### DIFF
--- a/tests/test_scan_cancellation_logic.py
+++ b/tests/test_scan_cancellation_logic.py
@@ -1,0 +1,64 @@
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+@pytest.fixture
+def mock_scan_deps(monkeypatch):
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.1]]
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    mock_tf = MagicMock()
+    mock_tf.constant = lambda x: x
+    mock_tf.expand_dims = lambda x, axis: x
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+
+    monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
+
+    return mock_model
+
+def test_scan_files_cancellation_at_file_start(monkeypatch, tmp_path, mock_scan_deps):
+    (tmp_path / "file1.py").write_text("content1")
+    (tmp_path / "file2.py").write_text("content2")
+
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [tmp_path / "file1.py", tmp_path / "file2.py"])
+
+    cancel_event = threading.Event()
+
+    gen = gptscan.scan_files(str(tmp_path), deep_scan=False, show_all=True, use_gpt=False, cancel_event=cancel_event)
+
+    results = []
+    for event_type, data in gen:
+        results.append((event_type, data))
+        if event_type == 'progress' and data[2] and "file1.py" in data[2]:
+            cancel_event.set()
+
+    file_scanned = [data[0] for et, data in results if et == 'result']
+    assert not any("file2.py" in f for f in file_scanned)
+
+    progress_msgs = [str(data[2]) for et, data in results if et == 'progress' if data[2]]
+    assert any("file1.py" in m for m in progress_msgs)
+    assert not any("file2.py" in m for m in progress_msgs)
+
+def test_scan_files_cancellation_during_windows(monkeypatch, tmp_path, mock_scan_deps):
+    file_size = 3000
+    test_file = tmp_path / "large.py"
+    test_file.write_bytes(b"a" * file_size)
+
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+
+    cancel_event = threading.Event()
+
+    def side_effect(*args, **kwargs):
+        cancel_event.set()
+        return [[0.1]]
+
+    mock_scan_deps.predict.side_effect = side_effect
+
+    gen = gptscan.scan_files(str(tmp_path), deep_scan=True, show_all=True, use_gpt=False, cancel_event=cancel_event)
+
+    results = list(gen)
+
+    assert mock_scan_deps.predict.call_count == 1

--- a/tests/test_utility_gaps.py
+++ b/tests/test_utility_gaps.py
@@ -1,9 +1,10 @@
 import asyncio
 import pytest
 from unittest.mock import MagicMock, patch
-from gptscan import format_bytes, extract_data_from_gpt_response, async_handle_gpt_response, Config, AsyncRateLimiter
-
-# --- format_bytes Tests ---
+import json
+from tkinter import ttk
+import gptscan
+from gptscan import format_bytes, extract_data_from_gpt_response, async_handle_gpt_response, Config, AsyncRateLimiter, get_wrapped_values, enqueue_ui_update, ui_queue
 
 def test_format_bytes_units():
     assert "100.0 B" in format_bytes(100)
@@ -19,10 +20,7 @@ def test_format_bytes_edge_cases():
     assert "-512.0 B" in format_bytes(-512)
     assert "-1.0 KiB" in format_bytes(-1024)
 
-# --- extract_data_from_gpt_response Tests ---
-
 def test_extract_data_from_gpt_response_malformed_json():
-    # Mock response object
     class MockChoice:
         def __init__(self, content):
             self.message = MagicMock(content=content)
@@ -31,23 +29,15 @@ def test_extract_data_from_gpt_response_malformed_json():
         def __init__(self, content):
             self.choices = [MockChoice(content)]
 
-    # Malformed JSON (missing closing brace)
     response = MockResponse('{"administrator": "Admin", "end-user": "User", "threat-level": 50')
-
     result = extract_data_from_gpt_response(response)
 
-    # Should return the error message from JSONDecodeError
     assert isinstance(result, str)
     assert "Expecting" in result or "column" in result
 
-# --- async_handle_gpt_response Tests ---
-
 @pytest.mark.asyncio
 async def test_async_handle_gpt_response_no_client(monkeypatch):
-    # Mock get_async_openai_client to return None
     monkeypatch.setattr("gptscan.get_async_openai_client", lambda: None)
-
-    # Ensure cache is empty and doesn't hit
     monkeypatch.setattr(Config, "gpt_cache", {})
 
     limiter = AsyncRateLimiter(60)
@@ -61,3 +51,51 @@ async def test_async_handle_gpt_response_no_client(monkeypatch):
     )
 
     assert result is None
+
+def test_get_wrapped_values_with_hidden_column(monkeypatch):
+    mock_tree = MagicMock()
+    mock_tree.__getitem__.side_effect = lambda key: ("path", "c2", "c3", "c4", "c5", "c6", "orig_json") if key == "columns" else MagicMock()
+    mock_tree.column.return_value = {"width": 100}
+
+    orig_json_data = '{"key": "value"}'
+    values = ["path/to/file", "50%", "admin", "user", "40%", "snippet", orig_json_data]
+
+    monkeypatch.setattr("tkinter.font.Font", MagicMock())
+
+    with patch("gptscan.adjust_newlines", side_effect=lambda v, w, measure=None: f"wrapped_{v}"):
+        result = get_wrapped_values(mock_tree, values)
+
+    assert len(result) == 7
+    assert result[0] == "wrapped_path/to/file"
+    assert result[6] == orig_json_data
+
+def test_enqueue_ui_update():
+    while not ui_queue.empty():
+        ui_queue.get()
+
+    def my_func(a, b=1):
+        pass
+
+    enqueue_ui_update(my_func, "arg1", b=2)
+
+    assert not ui_queue.empty()
+    func, args, kwargs = ui_queue.get()
+    assert func == my_func
+    assert args == ("arg1",)
+    assert kwargs == {"b": 2}
+
+def test_progress_utils(monkeypatch):
+    mock_bar = MagicMock()
+    mock_root = MagicMock()
+    monkeypatch.setattr(gptscan, "progress_bar", mock_bar)
+    monkeypatch.setattr(gptscan, "root", mock_root)
+
+    gptscan.configure_progress(100)
+    mock_bar.__setitem__.assert_any_call("maximum", 100)
+    mock_bar.__setitem__.assert_any_call("value", 0)
+    assert mock_root.update_idletasks.call_count >= 1
+
+    mock_root.update_idletasks.reset_mock()
+    gptscan.update_progress(50)
+    mock_bar.__setitem__.assert_any_call("value", 50)
+    assert mock_root.update_idletasks.call_count >= 1


### PR DESCRIPTION
This PR increases the test coverage of `gptscan.py` from 78% to 79% by addressing identified gaps in core scan logic and UI utility functions.

Key changes:
1. **New Test File**: `tests/test_scan_cancellation_logic.py` verifies that `scan_files` correctly honors the `cancel_event` at both the file-collection level and the window-scanning level.
2. **Enhanced Utility Coverage**: `tests/test_utility_gaps.py` now includes tests for:
   - `get_wrapped_values`: Ensuring that columns beyond the first 6 (specifically the hidden `orig_json` column) are preserved.
   - `enqueue_ui_update`: Verifying that UI updates are correctly queued.
   - `configure_progress` and `update_progress`: Ensuring the progress bar and UI thread are updated as expected.
3. **Code Hygiene**: Removed all explanatory comments within the tests, relying on descriptive function names as per the execution rules.
4. **Clean Workspace**: Ensured that no ephemeral artifacts like `.coverage` are included in the submission.

---
*PR created automatically by Jules for task [7480022053085329257](https://jules.google.com/task/7480022053085329257) started by @RainRat*