### PR TITLE
[TEST] Fix Git subdirectory scan bug and add test coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -520,7 +520,7 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     # Changed (staged and unstaged) relative to HEAD
     try:
         output = subprocess.check_output(
-            ["git", "diff", "--name-only", "HEAD"],
+            ["git", "diff", "--name-only", "HEAD", "--relative"],
             cwd=path,
             stderr=subprocess.PIPE,
             universal_newlines=True
@@ -533,7 +533,7 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     # Untracked files
     try:
         output = subprocess.check_output(
-            ["git", "ls-files", "--others", "--exclude-standard"],
+            ["git", "ls-files", "--others", "--exclude-standard", "--relative"],
             cwd=path,
             stderr=subprocess.PIPE,
             universal_newlines=True

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -87,3 +87,26 @@ def test_path_argument_passed():
 
         assert kwargs1["cwd"] == target_dir
         assert kwargs2["cwd"] == target_dir
+
+def test_git_commands_use_relative_flag():
+    """Verify that both git diff and git ls-files include the --relative flag."""
+    with patch("subprocess.check_output") as mock_check_output, \
+         patch("os.path.exists") as mock_exists:
+        mock_check_output.side_effect = ["", ""]
+        mock_exists.return_value = True
+
+        get_git_changed_files("/some/path")
+
+        # First call should be git diff
+        args1, _ = mock_check_output.call_args_list[0]
+        cmd1 = args1[0]
+        assert "git" in cmd1
+        assert "diff" in cmd1
+        assert "--relative" in cmd1
+
+        # Second call should be git ls-files
+        args2, _ = mock_check_output.call_args_list[1]
+        cmd2 = args2[0]
+        assert "git" in cmd2
+        assert "ls-files" in cmd2
+        assert "--relative" in cmd2


### PR DESCRIPTION
This PR fixes a bug where scanning a subdirectory using the `--git-changes` flag would return no results due to path mismatches. It also adds a unit test to ensure path consistency in future changes.

---
*PR created automatically by Jules for task [15570124930735805491](https://jules.google.com/task/15570124930735805491) started by @RainRat*