### PR TITLE
[UI/UX] Default result action to detailed analysis instead of file opening

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2689,8 +2689,15 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     tree.configure(yscrollcommand=scrollbar.set)
     tree.bind('<ButtonRelease-1>', partial(motion_handler, tree))
-    tree.bind('<Double-1>', open_file)
-    tree.bind('<Return>', open_file)
+
+    def on_tree_double_click(event):
+        """Show details only if a data cell was double-clicked."""
+        if tree.identify_region(event.x, event.y) == "cell":
+            view_details(event)
+
+    tree.bind('<Double-1>', on_tree_double_click)
+    tree.bind('<Return>', view_details)
+    tree.bind('<Shift-Return>', open_file)
     tree.grid(row=0, column=0, sticky="nsew")
 
     # --- Footer Frame ---


### PR DESCRIPTION
Improved the usability and safety of the results list in the GUI by defaulting primary interactions (Double-click and Enter) to the Detailed Analysis view. Added a Shift-Enter shortcut for opening files and ensured header clicks are ignored for double-click actions.

---
*PR created automatically by Jules for task [2509268812980017400](https://jules.google.com/task/2509268812980017400) started by @RainRat*