### PR TITLE
[TEST] Fix shebang detection logic bug and add regression tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4,6 +4,7 @@ import html
 import json
 import os
 import queue
+import re
 import shutil
 import subprocess
 import sys
@@ -161,7 +162,9 @@ class Config:
                     first_line = f.readline(126).decode('utf-8', errors='ignore').lower()
                     # Common interpreters for supported or similar script types
                     interpreters = ['python', 'node', 'javascript', 'bash', 'sh', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell']
-                    if any(interp in first_line for interp in interpreters):
+                    escaped_interpreters = [re.escape(i) for i in interpreters]
+                    pattern = r'(?:/|\s|^)(?:' + '|'.join(escaped_interpreters) + r')\d*\b'
+                    if re.search(pattern, first_line):
                         return True
         except (OSError, UnicodeDecodeError):
             pass

--- a/tests/test_shebang_detection.py
+++ b/tests/test_shebang_detection.py
@@ -61,6 +61,15 @@ def test_is_supported_file_shebang(tmp_path):
         f9.write_bytes(b"#!/usr/bin/env powershell\nls")
         assert Config.is_supported_file(f9) is True
 
+        # Regression test for substring false positives (e.g., 'sh' in 'ships')
+        f10 = tmp_path / "ships_script"
+        f10.write_bytes(b"#!/usr/bin/ships\n")
+        assert Config.is_supported_file(f10) is False
+
+        f11 = tmp_path / "mysh_script"
+        f11.write_bytes(b"#!/usr/bin/mysh\n")
+        assert Config.is_supported_file(f11) is False
+
     finally:
         Config.extensions_set = original_exts
 


### PR DESCRIPTION
This PR fixes a logic bug in the shebang detection mechanism and adds regression tests to ensure long-term reliability.

**Key Changes:**
- **gptscan.py**: Switched from a simple substring check to a regular expression `(?:/|\s|^)(?:<interpreters>)\d*\b` for shebang detection. Used `re.escape` for all interpreter names.
- **tests/test_shebang_detection.py**: Added new test cases for substring false positives.

**Verification:**
- Ran the full test suite: 275 tests passed.
- Manually verified the fix with a reproduction script.
- Cleaned up temporary artifacts (`.coverage`, `test_repro.py`) before submission.

---
*PR created automatically by Jules for task [10617616103900785614](https://jules.google.com/task/10617616103900785614) started by @RainRat*