### PR TITLE
Refactor risk categorization in report generators

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1537,12 +1537,14 @@ def generate_sarif(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     sarif_results = []
     for r in results:
         # Convert confidence strings to levels
-        level = "note"
         conf = get_effective_confidence(r.get("own_conf", ""), r.get("gpt_conf", ""))
-        if conf > 80:
+        risk = get_risk_category(conf, Config.THRESHOLD)
+        if risk == 'high':
             level = "error"
-        elif conf > Config.THRESHOLD:
+        elif risk == 'medium':
             level = "warning"
+        else:
+            level = "note"
 
         message_text = r.get("admin_desc") or r.get("end-user_desc") or "Suspicious content detected"
 
@@ -1618,11 +1620,12 @@ def generate_html(results: List[Dict[str, Any]]) -> str:
         snippet = r.get("snippet", "")
 
         conf_val = get_effective_confidence(own_conf, gpt_conf)
+        risk = get_risk_category(conf_val, Config.THRESHOLD)
 
         row_class = ""
-        if conf_val > 80:
+        if risk == 'high':
             row_class = "high-risk"
-        elif conf_val > Config.THRESHOLD:
+        elif risk == 'medium':
             row_class = "medium-risk"
 
         rows.append(f"""

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -241,3 +241,11 @@ def test_import_results_sarif_content_detection(monkeypatch, tmp_path):
     gptscan.import_results()
 
     mock_status.assert_called_with(f"Imported 1 results from not_sarif_ext.json")
+
+def test_generate_sarif_boundary_80():
+    """Verify that exactly 80% is categorized as an error (high risk)."""
+    results = [
+        {"path": "boundary.py", "own_conf": "80%", "admin_desc": "Boundary test"}
+    ]
+    sarif = generate_sarif(results)
+    assert sarif["runs"][0]["results"][0]["level"] == "error"


### PR DESCRIPTION
This PR refactors the report generation logic in `gptscan.py` to eliminate duplication and ensure consistency in risk categorization. 

Previously, `generate_sarif` and `generate_html` implemented their own threshold checks using exclusive comparisons (`>`), which was inconsistent with the central `get_risk_category` helper used elsewhere in the application (which uses inclusive `>=` comparisons).

By centralizing this logic:
1. **Consistency:** All output formats (GUI, CLI, SARIF, HTML) now categorize threats identically.
2. **Correctness:** Boundary cases (like exactly 80% confidence) are now correctly reported as High Risk/Error, adhering to project standards.
3. **Maintainability:** Duplicated logic is removed, making future changes to risk levels easier to implement.

Verified by running the full test suite and adding a specific boundary test case.

---
*PR created automatically by Jules for task [17163425425603648079](https://jules.google.com/task/17163425425603648079) started by @RainRat*