### PR TITLE
[UI/UX] Show filtered results count in status bar

### DIFF
--- a/.gptscanignore
+++ b/.gptscanignore
@@ -1,1 +1,2 @@
 <MagicMock name='mock.item().__getitem__()' id='140233607807344'>
+<MagicMock name='mock.item().__getitem__()' id='140344769895008'>

--- a/gptscan.py
+++ b/gptscan.py
@@ -35,6 +35,7 @@ scan_button: Optional[ttk.Button] = None
 cancel_button: Optional[ttk.Button] = None
 context_menu: Optional[tk.Menu] = None
 _all_results_cache: List[Tuple[Any, ...]] = []
+_last_scan_summary: str = ""
 
 
 def load_file(filename: str, mode: str = 'single_line') -> Union[str, List[str]]:
@@ -669,10 +670,22 @@ def _apply_filter(*args: Any) -> None:
     if items:
         tree.delete(*items)
 
+    match_count = 0
     for values in _all_results_cache:
         if _matches_filter(values):
+            match_count += 1
             wrapped_values, tags = _prepare_tree_row(values)
             tree.insert("", tk.END, values=wrapped_values, tags=tags)
+
+    # Update status label with filtered count if not currently scanning
+    if current_cancel_event is None:
+        query = filter_var.get().strip() if filter_var else ""
+        if query:
+            update_status(f"Showing {match_count} of {len(_all_results_cache)} results matching '{query}'")
+        elif _last_scan_summary:
+            update_status(_last_scan_summary)
+        else:
+            update_status("Ready")
 
 
 def _prepare_tree_row(values: Tuple[Any, ...]) -> Tuple[List[Any], Tuple[str, ...]]:
@@ -778,6 +791,8 @@ def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Option
 
     if total_scanned is not None and threats_found is not None:
         summary = format_scan_summary(total_scanned, threats_found, total_bytes, elapsed_time)
+        global _last_scan_summary
+        _last_scan_summary = summary
         update_status(summary)
     else:
         update_status("Ready")
@@ -1768,7 +1783,10 @@ def import_results() -> None:
             insert_tree_row(tuple(values))
             count += 1
 
-        update_status(f"Imported {count} results from {os.path.basename(file_path)}")
+        msg = f"Imported {count} results from {os.path.basename(file_path)}"
+        global _last_scan_summary
+        _last_scan_summary = msg
+        update_status(msg)
         update_tree_columns()
 
     except Exception as err:
@@ -1777,8 +1795,9 @@ def import_results() -> None:
 
 def clear_results() -> None:
     """Clear all results from the Treeview and reset progress/status."""
-    global _all_results_cache
+    global _all_results_cache, _last_scan_summary
     _all_results_cache = []
+    _last_scan_summary = ""
     if tree:
         items = tree.get_children()
         if items:

--- a/tests/test_filter_status_update.py
+++ b/tests/test_filter_status_update.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+
+def test_apply_filter_updates_status(monkeypatch):
+    """Test that _apply_filter updates the status label with match counts."""
+    mock_tree = MagicMock()
+    mock_status_label = MagicMock()
+    mock_filter_var = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'status_label', mock_status_label)
+    monkeypatch.setattr(gptscan, 'filter_var', mock_filter_var)
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+    monkeypatch.setattr(gptscan, '_last_scan_summary', "Original Summary")
+
+    # Setup cache with items
+    results = [
+        ("danger.py", "90%", "Admin", "User", "80%", "eval(evil)"),
+        ("safe.py", "10%", "Admin", "User", "0%", "print(safe)")
+    ]
+    monkeypatch.setattr(gptscan, '_all_results_cache', results)
+
+    # Mock _prepare_tree_row and _matches_filter to work with our data
+    monkeypatch.setattr(gptscan, '_prepare_tree_row', lambda v: (list(v), ()))
+
+    # 1. Test filtering with results
+    mock_filter_var.get.return_value = "danger"
+    gptscan._apply_filter()
+
+    # Verify status was updated with "Showing 1 of 2 results matching 'danger'"
+    mock_status_label.config.assert_any_call(text="Showing 1 of 2 results matching 'danger'")
+
+    # 2. Test clearing filter restores summary
+    mock_filter_var.get.return_value = ""
+    gptscan._apply_filter()
+    mock_status_label.config.assert_any_call(text="Original Summary")
+
+    # 3. Test filter with no results
+    mock_filter_var.get.return_value = "nothing"
+    gptscan._apply_filter()
+    mock_status_label.config.assert_any_call(text="Showing 0 of 2 results matching 'nothing'")
+
+def test_finish_scan_updates_summary_variable(monkeypatch):
+    """Test that finish_scan_state updates the _last_scan_summary global."""
+    monkeypatch.setattr(gptscan, 'status_label', MagicMock())
+    monkeypatch.setattr(gptscan, 'root', MagicMock())
+    monkeypatch.setattr(gptscan, '_last_scan_summary', "")
+
+    # Call finish_scan_state with results
+    gptscan.finish_scan_state(total_scanned=10, threats_found=2, total_bytes=1024, elapsed_time=1.0)
+
+    assert "10 files scanned, 2 suspicious files found" in gptscan._last_scan_summary
+
+def test_clear_results_resets_summary_variable(monkeypatch):
+    """Test that clear_results resets the _last_scan_summary global."""
+    monkeypatch.setattr(gptscan, 'status_label', MagicMock())
+    monkeypatch.setattr(gptscan, 'progress_bar', MagicMock())
+    monkeypatch.setattr(gptscan, '_last_scan_summary', "Some Summary")
+
+    gptscan.clear_results()
+
+    assert gptscan._last_scan_summary == ""


### PR DESCRIPTION
**PR Title:** [UI/UX] Show filtered results count in status bar

**Description:**
* **Context:** GUI
* **Problem:** When the user applies a filter to the results tree, they have no visual indication of how many results match the query versus the total number of results. This makes it difficult to gauge the scope of findings without manual counting.
* **Solution:** Update the status label in real-time as the user types in the filter box to show the count of matching items (e.g., "Showing 2 of 15 results"). When the filter is cleared, restore the original scan summary.

**Changes:**
- Added a global variable `_last_scan_summary` to `gptscan.py` to preserve scan/import summaries.
- Modified `finish_scan_state`, `import_results`, and `clear_results` to manage this state.
- Enhanced `_apply_filter` to calculate and display the match count in the status bar.
- Added a new test file `tests/test_filter_status_update.py` to verify the behavior.

---
*PR created automatically by Jules for task [15252985158997008022](https://jules.google.com/task/15252985158997008022) started by @RainRat*