### PR TITLE
[UI/UX] Improve scan result workflow and UI consistency

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -801,6 +801,8 @@ def _apply_filter(*args: Any) -> None:
         else:
             update_status("Ready")
 
+    update_tree_columns()
+
 
 def _prepare_tree_row(values: Tuple[Any, ...]) -> Tuple[List[Any], Tuple[str, ...]]:
     """Prepare wrapped values and tags for a Treeview row."""
@@ -880,6 +882,10 @@ def set_scanning_state(is_scanning: bool) -> None:
         scan_button.config(state="disabled" if is_scanning else "normal")
         cancel_button.config(state="normal" if is_scanning else "disabled")
 
+    if view_button and rescan_button:
+        view_button.config(state="disabled" if is_scanning else "normal")
+        rescan_button.config(state="disabled" if is_scanning else "normal")
+
 
 def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Optional[int] = None, total_bytes: Optional[int] = None, elapsed_time: Optional[float] = None, high_risk: int = 0, medium_risk: int = 0) -> None:
     """Reset scanning controls when a scan finishes or is cancelled.
@@ -913,6 +919,14 @@ def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Option
         update_status("Ready")
 
     update_tree_columns()
+
+    # Auto-select the first result and focus the tree for immediate keyboard navigation
+    if tree:
+        items = tree.get_children()
+        if items:
+            tree.selection_set(items[0])
+            tree.focus(items[0])
+            tree.focus_set()
 
 
 def button_click() -> None:
@@ -2023,6 +2037,13 @@ def import_results() -> None:
         _last_scan_summary = msg
         update_status(msg)
         update_tree_columns()
+
+        # Auto-select the first result and focus the tree for immediate keyboard navigation
+        items = tree.get_children()
+        if items:
+            tree.selection_set(items[0])
+            tree.focus(items[0])
+            tree.focus_set()
 
     except Exception as err:
         messagebox.showerror("Import Failed", f"Could not load results:\n{err}")

--- a/tests/test_filter_select_all.py
+++ b/tests/test_filter_select_all.py
@@ -53,7 +53,7 @@ def test_apply_filter_refreshes_tree(monkeypatch):
     gptscan._apply_filter()
 
     # Verify tree was cleared
-    mock_tree.get_children.assert_called_once()
+    assert mock_tree.get_children.called
     mock_tree.delete.assert_called_once()
 
     # Verify only matching item was inserted


### PR DESCRIPTION
This PR introduces several UI/UX improvements to the `gptscan` GUI to reduce friction and improve clarity:

1. **Friction Reduction**: After a scan finishes or results are imported, the first row in the results list is automatically selected and the Treeview is focused. This allows users to immediately start navigating findings with arrow keys or view details with Space/Enter without needing to click first.
2. **Feedback & Clarity**: The 'View Details' and 'Rescan Selected' buttons are now disabled while a scan is in progress, mirroring the 'Scan now' button state. This provides clearer feedback on the application's state and prevents concurrent operations on potentially stale selection data.
3. **Consistency**: The `_apply_filter` function now triggers an update to the Treeview's visible columns. This ensures that AI-specific columns are correctly displayed or hidden based on whether the *current* filtered results contain AI data, maintaining a clean and relevant interface.

Existing unit tests were updated to accommodate the logic changes in the filtering process.

---
*PR created automatically by Jules for task [7889281709836945490](https://jules.google.com/task/7889281709836945490) started by @RainRat*