### PR TITLE
[UI/UX] Add result counter to detailed view navigation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2225,7 +2225,20 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         if not vals: return
         path, own_conf, admin, user, gpt_conf, snippet = vals[:6]
 
-        details_win.title(f"Result Details - {os.path.basename(path)}")
+        all_visible = tree.get_children()
+        total = len(all_visible)
+        try:
+            idx = all_visible.index(new_id)
+            prev_btn.config(state='normal' if idx > 0 else 'disabled')
+            next_btn.config(state='normal' if idx < total - 1 else 'disabled')
+            count_label.config(text=f"Result {idx + 1} of {total}")
+            details_win.title(f"Result {idx + 1} of {total} - {os.path.basename(path)}")
+        except ValueError:
+            prev_btn.config(state='disabled')
+            next_btn.config(state='disabled')
+            count_label.config(text="")
+            details_win.title(f"Result Details - {os.path.basename(path)}")
+
         path_entry.config(state='normal')
         path_entry.delete(0, tk.END)
         path_entry.insert(0, path)
@@ -2271,15 +2284,6 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         snippet_text.insert(tk.END, snippet)
         snippet_text.config(state='disabled')
 
-        all_visible = tree.get_children()
-        try:
-            idx = all_visible.index(new_id)
-            prev_btn.config(state='normal' if idx > 0 else 'disabled')
-            next_btn.config(state='normal' if idx < len(all_visible) - 1 else 'disabled')
-        except ValueError:
-            prev_btn.config(state='disabled')
-            next_btn.config(state='disabled')
-
     def on_prev():
         all_visible = tree.get_children()
         try:
@@ -2304,6 +2308,10 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     prev_btn = ttk.Button(nav_frame, text="< Previous", command=on_prev)
     prev_btn.pack(side=tk.LEFT, padx=5)
+
+    count_label = ttk.Label(nav_frame, text="")
+    count_label.pack(side=tk.LEFT, padx=10)
+
     next_btn = ttk.Button(nav_frame, text="Next >", command=on_next)
     next_btn.pack(side=tk.LEFT, padx=5)
     details_win.bind('<Left>', lambda e: on_prev())

--- a/readme.md
+++ b/readme.md
@@ -71,8 +71,8 @@ Run `python gptscan.py` to open the GUI.
 *   **Ctrl+A / Cmd+A:** Select all results.
 *   **Ctrl+F / Cmd+F:** Focus the search filter.
 *   **F5 / R:** Rescan selected files.
-*   **Double-click / Enter:** Open selected file.
-*   **Space:** View detailed analysis and code.
+*   **Double-click / Enter / Space:** View detailed analysis and code.
+*   **Shift+Enter:** Open selected file.
 *   **Esc:** Cancel the active scan.
 
 ### Using the Command Line (CLI)

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -45,7 +45,7 @@ def test_view_details_open_window(mock_tree, monkeypatch):
 
     # Verify Toplevel was created with correct title
     gptscan.tk.Toplevel.assert_called_once()
-    mock_toplevel.title.assert_called_with("Result Details - test.py")
+    mock_toplevel.title.assert_called_with("Result 1 of 1 - test.py")
 
     # Verify data was inserted into ScrolledText widgets (we expect 3: admin, user, snippet)
     # Actually if both admin and user are present, there are 3 ScrolledText calls.

--- a/tests/test_view_details_nav.py
+++ b/tests/test_view_details_nav.py
@@ -56,7 +56,7 @@ def test_view_details_navigation(mock_tree, monkeypatch):
     gptscan.view_details(item_id="item2")
 
     # Verify initial state
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 2 of 3 - file2.py"
     assert "< Previous" in captured_commands
     assert "Next >" in captured_commands
 
@@ -65,19 +65,19 @@ def test_view_details_navigation(mock_tree, monkeypatch):
     # Verify it updated selection and title
     mock_tree.selection_set.assert_called_with("item3")
     mock_tree.see.assert_called_with("item3")
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file3.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 3 of 3 - file3.py"
 
     # Test "< Previous" button
     captured_commands["< Previous"]()
     # Verify it updated selection and title back to item2
     mock_tree.selection_set.assert_called_with("item2")
     mock_tree.see.assert_called_with("item2")
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 2 of 3 - file2.py"
 
     # Test Previous again to item1
     captured_commands["< Previous"]()
     mock_tree.selection_set.assert_called_with("item1")
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file1.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 1 of 3 - file1.py"
 
 def test_view_details_keyboard_bindings(mock_tree, monkeypatch):
     # Mock Toplevel
@@ -97,9 +97,9 @@ def test_view_details_keyboard_bindings(mock_tree, monkeypatch):
     # Trigger Right arrow
     captured_bindings['<Right>'](None)
     mock_tree.selection_set.assert_called_with("item3")
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file3.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 3 of 3 - file3.py"
 
     # Trigger Left arrow
     captured_bindings['<Left>'](None)
     mock_tree.selection_set.assert_called_with("item2")
-    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result Details - file2.py"
+    assert mock_toplevel.title.call_args_list[-1][0][0] == "Result 2 of 3 - file2.py"


### PR DESCRIPTION
Improved the UI/UX of the result details view by adding a sequential result counter (e.g., "Result 3 of 10") in both the window title and a new label within the navigation frame. This provides essential context for users reviewing multiple findings. Additionally, updated the README documentation to correctly reflect the safer keyboard shortcut behavior of the application.

Changes:
- Modified `view_details` in `gptscan.py` to include a `count_label`.
- Updated `refresh_content` in `gptscan.py` to dynamically calculate and display the item index and total count.
- Updated `readme.md` to fix misleading shortcut descriptions.
- Updated `tests/test_view_details_nav.py` and `tests/test_view_details.py` to verify the new title and counter format.

---
*PR created automatically by Jules for task [13493142926564030955](https://jules.google.com/task/13493142926564030955) started by @RainRat*