### PR TITLE
[FEAT] Add sequential navigation (Next/Previous) to Result Details view

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1960,24 +1960,25 @@ def _get_selected_row_values() -> Optional[List[Any]]:
     return _get_item_raw_values(selection[0])
 
 
-def view_details(event: Optional[tk.Event] = None) -> None:
+def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None) -> None:
     """Open a detailed view of the selected scan result."""
-    values = _get_selected_row_values()
+    if item_id is None:
+        selection = tree.selection()
+        if not selection:
+            return
+        item_id = selection[0]
+
+    values = _get_item_raw_values(item_id)
     if not values:
         return
 
     # values: (path, own_conf, admin, user, gpt_conf, snippet)
     path = values[0]
-    own_conf = values[1]
-    admin = values[2]
-    user = values[3]
-    gpt_conf = values[4]
-    snippet = values[5]
 
     details_win = tk.Toplevel(root)
     details_win.title(f"Result Details - {os.path.basename(path)}")
-    details_win.geometry("700x600")
-    details_win.minsize(500, 400)
+    details_win.geometry("700x650")
+    details_win.minsize(500, 450)
 
     # Make it modal-ish but not blocking
     details_win.transient(root)
@@ -1991,57 +1992,41 @@ def view_details(event: Optional[tk.Event] = None) -> None:
 
     ttk.Label(header_frame, text="File Path:", font=('TkDefaultFont', 9, 'bold')).grid(row=0, column=0, sticky="w")
     path_entry = ttk.Entry(header_frame)
-    path_entry.insert(0, path)
-    path_entry.config(state='readonly')
     path_entry.grid(row=0, column=1, sticky="ew", padx=5)
     header_frame.columnconfigure(1, weight=1)
 
     def copy_path_btn():
         root.clipboard_clear()
-        root.clipboard_append(path)
+        root.clipboard_append(path_entry.get())
         messagebox.showinfo("Copied", "File path copied to clipboard.")
 
     ttk.Button(header_frame, text="Copy Path", width=12, command=copy_path_btn).grid(row=0, column=2, padx=2)
-    ttk.Button(header_frame, text="Show in Folder", width=15, command=lambda: show_in_folder(path)).grid(row=0, column=3, padx=2)
+    ttk.Button(header_frame, text="Show in Folder", width=15, command=lambda: show_in_folder(path_entry.get())).grid(row=0, column=3, padx=2)
 
     conf_frame = ttk.Frame(header_frame)
     conf_frame.grid(row=1, column=0, columnspan=4, sticky="w", pady=(5, 0))
 
     ttk.Label(conf_frame, text="Local Confidence:").grid(row=0, column=0, sticky="w")
-    ttk.Label(conf_frame, text=own_conf, font=('TkDefaultFont', 9, 'bold')).grid(row=0, column=1, sticky="w", padx=(5, 20))
+    own_conf_label = ttk.Label(conf_frame, font=('TkDefaultFont', 9, 'bold'))
+    own_conf_label.grid(row=0, column=1, sticky="w", padx=(5, 20))
 
-    if gpt_conf:
-        ttk.Label(conf_frame, text="AI Confidence:").grid(row=0, column=2, sticky="w")
-        ttk.Label(conf_frame, text=gpt_conf, font=('TkDefaultFont', 9, 'bold')).grid(row=0, column=3, sticky="w", padx=(5, 0))
+    ai_conf_prefix = ttk.Label(conf_frame, text="AI Confidence:")
+    gpt_conf_label = ttk.Label(conf_frame, font=('TkDefaultFont', 9, 'bold'))
 
     ttk.Separator(main_frame, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=10)
 
     # Analysis sections
-    if admin or user:
-        analysis_frame = ttk.LabelFrame(main_frame, text="AI Analysis", padding=5)
-        analysis_frame.pack(fill=tk.BOTH, expand=True, pady=5)
-
-        if admin:
-            ttk.Label(analysis_frame, text="Administrator Notes:", font=('TkDefaultFont', 9, 'bold')).pack(anchor="w")
-            admin_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
-            admin_text.insert(tk.END, admin)
-            admin_text.config(state='disabled')
-            admin_text.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
-
-        if user:
-            ttk.Label(analysis_frame, text="End-User Notes:", font=('TkDefaultFont', 9, 'bold')).pack(anchor="w")
-            user_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
-            user_text.insert(tk.END, user)
-            user_text.config(state='disabled')
-            user_text.pack(fill=tk.BOTH, expand=True)
+    analysis_frame = ttk.LabelFrame(main_frame, text="AI Analysis", padding=5)
+    admin_label = ttk.Label(analysis_frame, text="Administrator Notes:", font=('TkDefaultFont', 9, 'bold'))
+    admin_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
+    user_label = ttk.Label(analysis_frame, text="End-User Notes:", font=('TkDefaultFont', 9, 'bold'))
+    user_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
 
     # Snippet section
     snippet_frame = ttk.LabelFrame(main_frame, text="Code Snippet", padding=5)
     snippet_frame.pack(fill=tk.BOTH, expand=True, pady=5)
 
     snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font=('Courier', 10), wrap=tk.NONE)
-    snippet_text.insert(tk.END, snippet)
-    snippet_text.config(state='disabled')
     snippet_text.pack(fill=tk.BOTH, expand=True)
 
     # Footer buttons
@@ -2049,21 +2034,122 @@ def view_details(event: Optional[tk.Event] = None) -> None:
     btn_frame.pack(fill=tk.X, pady=(10, 0))
 
     def copy_analysis():
+        path = path_entry.get()
+        own_conf = own_conf_label.cget("text")
+        gpt_conf = gpt_conf_label.cget("text")
         text = f"Path: {path}\nLocal Conf: {own_conf}\n"
         if gpt_conf:
             text += f"AI Conf: {gpt_conf}\n"
-        if admin:
-            text += f"\nAdmin Notes:\n{admin}\n"
-        if user:
-            text += f"\nUser Notes:\n{user}\n"
-        text += f"\nSnippet:\n{snippet}"
+        if analysis_frame.winfo_viewable():
+            if admin_label.winfo_viewable():
+                text += f"\nAdmin Notes:\n{admin_text.get('1.0', tk.END).strip()}\n"
+            if user_label.winfo_viewable():
+                text += f"\nUser Notes:\n{user_text.get('1.0', tk.END).strip()}\n"
+        text += f"\nSnippet:\n{snippet_text.get('1.0', tk.END).strip()}"
         root.clipboard_clear()
         root.clipboard_append(text)
         messagebox.showinfo("Copied", "Detailed analysis copied to clipboard.")
 
-    ttk.Button(btn_frame, text="Open File", command=lambda: open_file(path)).pack(side=tk.LEFT, padx=5)
+    ttk.Button(btn_frame, text="Open File", command=lambda: open_file(path_entry.get())).pack(side=tk.LEFT, padx=5)
     ttk.Button(btn_frame, text="Copy Analysis", command=copy_analysis).pack(side=tk.LEFT, padx=5)
     ttk.Button(btn_frame, text="Close", command=details_win.destroy).pack(side=tk.RIGHT, padx=5)
+
+    # Navigation buttons
+    nav_frame = ttk.Frame(main_frame)
+    nav_frame.pack(fill=tk.X, pady=(10, 0))
+    current_item_id = item_id
+
+    def refresh_content(new_id):
+        nonlocal current_item_id
+        current_item_id = new_id
+        vals = _get_item_raw_values(new_id)
+        if not vals: return
+        path, own_conf, admin, user, gpt_conf, snippet = vals[:6]
+
+        details_win.title(f"Result Details - {os.path.basename(path)}")
+        path_entry.config(state='normal')
+        path_entry.delete(0, tk.END)
+        path_entry.insert(0, path)
+        path_entry.config(state='readonly')
+        own_conf_label.config(text=own_conf)
+
+        if gpt_conf:
+            ai_conf_prefix.grid(row=0, column=2, sticky="w")
+            gpt_conf_label.grid(row=0, column=3, sticky="w", padx=(5, 0))
+            gpt_conf_label.config(text=gpt_conf)
+        else:
+            ai_conf_prefix.grid_forget()
+            gpt_conf_label.grid_forget()
+            gpt_conf_label.config(text="")
+
+        if admin or user:
+            analysis_frame.pack(fill=tk.BOTH, expand=True, pady=5, before=snippet_frame)
+            if admin:
+                admin_label.pack(anchor="w")
+                admin_text.config(state='normal')
+                admin_text.delete('1.0', tk.END)
+                admin_text.insert(tk.END, admin)
+                admin_text.config(state='disabled')
+                admin_text.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
+            else:
+                admin_label.pack_forget()
+                admin_text.pack_forget()
+            if user:
+                user_label.pack(anchor="w")
+                user_text.config(state='normal')
+                user_text.delete('1.0', tk.END)
+                user_text.insert(tk.END, user)
+                user_text.config(state='disabled')
+                user_text.pack(fill=tk.BOTH, expand=True)
+            else:
+                user_label.pack_forget()
+                user_text.pack_forget()
+        else:
+            analysis_frame.pack_forget()
+
+        snippet_text.config(state='normal')
+        snippet_text.delete('1.0', tk.END)
+        snippet_text.insert(tk.END, snippet)
+        snippet_text.config(state='disabled')
+
+        all_visible = tree.get_children()
+        try:
+            idx = all_visible.index(new_id)
+            prev_btn.config(state='normal' if idx > 0 else 'disabled')
+            next_btn.config(state='normal' if idx < len(all_visible) - 1 else 'disabled')
+        except ValueError:
+            prev_btn.config(state='disabled')
+            next_btn.config(state='disabled')
+
+    def on_prev():
+        all_visible = tree.get_children()
+        try:
+            idx = all_visible.index(current_item_id)
+            if idx > 0:
+                new_id = all_visible[idx - 1]
+                tree.selection_set(new_id)
+                tree.see(new_id)
+                refresh_content(new_id)
+        except ValueError: pass
+
+    def on_next():
+        all_visible = tree.get_children()
+        try:
+            idx = all_visible.index(current_item_id)
+            if idx < len(all_visible) - 1:
+                new_id = all_visible[idx + 1]
+                tree.selection_set(new_id)
+                tree.see(new_id)
+                refresh_content(new_id)
+        except ValueError: pass
+
+    prev_btn = ttk.Button(nav_frame, text="< Previous", command=on_prev)
+    prev_btn.pack(side=tk.LEFT, padx=5)
+    next_btn = ttk.Button(nav_frame, text="Next >", command=on_next)
+    next_btn.pack(side=tk.LEFT, padx=5)
+    details_win.bind('<Left>', lambda e: on_prev())
+    details_win.bind('<Right>', lambda e: on_next())
+    refresh_content(item_id)
 
 
 def open_file(event_or_path: Union[tk.Event, str, None] = None) -> None:

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -10,6 +10,9 @@ def mock_tree(monkeypatch):
     mock_tree = MagicMock()
     monkeypatch.setattr(gptscan, 'tree', mock_tree, raising=False)
 
+    # Mock get_children for navigation logic
+    mock_tree.get_children.return_value = ["item1"]
+
     # Mock _get_selected_row_values dependencies
     def mock_item_func(item_id, option=None):
         vals = mock_tree._item_values.get(item_id, ())

--- a/tests/test_view_details_nav.py
+++ b/tests/test_view_details_nav.py
@@ -1,0 +1,105 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import json
+import tkinter as tk
+import os
+
+@pytest.fixture
+def mock_tree(monkeypatch):
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree, raising=False)
+
+    # Mock tree.get_children
+    mock_tree.get_children.return_value = ["item1", "item2", "item3"]
+
+    # Mock data for items
+    # Format in Treeview: (path, own_conf, admin, user, gpt_conf, snippet, orig_json)
+    mock_data = {
+        "item1": ["file1.py", "10%", "", "", "", "snippet1", json.dumps(["file1.py", "10%", "", "", "", "snippet1"])],
+        "item2": ["file2.py", "20%", "Admin", "User", "90%", "snippet2", json.dumps(["file2.py", "20%", "Admin", "User", "90%", "snippet2"])],
+        "item3": ["file3.py", "30%", "", "", "", "snippet3", json.dumps(["file3.py", "30%", "", "", "", "snippet3"])]
+    }
+
+    def mock_item_func(item_id, option=None):
+        vals = mock_data.get(item_id, [])
+        if option == "values":
+            return vals
+        return {"values": vals}
+
+    mock_tree.item.side_effect = mock_item_func
+    mock_tree.exists.side_effect = lambda iid: iid in mock_data
+
+    return mock_tree
+
+def test_view_details_navigation(mock_tree, monkeypatch):
+    # Mock Toplevel
+    mock_toplevel = MagicMock()
+    monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock(return_value=mock_toplevel))
+
+    # Mock ScrolledText
+    mock_scrolledtext = MagicMock()
+    monkeypatch.setattr(gptscan.scrolledtext, 'ScrolledText', MagicMock(return_value=mock_scrolledtext))
+
+    # Capture commands of buttons
+    captured_commands = {}
+    original_button = gptscan.ttk.Button
+    def mock_button_init(master, **kwargs):
+        btn = MagicMock()
+        text = kwargs.get('text', '')
+        if text:
+            captured_commands[text] = kwargs.get('command')
+        return btn
+    monkeypatch.setattr(gptscan.ttk, 'Button', mock_button_init)
+
+    # Call view_details starting with item2
+    gptscan.view_details(item_id="item2")
+
+    # Verify initial state
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"
+    assert "< Previous" in captured_commands
+    assert "Next >" in captured_commands
+
+    # Test "Next >" button
+    captured_commands["Next >"]()
+    # Verify it updated selection and title
+    mock_tree.selection_set.assert_called_with("item3")
+    mock_tree.see.assert_called_with("item3")
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file3.py"
+
+    # Test "< Previous" button
+    captured_commands["< Previous"]()
+    # Verify it updated selection and title back to item2
+    mock_tree.selection_set.assert_called_with("item2")
+    mock_tree.see.assert_called_with("item2")
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"
+
+    # Test Previous again to item1
+    captured_commands["< Previous"]()
+    mock_tree.selection_set.assert_called_with("item1")
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file1.py"
+
+def test_view_details_keyboard_bindings(mock_tree, monkeypatch):
+    # Mock Toplevel
+    mock_toplevel = MagicMock()
+    monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock(return_value=mock_toplevel))
+    monkeypatch.setattr(gptscan.scrolledtext, 'ScrolledText', MagicMock())
+
+    # Capture bindings
+    captured_bindings = {}
+    mock_toplevel.bind.side_effect = lambda event, func: captured_bindings.update({event: func})
+
+    gptscan.view_details(item_id="item2")
+
+    assert '<Left>' in captured_bindings
+    assert '<Right>' in captured_bindings
+
+    # Trigger Right arrow
+    captured_bindings['<Right>'](None)
+    mock_tree.selection_set.assert_called_with("item3")
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file3.py"
+
+    # Trigger Left arrow
+    captured_bindings['<Left>'](None)
+    mock_tree.selection_set.assert_called_with("item2")
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"


### PR DESCRIPTION
Added "< Previous" and "Next >" buttons to the Result Details window, along with keyboard shortcuts (Left/Right arrow keys). These buttons allow users to cycle through all visible scan results without closing and reopening the details window. Navigating also synchronizes the selection in the main Results Treeview. This streamlines the review process for multiple suspicious files.

---
*PR created automatically by Jules for task [7189864131416252514](https://jules.google.com/task/7189864131416252514) started by @RainRat*