### PR TITLE
[FEAT] SARIF Import Support

### DIFF
--- a/.gptscanignore
+++ b/.gptscanignore
@@ -1,2 +1,3 @@
 <MagicMock name='mock.item().__getitem__()' id='140233607807344'>
 <MagicMock name='mock.item().__getitem__()' id='140344769895008'>
+<MagicMock name='mock.item().__getitem__()' id='140489315393104'>

--- a/gptscan.py
+++ b/gptscan.py
@@ -1715,8 +1715,9 @@ def import_results() -> None:
 
     file_path = tkinter.filedialog.askopenfilename(
         filetypes=[
-            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv"),
+            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif"),
             ("JSON files", "*.json;*.jsonl;*.ndjson"),
+            ("SARIF files", "*.sarif"),
             ("CSV files", "*.csv"),
             ("All files", "*.*")
         ],
@@ -1729,7 +1730,7 @@ def import_results() -> None:
         data_to_import = []
         ext = os.path.splitext(file_path)[1].lower()
 
-        if ext in ('.json', '.jsonl', '.ndjson'):
+        if ext in ('.json', '.jsonl', '.ndjson', '.sarif'):
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read().strip()
                 if not content:
@@ -1738,6 +1739,32 @@ def import_results() -> None:
                 if content.startswith('['):
                     # Standard JSON list
                     data_to_import = json.loads(content)
+                elif ext == '.sarif' or (content.startswith('{') and '"runs"' in content):
+                    # SARIF format
+                    sarif_data = json.loads(content)
+                    data_to_import = []
+                    for run in sarif_data.get("runs", []):
+                        for result in run.get("results", []):
+                            mapped = {
+                                "path": "",
+                                "own_conf": "",
+                                "admin_desc": result.get("message", {}).get("text", ""),
+                                "gpt_conf": "",
+                                "snippet": ""
+                            }
+                            # Extract path
+                            locations = result.get("locations", [])
+                            if locations:
+                                uri = locations[0].get("physicalLocation", {}).get("artifactLocation", {}).get("uri", "")
+                                mapped["path"] = uri.replace("/", os.sep)
+
+                            # Extract properties
+                            props = result.get("properties", {})
+                            mapped["own_conf"] = props.get("own_conf", "")
+                            mapped["gpt_conf"] = props.get("gpt_conf", "")
+                            mapped["snippet"] = props.get("snippet", "")
+
+                            data_to_import.append(mapped)
                 else:
                     # NDJSON (newline-delimited JSON)
                     data_to_import = [json.loads(line) for line in content.splitlines() if line.strip()]

--- a/tests/test_sarif_import.py
+++ b/tests/test_sarif_import.py
@@ -1,0 +1,97 @@
+import json
+import os
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+def test_import_results_sarif(monkeypatch, tmp_path):
+    """Test importing a SARIF file."""
+    sarif_data = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "results": [
+                    {
+                        "message": {"text": "Suspicious behavior"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {
+                                        "uri": "test_script.py"
+                                    }
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "own_conf": "85%",
+                            "gpt_conf": "90%",
+                            "snippet": "dangerous_code()"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    sarif_file = tmp_path / "results.sarif"
+    sarif_file.write_text(json.dumps(sarif_data))
+
+    monkeypatch.setattr(gptscan.tkinter.filedialog, "askopenfilename", lambda **kwargs: str(sarif_file))
+
+    mock_tree = MagicMock()
+    mock_tree.__getitem__.side_effect = lambda key: ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet") if key == "columns" else MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree)
+
+    mock_insert = MagicMock()
+    monkeypatch.setattr(gptscan, "insert_tree_row", mock_insert)
+
+    mock_status = MagicMock()
+    monkeypatch.setattr(gptscan, "update_status", mock_status)
+
+    # Mock clear_results to avoid side effects
+    monkeypatch.setattr(gptscan, "clear_results", MagicMock())
+
+    gptscan.import_results()
+
+    mock_insert.assert_called_once()
+    args, _ = mock_insert.call_args
+    values = args[0]
+    assert values[0] == "test_script.py"
+    assert values[1] == "85%"
+    assert values[2] == "Suspicious behavior"
+    assert values[4] == "90%"
+    assert values[5] == "dangerous_code()"
+
+    mock_status.assert_called_with(f"Imported 1 results from results.sarif")
+
+def test_import_results_sarif_content_detection(monkeypatch, tmp_path):
+    """Test that a SARIF file is detected by content even if extension is .json."""
+    sarif_data = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "results": [
+                    {
+                        "message": {"text": "Detected threat"},
+                        "locations": [{"physicalLocation": {"artifactLocation": {"uri": "file.py"}}}]
+                    }
+                ]
+            }
+        ]
+    }
+    json_file = tmp_path / "not_sarif_ext.json"
+    json_file.write_text(json.dumps(sarif_data))
+
+    monkeypatch.setattr(gptscan.tkinter.filedialog, "askopenfilename", lambda **kwargs: str(json_file))
+
+    mock_tree = MagicMock()
+    mock_tree.__getitem__.side_effect = lambda key: ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet") if key == "columns" else MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree)
+
+    monkeypatch.setattr(gptscan, "insert_tree_row", MagicMock())
+    mock_status = MagicMock()
+    monkeypatch.setattr(gptscan, "update_status", mock_status)
+    monkeypatch.setattr(gptscan, "clear_results", MagicMock())
+
+    gptscan.import_results()
+
+    mock_status.assert_called_with(f"Imported 1 results from not_sarif_ext.json")


### PR DESCRIPTION
Identified and implemented SARIF import support to complement the existing SARIF export feature (Heuristic: Symmetry). This allows users to load previous scan results into the GUI for review and management. Tested thoroughly with new and existing tests.

---
*PR created automatically by Jules for task [8485565440737355289](https://jules.google.com/task/8485565440737355289) started by @RainRat*