### PR TITLE
Refactor shared scan target update logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -310,14 +310,19 @@ def bind_hover_message(widget: tk.Widget, message: str) -> None:
     widget.bind("<Leave>", on_leave)
 
 
+def _set_scan_target(path: str) -> None:
+    """Update the scan target textbox and set focus to the scan button."""
+    if path and textbox:
+        textbox.delete(0, tk.END)
+        textbox.insert(0, path)
+        if scan_button:
+            scan_button.focus_set()
+
+
 def browse_dir_click() -> None:
     """Handle the directory selection dialog and populate the textbox."""
     folder_selected = tkinter.filedialog.askdirectory()
-    if folder_selected:
-        textbox.delete(0, tk.END)
-        textbox.insert(0, folder_selected)
-        if scan_button:
-            scan_button.focus_set()
+    _set_scan_target(folder_selected)
 
 
 def browse_file_click() -> None:
@@ -331,11 +336,7 @@ def browse_file_click() -> None:
         title="Select File to Scan",
         filetypes=file_types
     )
-    if file_selected:
-        textbox.delete(0, tk.END)
-        textbox.insert(0, file_selected)
-        if scan_button:
-            scan_button.focus_set()
+    _set_scan_target(file_selected)
 
 
 class AsyncRateLimiter:


### PR DESCRIPTION
This change identifies and resolves a duplication issue in `gptscan.py`. The logic for updating the scan path in the GUI textbox and shifting focus to the scan button was identical in both the directory and file selection handlers. This refactor extracts that logic into a shared helper function `_set_scan_target`.

**What:** 
- Created `_set_scan_target(path: str)` in `gptscan.py`.
- Updated `browse_dir_click` and `browse_file_click` to call the new helper.

**Why:**
- Improves code maintainability by reducing duplication.
- Simplifies future changes to how the scan target is updated in the UI.
- Non-breaking change with identical external behavior.

---
*PR created automatically by Jules for task [4558645215538380044](https://jules.google.com/task/4558645215538380044) started by @RainRat*