### PR TITLE
[TEST] Fix filter matching against hidden metadata and add coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -665,7 +665,7 @@ def _matches_filter(values: Tuple[Any, ...]) -> bool:
     if not query:
         return True
 
-    for val in values:
+    for val in values[:6]:
         if query in str(val).lower():
             return True
     return False

--- a/tests/test_filter_select_all.py
+++ b/tests/test_filter_select_all.py
@@ -25,6 +25,11 @@ def test_matches_filter_basic(monkeypatch):
     mock_filter_var.get.return_value = ""
     assert gptscan._matches_filter(values) is True
 
+    # Test case: ignore hidden 7th column (index 6)
+    mock_filter_var.get.return_value = "hidden_secret"
+    values_with_hidden = ("path.py", "10%", "Admin", "User", "0%", "snippet", '{"secret": "hidden_secret"}')
+    assert gptscan._matches_filter(values_with_hidden) is False
+
 def test_apply_filter_refreshes_tree(monkeypatch):
     """Test that _apply_filter clears and repopulates the tree."""
     mock_tree = MagicMock()


### PR DESCRIPTION
This PR fixes a logic bug in the GUI filtering system where search queries could match against hidden raw JSON metadata (the 7th column), leading to false positive results in the Treeview.

**Changes:**
- Updated `_matches_filter` in `gptscan.py` to use `values[:6]`.
- Added a new test case in `tests/test_filter_select_all.py` that specifically checks that the filter ignores data in the hidden 7th column (index 6).

The fix was verified with a reproduction script and the full test suite (258 tests passed).

---
*PR created automatically by Jules for task [10817413131037237314](https://jules.google.com/task/10817413131037237314) started by @RainRat*