### PR TITLE
[TEST] Snippet Scanning Coverage & Boundary Fix

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1000,6 +1000,17 @@ def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Option
     _auto_select_best_result()
 
 
+def scan_clipboard_click():
+    """Scan code currently in the clipboard."""
+    try:
+        if root:
+            content = root.clipboard_get()
+            if content:
+                button_click(extra_snippets=[("[Clipboard]", content.encode('utf-8'))])
+    except Exception as e:
+        messagebox.showwarning("Clipboard Error", f"Could not read from clipboard: {e}")
+
+
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None) -> None:
     """Trigger a scan in a background thread using the selected path.
 
@@ -1375,7 +1386,7 @@ def scan_files(
                         snippet = ''.join(map(chr, max_window_bytes)).strip()
                         cleaned_snippet = ''.join([s for s in snippet.strip().splitlines(True) if s.strip()])
                         threshold_val = Config.THRESHOLD / 100.0
-                        if maxconf > threshold_val and use_gpt and Config.GPT_ENABLED:
+                        if maxconf >= threshold_val and use_gpt and Config.GPT_ENABLED:
                             gpt_requests.append(
                                 {
                                     "path": str(file_path),
@@ -1384,7 +1395,7 @@ def scan_files(
                                     "cleaned_snippet": cleaned_snippet,
                                 }
                             )
-                        elif maxconf > threshold_val or show_all:
+                        elif maxconf >= threshold_val or show_all:
                             yield (
                                 'result',
                                 (
@@ -1436,7 +1447,7 @@ def scan_files(
                 snippet = ''.join(map(chr, max_window_bytes)).strip()
                 cleaned_snippet = ''.join([s for s in snippet.strip().splitlines(True) if s.strip()])
                 threshold_val = Config.THRESHOLD / 100.0
-                if maxconf > threshold_val and use_gpt and Config.GPT_ENABLED:
+                if maxconf >= threshold_val and use_gpt and Config.GPT_ENABLED:
                     gpt_requests.append(
                         {
                             "path": name,
@@ -1445,7 +1456,7 @@ def scan_files(
                             "cleaned_snippet": cleaned_snippet,
                         }
                     )
-                elif maxconf > threshold_val or show_all:
+                elif maxconf >= threshold_val or show_all:
                     yield (
                         'result',
                         (
@@ -2802,14 +2813,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     select_dir_btn = ttk.Button(input_frame, text="Folder...", command=browse_dir_click)
     select_dir_btn.grid(row=0, column=3, sticky="e", padx=(5, 0))
     bind_hover_message(select_dir_btn, "Select a directory to scan.")
-
-    def scan_clipboard_click():
-        try:
-            content = root.clipboard_get()
-            if content:
-                button_click(extra_snippets=[("[Clipboard]", content.encode('utf-8'))])
-        except Exception as e:
-            messagebox.showwarning("Clipboard Error", f"Could not read from clipboard: {e}")
 
     select_clipboard_btn = ttk.Button(input_frame, text="Clipboard", command=scan_clipboard_click)
     select_clipboard_btn.grid(row=0, column=4, sticky="e", padx=(5, 0))

--- a/tests/test_extra_snippets.py
+++ b/tests/test_extra_snippets.py
@@ -1,0 +1,181 @@
+import io
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+from gptscan import scan_files, Config, scan_clipboard_click
+
+@pytest.fixture
+def mock_tf_env(monkeypatch):
+    """Setup mock TensorFlow and Model to avoid actual loading."""
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.5]] # 50%
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    mock_tf = MagicMock()
+    mock_tf.constant = lambda x: x
+    mock_tf.expand_dims = lambda x, axis: x
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+
+    # Mock collect_files to return empty list by default
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+
+    return mock_model
+
+def test_scan_files_extra_snippets_basic(mock_tf_env):
+    """Test that extra_snippets are correctly processed by scan_files."""
+    snippet_content = b"print('hello world')"
+    extra_snippets = [("[Clipboard]", snippet_content)]
+
+    events = list(scan_files(
+        scan_targets=[],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False,
+        extra_snippets=extra_snippets
+    ))
+
+    # Filter for result events
+    results = [data for event, data in events if event == 'result']
+
+    assert len(results) == 1
+    path, own_conf, admin, user, gpt, snippet = results[0]
+    assert path == "[Clipboard]"
+    assert own_conf == "50%"
+    assert "print('hello world')" in snippet
+
+def test_scan_files_boundary_threshold(mock_tf_env):
+    """Verify that a snippet exactly at the threshold is yielded (inclusive check)."""
+    mock_tf_env.predict.return_value = [[0.5]] # Exactly 50%
+    Config.THRESHOLD = 50
+
+    snippet_content = b"at threshold"
+    extra_snippets = [("boundary", snippet_content)]
+
+    events = list(scan_files(
+        scan_targets=[],
+        deep_scan=False,
+        show_all=False, # NOT showing all
+        use_gpt=False,
+        extra_snippets=extra_snippets
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 1
+    assert results[0][1] == "50%"
+
+def test_scan_files_below_threshold_ignored(mock_tf_env):
+    """Verify that a snippet below the threshold is ignored when show_all=False."""
+    mock_tf_env.predict.return_value = [[0.49]] # 49%
+    Config.THRESHOLD = 50
+
+    snippet_content = b"below threshold"
+    extra_snippets = [("safe", snippet_content)]
+
+    events = list(scan_files(
+        scan_targets=[],
+        deep_scan=False,
+        show_all=False,
+        use_gpt=False,
+        extra_snippets=extra_snippets
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 0
+
+def test_scan_files_extra_snippets_gpt_trigger(mock_tf_env, monkeypatch):
+    """Test that extra_snippets can trigger GPT analysis."""
+    mock_tf_env.predict.return_value = [[0.9]]
+    Config.THRESHOLD = 50
+    Config.GPT_ENABLED = True
+    Config.taskdesc = "Analyze this"
+
+    async def mock_gpt_handle(*args, **kwargs):
+        return {
+            "administrator": "Admin analysis",
+            "end-user": "User explanation",
+            "threat-level": 85
+        }
+
+    monkeypatch.setattr(gptscan, "async_handle_gpt_response", mock_gpt_handle)
+
+    extra_snippets = [("[Stdin]", b"malicious code")]
+
+    events = list(scan_files(
+        scan_targets=[],
+        deep_scan=False,
+        show_all=False,
+        use_gpt=True,
+        extra_snippets=extra_snippets
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 1
+    path, own, admin, user, gpt, snippet = results[0]
+    assert path == "[Stdin]"
+    assert admin == "Admin analysis"
+    assert gpt == "85%"
+
+def test_cli_stdin_integration(monkeypatch):
+    """Test that --stdin correctly passes content to run_cli."""
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+
+    # Mock sys.stdin.buffer.read
+    mock_stdin_buffer = MagicMock()
+    mock_stdin_buffer.read.return_value = b"stdin content"
+
+    # Mock sys.stdin and its buffer
+    mock_stdin = MagicMock()
+    mock_stdin.buffer = mock_stdin_buffer
+
+    # Simulate: python gptscan.py --cli --stdin
+    test_args = ["gptscan.py", "--cli", "--stdin"]
+    with patch("sys.argv", test_args), patch("sys.stdin", mock_stdin):
+        gptscan.main()
+
+    mock_run_cli.assert_called_once()
+    _, kwargs = mock_run_cli.call_args
+    extra_snippets = kwargs.get("extra_snippets")
+    assert extra_snippets == [("[Stdin]", b"stdin content")]
+
+def test_scan_clipboard_click_logic(monkeypatch):
+    """Test the GUI clipboard scan flow."""
+    mock_root = MagicMock()
+    mock_root.clipboard_get.return_value = "clipboard content"
+    monkeypatch.setattr(gptscan, "root", mock_root)
+
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, "button_click", mock_button_click)
+
+    scan_clipboard_click()
+
+    mock_button_click.assert_called_once_with(
+        extra_snippets=[("[Clipboard]", b"clipboard content")]
+    )
+
+def test_scan_clipboard_click_empty(monkeypatch):
+    """Test that empty clipboard does nothing."""
+    mock_root = MagicMock()
+    mock_root.clipboard_get.return_value = ""
+    monkeypatch.setattr(gptscan, "root", mock_root)
+
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, "button_click", mock_button_click)
+
+    scan_clipboard_click()
+
+    mock_button_click.assert_not_called()
+
+def test_scan_clipboard_click_error(monkeypatch):
+    """Test error handling in scan_clipboard_click."""
+    mock_root = MagicMock()
+    mock_root.clipboard_get.side_effect = Exception("Clipboard busy")
+    monkeypatch.setattr(gptscan, "root", mock_root)
+
+    mock_messagebox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_messagebox)
+
+    scan_clipboard_click()
+
+    mock_messagebox.showwarning.assert_called_once()
+    assert "Could not read from clipboard" in mock_messagebox.showwarning.call_args[0][1]

--- a/tests/test_threat_intel.py
+++ b/tests/test_threat_intel.py
@@ -80,6 +80,36 @@ def test_check_virustotal_with_path(tmp_path):
     expected_url = f"https://www.virustotal.com/gui/file/{expected_hash}"
     mock_open.assert_called_once_with(expected_url)
 
+def test_copy_sha256_virtual_path(mock_tree):
+    """Test that copy_sha256 hashes the snippet for virtual paths."""
+    snippet = "print('virtual')"
+    expected_hash = hashlib.sha256(snippet.encode('utf-8')).hexdigest()
+
+    mock_tree.selection.return_value = ["item1"]
+    raw_values = ["[Clipboard]", "50%", "", "", "", snippet]
+    mock_tree._item_values["item1"] = ("[Clipboard]", "50%", "", "", "", snippet, json.dumps(raw_values))
+
+    with patch('gptscan.update_status'):
+        gptscan.copy_sha256()
+
+    mock_tree.clipboard_clear.assert_called_once()
+    mock_tree.clipboard_append.assert_called_with(expected_hash)
+
+def test_check_virustotal_virtual_path(mock_tree):
+    """Test that check_virustotal hashes the snippet for virtual paths."""
+    snippet = "print('virtual')"
+    expected_hash = hashlib.sha256(snippet.encode('utf-8')).hexdigest()
+
+    mock_tree.selection.return_value = ["item1"]
+    raw_values = ["[Stdin]", "50%", "", "", "", snippet]
+    mock_tree._item_values["item1"] = ("[Stdin]", "50%", "", "", "", snippet, json.dumps(raw_values))
+
+    with patch('webbrowser.open') as mock_open, patch('gptscan.update_status'):
+        gptscan.check_virustotal()
+
+    expected_url = f"https://www.virustotal.com/gui/file/{expected_hash}"
+    mock_open.assert_called_once_with(expected_url)
+
 def test_check_virustotal_not_found(monkeypatch):
     mock_msgbox = MagicMock()
     monkeypatch.setattr(gptscan, 'messagebox', mock_msgbox)


### PR DESCRIPTION
This PR improves the test suite's reliability and coverage while fixing a minor logic bug in the threat detection pipeline.

### Changes:
- **Testability Refactoring:** Moved `scan_clipboard_click` from a local scope within `create_gui` to the module level. This allows automated tests to trigger clipboard scanning without initializing the entire GUI.
- **Bug Fix:** Updated `scan_files` to use inclusive comparisons (`>=`) when checking if a model confidence score meets the threat threshold. Previously, files exactly at the threshold (e.g., 50%) were incorrectly filtered out.
- **New Coverage (extra_snippets):** Added `tests/test_extra_snippets.py` which provides comprehensive coverage for the `extra_snippets` parameter in `scan_files`. It verifies:
    - Basic scanning of in-memory snippets (`[Clipboard]`, `[Stdin]`).
    - Inclusive boundary threshold logic.
    - CLI integration for the `--stdin` flag.
    - GUI logic for the "Clipboard" button, including error handling.
- **Enhanced Coverage (Threat Intel):** Updated `tests/test_threat_intel.py` to ensure that virtual paths are correctly handled by the SHA256 and VirusTotal logic (hashing the snippet content directly instead of trying to read from disk).

Verified all 317 tests pass on Python 3.12.

---
*PR created automatically by Jules for task [13769790756660998622](https://jules.google.com/task/13769790756660998622) started by @RainRat*