### PR TITLE
Fix logic bug in open_file and view_details

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2025,18 +2025,20 @@ def view_details(event: Optional[tk.Event] = None) -> None:
         root.clipboard_append(text)
         messagebox.showinfo("Copied", "Detailed analysis copied to clipboard.")
 
-    ttk.Button(btn_frame, text="Open File", command=open_file).pack(side=tk.LEFT, padx=5)
+    ttk.Button(btn_frame, text="Open File", command=lambda: open_file(path)).pack(side=tk.LEFT, padx=5)
     ttk.Button(btn_frame, text="Copy Analysis", command=copy_analysis).pack(side=tk.LEFT, padx=5)
     ttk.Button(btn_frame, text="Close", command=details_win.destroy).pack(side=tk.RIGHT, padx=5)
 
 
-def open_file(event: Optional[tk.Event] = None) -> None:
-    """Open the selected file in the system's default application."""
-    values = _get_selected_row_values()
-    if not values:
-        return
-
-    file_path = str(values[0])
+def open_file(event_or_path: Union[tk.Event, str, None] = None) -> None:
+    """Open the selected or specified file in the system's default application."""
+    if isinstance(event_or_path, str):
+        file_path = event_or_path
+    else:
+        values = _get_selected_row_values()
+        if not values:
+            return
+        file_path = str(values[0])
     if os.path.exists(file_path):
         try:
             if sys.platform == "win32":

--- a/tests/test_open_file_fix.py
+++ b/tests/test_open_file_fix.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import tkinter as tk
+
+def test_open_file_with_explicit_path(monkeypatch):
+    """Test that open_file uses the provided path when passed as a string."""
+    mock_selected = MagicMock(return_value=["selected.py"])
+    monkeypatch.setattr(gptscan, '_get_selected_row_values', mock_selected)
+
+    mock_exists = MagicMock(return_value=True)
+    monkeypatch.setattr(gptscan.os.path, 'exists', mock_exists)
+
+    # Mock subprocess.run based on platform
+    mock_run = MagicMock()
+    monkeypatch.setattr(gptscan.subprocess, 'run', mock_run)
+
+    if gptscan.sys.platform == "win32":
+        mock_startfile = MagicMock()
+        monkeypatch.setattr(gptscan.os, 'startfile', mock_startfile)
+        gptscan.open_file("explicit.py")
+        mock_startfile.assert_called_with("explicit.py")
+    elif gptscan.sys.platform == "darwin":
+        gptscan.open_file("explicit.py")
+        mock_run.assert_called_with(["open", "explicit.py"])
+    else:
+        gptscan.open_file("explicit.py")
+        mock_run.assert_called_with(["xdg-open", "explicit.py"])
+
+    # Verify _get_selected_row_values was NOT called when path was provided
+    assert mock_selected.call_count == 0
+
+def test_open_file_with_none_uses_selection(monkeypatch):
+    """Test that open_file falls back to selection when no path is provided."""
+    mock_selected = MagicMock(return_value=["selected.py"])
+    monkeypatch.setattr(gptscan, '_get_selected_row_values', mock_selected)
+
+    mock_exists = MagicMock(return_value=True)
+    monkeypatch.setattr(gptscan.os.path, 'exists', mock_exists)
+
+    # Mock subprocess.run based on platform
+    mock_run = MagicMock()
+    monkeypatch.setattr(gptscan.subprocess, 'run', mock_run)
+
+    if gptscan.sys.platform == "win32":
+        mock_startfile = MagicMock()
+        monkeypatch.setattr(gptscan.os, 'startfile', mock_startfile)
+        gptscan.open_file()
+        mock_startfile.assert_called_with("selected.py")
+    elif gptscan.sys.platform == "darwin":
+        gptscan.open_file()
+        mock_run.assert_called_with(["open", "selected.py"])
+    else:
+        gptscan.open_file()
+        mock_run.assert_called_with(["xdg-open", "selected.py"])
+
+    # Verify _get_selected_row_values WAS called
+    assert mock_selected.call_count == 1
+
+def test_open_file_with_event_uses_selection(monkeypatch):
+    """Test that open_file falls back to selection when an event is provided."""
+    mock_selected = MagicMock(return_value=["selected.py"])
+    monkeypatch.setattr(gptscan, '_get_selected_row_values', mock_selected)
+
+    mock_exists = MagicMock(return_value=True)
+    monkeypatch.setattr(gptscan.os.path, 'exists', mock_exists)
+
+    # Mock subprocess.run based on platform
+    mock_run = MagicMock()
+    monkeypatch.setattr(gptscan.subprocess, 'run', mock_run)
+
+    mock_event = MagicMock()
+
+    if gptscan.sys.platform == "win32":
+        mock_startfile = MagicMock()
+        monkeypatch.setattr(gptscan.os, 'startfile', mock_startfile)
+        gptscan.open_file(mock_event)
+        mock_startfile.assert_called_with("selected.py")
+    elif gptscan.sys.platform == "darwin":
+        gptscan.open_file(mock_event)
+        mock_run.assert_called_with(["open", "selected.py"])
+    else:
+        gptscan.open_file(mock_event)
+        mock_run.assert_called_with(["xdg-open", "selected.py"])
+
+    # Verify _get_selected_row_values WAS called
+    assert mock_selected.call_count == 1


### PR DESCRIPTION
The "Open File" button in the "View Details" window was incorrectly relying on the current selection in the main results tree. If a user opened the details window for one file and then changed the selection in the background main window, clicking "Open File" in the details window would open the newly selected file instead of the one being viewed.

This PR fixes this by:
1. Updating `open_file` to accept an optional `event_or_path` argument.
2. Handling string paths directly in `open_file`, while falling back to selection for event objects or None.
3. Updating the `view_details` "Open File" button to pass the viewed file's path.

A new test file `tests/test_open_file_fix.py` has been added to verify these changes.

---
*PR created automatically by Jules for task [17164978430886473226](https://jules.google.com/task/17164978430886473226) started by @RainRat*