### PR TITLE
[DOCS] Synchronize README with supported CLI options and export formats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ python gptscan.py
 *   **Show all files:** List every file scanned, even the safe ones.
 *   **Use AI Analysis:** Get a detailed report for suspicious files.
 *   **AI Analysis Settings:** Choose your service (OpenAI, OpenRouter, or Ollama) and the model you want to use.
-*   **Import/Export Results:** Save your results to CSV, JSON, HTML, or SARIF files, or load them back later.
+*   **Import/Export Results:** Save your results to CSV, JSON, HTML, SARIF, or Markdown files, or load them back later.
 
 You can sort the results by clicking the column headers.
 
@@ -108,18 +108,23 @@ python gptscan.py ./my_scripts --cli --json --exclude "tests/*"
 **Common Options:**
 *   `--cli`: Run in command-line mode (required for terminal use).
 *   `[target]`: The folder or file to scan.
+*   `--path [path]`: An alternative way to specify the scan target.
 *   `--deep`: Scan the entire file instead of just the beginning and end.
 *   `--show-all`: List all files, even safe ones.
 *   `--use-gpt`: Enable AI Analysis for suspicious code.
 *   `--json`: Output results in JSON format (one object per line).
 *   `--sarif`: Save results in SARIF format (standard for security tools).
 *   `--html`: Create a standalone HTML report.
+*   `--md, --markdown`: Create a Markdown report of the results.
 *   `--dry-run`: List files that would be scanned without analyzing them.
 *   `--extensions "py,js,bat"`: Scan specific file types (separated by commas).
 *   `--exclude [patterns]`: Skip files matching these patterns (e.g., `node_modules/*`).
+*   `--file-list [file]`: Read a list of files to scan from a text file.
 *   `--git-changes`: Only scan files that have changed in your git repository.
 *   `--provider [name]`: Choose your AI service ('openai', 'openrouter', or 'ollama').
 *   `--model [name]`: Specify the exact AI model (e.g., 'gpt-4o', 'llama3.2').
+*   `--api-base [url]`: Set a custom URL for the AI service (useful for local servers).
+*   `--rate-limit [n]`: Limit AI requests per minute to avoid errors (default: 60).
 *   `--fail-threshold [0-100]`: Return a failure code if any file meets this threat level.
 *   `--version`: Show the tool's version.
 


### PR DESCRIPTION
**Type:** Documentation
**What:** Updated `readme.md` to include missing command-line arguments and the Markdown export format.
**Why:** Ensures the user-facing documentation accurately reflects all available features of the tool, specifically adding documentation for `--path`, `--file-list`, `--api-base`, `--rate-limit`, and `--markdown` support.

---
*PR created automatically by Jules for task [798565375471627156](https://jules.google.com/task/798565375471627156) started by @RainRat*