### PR TITLE
[TEST] Add PowerShell shebang support and fix Python < 3.12 compatibility

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -158,7 +158,7 @@ class Config:
                     # It has a shebang! Read the rest of the first line.
                     first_line = f.readline(126).decode('utf-8', errors='ignore').lower()
                     # Common interpreters for supported or similar script types
-                    interpreters = ['python', 'node', 'javascript', 'bash', 'sh', 'zsh', 'perl', 'ruby', 'php']
+                    interpreters = ['python', 'node', 'javascript', 'bash', 'sh', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell']
                     if any(interp in first_line for interp in interpreters):
                         return True
         except (OSError, UnicodeDecodeError):
@@ -1583,9 +1583,11 @@ def generate_markdown(results: List[Dict[str, Any]]) -> str:
         conf_str = gpt_conf or own_conf
         analysis = ""
         if admin:
-            analysis += f"**Admin:** {admin.replace('|', '\\|')}<br>"
+            admin_esc = admin.replace('|', '\\|')
+            analysis += f"**Admin:** {admin_esc}<br>"
         if user:
-            analysis += f"**User:** {user.replace('|', '\\|')}"
+            user_esc = user.replace('|', '\\|')
+            analysis += f"**User:** {user_esc}"
 
         # Clean up snippet for markdown table (one line, escaped)
         clean_snippet = snippet.replace("\n", " ").replace("|", "\\|")

--- a/tests/test_shebang_detection.py
+++ b/tests/test_shebang_detection.py
@@ -52,6 +52,15 @@ def test_is_supported_file_shebang(tmp_path):
         f7.write_bytes(b"#!/bin/bash\nls")
         assert Config.is_supported_file(f7) is True
 
+        # PowerShell shebangs
+        f8 = tmp_path / "pwsh_script"
+        f8.write_bytes(b"#!/usr/bin/pwsh\nGet-ChildItem")
+        assert Config.is_supported_file(f8) is True
+
+        f9 = tmp_path / "powershell_script"
+        f9.write_bytes(b"#!/usr/bin/env powershell\nls")
+        assert Config.is_supported_file(f9) is True
+
     finally:
         Config.extensions_set = original_exts
 


### PR DESCRIPTION
This PR addresses a gap in script detection by adding support for PowerShell shebangs (`#!...pwsh` and `#!...powershell`). It also includes a critical bug fix for a `SyntaxError` that prevented the application and tests from running on its target platforms (Python 3.9-3.11).

Key changes:
1.  **Shebang Detection:** Updated `Config.is_supported_file` to recognize PowerShell core and Windows PowerShell shebang lines.
2.  **Test Coverage:** Added specific test cases to `tests/test_shebang_detection.py` to verify the new detection logic.
3.  **Python 3.10 Compatibility:** Fixed a syntax error in `gptscan.py` where backslashes were used inside f-string expressions, which is only supported in Python 3.12+. This fix allows the tool to run in the documented target environments.
4.  **Verification:** All tests passed successfully in a Python 3.10.19 environment.

---
*PR created automatically by Jules for task [9948065117708454281](https://jules.google.com/task/9948065117708454281) started by @RainRat*