### PR TITLE
[TEST] Improve Git integration robustness and fix untracked file detection

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -549,33 +549,46 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     """Get a list of changed files (staged, unstaged, untracked) from git."""
     files = set()
 
+    # Ensure we have a directory for cwd
+    if os.path.isfile(path):
+        cwd = os.path.dirname(path) or "."
+        # If we are looking at a specific file, we only care about that file
+        targets = [os.path.basename(path)]
+    else:
+        cwd = path
+        targets = []
+
     # Changed (staged and unstaged) relative to HEAD
     try:
+        cmd = ["git", "diff", "--name-only", "HEAD", "--relative"] + targets
         output = subprocess.check_output(
-            ["git", "diff", "--name-only", "HEAD", "--relative"],
-            cwd=path,
+            cmd,
+            cwd=cwd,
             stderr=subprocess.PIPE,
             universal_newlines=True
         )
         files.update(line.strip() for line in output.splitlines() if line.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # HEAD might not exist in a new repo, or git is missing
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        # HEAD might not exist, git is missing, or cwd is invalid
         pass
 
     # Untracked files
     try:
+        # Note: git ls-files does not support --relative in all versions,
+        # and it returns relative paths by default when run inside a subdirectory.
+        cmd = ["git", "ls-files", "--others", "--exclude-standard"] + targets
         output = subprocess.check_output(
-            ["git", "ls-files", "--others", "--exclude-standard", "--relative"],
-            cwd=path,
+            cmd,
+            cwd=cwd,
             stderr=subprocess.PIPE,
             universal_newlines=True
         )
         files.update(line.strip() for line in output.splitlines() if line.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # Not a git repo or git is missing
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        # Not a git repo, git is missing, or cwd is invalid
         pass
 
-    return [os.path.join(path, f) for f in files if os.path.exists(os.path.join(path, f))]
+    return [os.path.join(cwd, f) for f in files if os.path.exists(os.path.join(cwd, f))]
 
 
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -109,4 +109,29 @@ def test_git_commands_use_relative_flag():
         cmd2 = args2[0]
         assert "git" in cmd2
         assert "ls-files" in cmd2
-        assert "--relative" in cmd2
+        # --relative is NOT supported by git ls-files
+        assert "--relative" not in cmd2
+
+def test_get_git_changed_files_with_file_path(tmp_path):
+    """Test that get_git_changed_files handles being passed a file path instead of a directory."""
+    f = tmp_path / "test.txt"
+    f.touch()
+
+    # This should not raise NotADirectoryError (fix for bug where cwd was set to a file)
+    results = get_git_changed_files(str(f))
+    assert results == []
+
+def test_get_git_changed_files_untracked_real_git(tmp_path):
+    """Verify that untracked files are correctly detected in a real git repository."""
+    # Initialize a git repo
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+    # Create an untracked file
+    untracked = tmp_path / "untracked.py"
+    untracked.touch()
+
+    # Run get_git_changed_files
+    results = get_git_changed_files(str(tmp_path))
+
+    # It should find the untracked file.
+    # If --relative is passed to ls-files, this will likely be empty because the command failed.
+    assert any(str(untracked) == os.path.abspath(r) for r in results)


### PR DESCRIPTION
This PR improves the robustness of the Git-based scan target collection logic.

Key changes:
1.  **File Path Support:** The `get_git_changed_files` function now correctly handles cases where a user selects a specific file in the GUI while having "Git changes only" enabled. Previously, this would cause a `NotADirectoryError` because it tried to use the file path as the working directory for Git commands.
2.  **ls-files Fix:** Removed the `--relative` flag from the `git ls-files` call. This flag is not supported by `ls-files` (unlike `git diff`), and its presence was causing the command to fail silently, meaning untracked files were never being detected during Git scans.
3.  **Error Handling:** Added `OSError` to the list of caught exceptions when running Git commands to ensure the application remains responsive even if the Git environment is in an unexpected state.
4.  **Tests:** 
    - Added `test_get_git_changed_files_with_file_path` to verify that passing a file path no longer crashes.
    - Added `test_get_git_changed_files_untracked_real_git` as a real integration test to verify that untracked files are now correctly detected (proving the fix for the `--relative` flag).
    - Updated existing mock-based tests to reflect the removal of the `--relative` flag.

---
*PR created automatically by Jules for task [17062669550499817215](https://jules.google.com/task/17062669550499817215) started by @RainRat*