### PR TITLE
Fix logic bug in search filtering to ignore hidden metadata column

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -665,7 +665,7 @@ def _matches_filter(values: Tuple[Any, ...]) -> bool:
     if not query:
         return True
 
-    for val in values:
+    for val in values[:6]:
         if query in str(val).lower():
             return True
     return False


### PR DESCRIPTION
Identified and resolved a logic bug in the GUI filtering system. The `_matches_filter` function was incorrectly iterating over all columns in the results data, including a hidden column containing a raw JSON representation of the row. This caused search filters to match against non-visible metadata, leading to confusing results for the user.

The fix restricts the iteration to the first six visible columns (`values[:6]`). All tests passed, and the fix was verified with a reproduction script. Additionally, implemented feedback from code review to optimize the slice operation by removing a redundant list conversion.

---
*PR created automatically by Jules for task [18164243065261673600](https://jules.google.com/task/18164243065261673600) started by @RainRat*