### PR TITLE
[UI/UX] [Friction Reduction] Prioritize suspicious files in selection after scan

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -922,6 +922,29 @@ def update_tree_columns() -> None:
         tree["displaycolumns"] = ("path", "own_conf", "snippet")
 
 
+def _auto_select_best_result() -> None:
+    """Select the most relevant result (first threat, or first file) and focus it."""
+    if not tree:
+        return
+
+    items = tree.get_children()
+    if not items:
+        return
+
+    # Prioritize selecting the first suspicious file
+    target_item = items[0]
+    for iid in items:
+        tags = tree.item(iid, 'tags')
+        if 'high-risk' in tags or 'medium-risk' in tags:
+            target_item = iid
+            break
+
+    tree.selection_set(target_item)
+    tree.focus(target_item)
+    tree.see(target_item)
+    tree.focus_set()
+
+
 def set_scanning_state(is_scanning: bool) -> None:
     """Enable or disable controls based on scanning state."""
 
@@ -966,14 +989,7 @@ def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Option
         update_status("Ready")
 
     update_tree_columns()
-
-    # Auto-select the first result and focus the tree for immediate keyboard navigation
-    if tree:
-        items = tree.get_children()
-        if items:
-            tree.selection_set(items[0])
-            tree.focus(items[0])
-            tree.focus_set()
+    _auto_select_best_result()
 
 
 def button_click() -> None:
@@ -2093,13 +2109,7 @@ def import_results() -> None:
         _last_scan_summary = msg
         update_status(msg)
         update_tree_columns()
-
-        # Auto-select the first result and focus the tree for immediate keyboard navigation
-        items = tree.get_children()
-        if items:
-            tree.selection_set(items[0])
-            tree.focus(items[0])
-            tree.focus_set()
+        _auto_select_best_result()
 
     except Exception as err:
         messagebox.showerror("Import Failed", f"Could not load results:\n{err}")

--- a/tests/test_ui_ux_smart_selection.py
+++ b/tests/test_ui_ux_smart_selection.py
@@ -1,0 +1,69 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+import gptscan
+
+def test_auto_select_best_result_prioritizes_risks(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+
+    # Mock items: item1 is safe, item2 is high-risk, item3 is medium-risk
+    items = ['item1', 'item2', 'item3']
+    mock_tree.get_children.return_value = items
+
+    # Mock tags for each item
+    def mock_item_tags(iid, option):
+        if iid == 'item1':
+            return []
+        elif iid == 'item2':
+            return ['high-risk']
+        elif iid == 'item3':
+            return ['medium-risk']
+        return []
+
+    mock_tree.item.side_effect = mock_item_tags
+
+    # Action
+    gptscan._auto_select_best_result()
+
+    # Assert: item2 should be selected as it's the first risk
+    mock_tree.selection_set.assert_called_once_with('item2')
+    mock_tree.focus.assert_called_once_with('item2')
+    mock_tree.see.assert_called_once_with('item2')
+    mock_tree.focus_set.assert_called_once()
+
+def test_auto_select_best_result_falls_back_to_first_item(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+
+    # Mock items: all are safe
+    items = ['item1', 'item2']
+    mock_tree.get_children.return_value = items
+    mock_tree.item.return_value = [] # No tags
+
+    # Action
+    gptscan._auto_select_best_result()
+
+    # Assert: item1 should be selected
+    mock_tree.selection_set.assert_called_once_with('item1')
+    mock_tree.focus.assert_called_once_with('item1')
+    mock_tree.see.assert_called_once_with('item1')
+
+def test_auto_select_best_result_handles_empty_tree(monkeypatch):
+    # Setup mocks
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    mock_tree.get_children.return_value = []
+
+    # Action
+    gptscan._auto_select_best_result()
+
+    # Assert
+    mock_tree.selection_set.assert_not_called()
+
+def test_auto_select_best_result_handles_none_tree(monkeypatch):
+    monkeypatch.setattr(gptscan, 'tree', None)
+    # Should not raise
+    gptscan._auto_select_best_result()


### PR DESCRIPTION
This PR introduces a "smart selection" mechanism to the Results Treeview. Instead of blindly selecting the first file in the list (which is often a safe file when "Show all files" is enabled), the GUI now automatically prioritizes, selects, and scrolls to the first suspicious finding (High or Medium risk) after a scan completes or a report is imported. This significantly reduces the manual "hunting" effort for users and ensures that critical information is presented immediately.

---
*PR created automatically by Jules for task [13164302538748845369](https://jules.google.com/task/13164302538748845369) started by @RainRat*