### PR TITLE
[UI/UX] Add Risk Level Badge to Result Details

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2371,6 +2371,9 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     ai_conf_prefix = ttk.Label(conf_frame, text="AI Confidence:")
     gpt_conf_label = ttk.Label(conf_frame, font=('TkDefaultFont', 9, 'bold'))
 
+    risk_badge = tk.Label(conf_frame, font=('TkDefaultFont', 9, 'bold'), padx=8, pady=2)
+    risk_badge.grid(row=0, column=4, sticky="w", padx=(20, 0))
+
     ttk.Separator(main_frame, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=10)
 
     # Analysis sections
@@ -2490,6 +2493,16 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         path_entry.insert(0, path)
         path_entry.config(state='readonly')
         own_conf_label.config(text=own_conf)
+
+        conf = get_effective_confidence(own_conf, gpt_conf)
+        risk = get_risk_category(conf, Config.THRESHOLD)
+
+        if risk == 'high':
+            risk_badge.config(text="HIGH RISK", background="#ffcccc", foreground="darkred")
+        elif risk == 'medium':
+            risk_badge.config(text="MEDIUM RISK", background="#fff0cc", foreground="darkorange")
+        else:
+            risk_badge.config(text="LOW RISK", background="lightgrey", foreground="grey")
 
         if gpt_conf:
             ai_conf_prefix.grid(row=0, column=2, sticky="w")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,30 @@ mock_tk.TclError = Exception
 sys.modules['tkinter'] = mock_tk
 sys.modules['tkinter.filedialog'] = MagicMock()
 sys.modules['tkinter.font'] = MagicMock()
-sys.modules['tkinter.ttk'] = MagicMock()
+
+# Explicitly mock Label to be a real class so it's not a mock instance
+class MockLabel:
+    def __init__(self, *args, **kwargs): pass
+    def grid(self, *args, **kwargs): pass
+    def pack(self, *args, **kwargs): pass
+    def config(self, *args, **kwargs): pass
+    def cget(self, *args, **kwargs): return ""
+    def __repr__(self): return "MockLabel"
+
+mock_tk.Label = MockLabel
+
+mock_ttk = MagicMock()
+# Explicitly mock Frame to be a real class so it's not a mock instance
+class MockFrame:
+    def __init__(self, *args, **kwargs): pass
+    def grid(self, *args, **kwargs): pass
+    def pack(self, *args, **kwargs): pass
+    def columnconfigure(self, *args, **kwargs): pass
+    def rowconfigure(self, *args, **kwargs): pass
+    def winfo_viewable(self): return True
+    def __repr__(self): return "MockFrame"
+
+mock_ttk.Frame = MockFrame
+sys.modules['tkinter.ttk'] = mock_ttk
 sys.modules['tkinter.messagebox'] = MagicMock()
 sys.modules['tkinter.scrolledtext'] = MagicMock()

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -34,6 +34,10 @@ def test_view_details_open_window(mock_tree, monkeypatch):
     mock_toplevel = MagicMock()
     monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock(return_value=mock_toplevel))
 
+    # Mock tk.Label for risk_badge
+    mock_label = MagicMock()
+    monkeypatch.setattr(gptscan.tk, 'Label', MagicMock(return_value=mock_label))
+
     # Mock scrolledtext
     mock_scrolledtext = MagicMock()
     mock_st_class = MagicMock(return_value=mock_scrolledtext)
@@ -47,8 +51,14 @@ def test_view_details_open_window(mock_tree, monkeypatch):
     gptscan.tk.Toplevel.assert_called_once()
     mock_toplevel.title.assert_called_with("Result 1 of 1 - test.py")
 
+    # Verify risk_badge was created and configured correctly (90% own_conf -> HIGH RISK)
+    gptscan.tk.Label.assert_called()
+    # Check that config was called with HIGH RISK. Note: Label might be used for other things
+    # but in view_details it's currently only used for risk_badge after my changes.
+    # Actually, own_conf_label is a ttk.Label.
+    mock_label.config.assert_any_call(text="HIGH RISK", background="#ffcccc", foreground="darkred")
+
     # Verify data was inserted into ScrolledText widgets (we expect 3: admin, user, snippet)
-    # Actually if both admin and user are present, there are 3 ScrolledText calls.
     assert mock_st_class.call_count == 3
 
     # Check that the data was inserted
@@ -57,6 +67,22 @@ def test_view_details_open_window(mock_tree, monkeypatch):
     assert "Admin Note" in contents
     assert "User Note" in contents
     assert "print('hello')" in contents
+
+def test_view_details_low_risk(mock_tree, monkeypatch):
+    # Setup mock selection with low confidence
+    mock_tree.selection.return_value = ["item1"]
+    raw_values = ["safe.py", "10%", "", "", "", "print('safe')"]
+    mock_tree._item_values["item1"] = ("safe.py", "10%", "", "", "", "print('safe')", json.dumps(raw_values))
+
+    monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock())
+    mock_label = MagicMock()
+    monkeypatch.setattr(gptscan.tk, 'Label', MagicMock(return_value=mock_label))
+    monkeypatch.setattr(gptscan.scrolledtext, 'ScrolledText', MagicMock())
+
+    gptscan.view_details()
+
+    # Verify risk_badge was configured as LOW RISK (10% < 50% threshold)
+    mock_label.config.assert_any_call(text="LOW RISK", background="lightgrey", foreground="grey")
 
 def test_view_details_no_selection(mock_tree, monkeypatch):
     mock_tree.selection.return_value = []


### PR DESCRIPTION
This improvement enhances the feedback and clarity of the scan results detail view by adding a prominent, color-coded 'Risk Level Badge' (e.g., HIGH RISK, MEDIUM RISK, LOW RISK). This badge allows users to immediately identify the severity of a finding without manually interpreting confidence percentages, and provides visual consistency with the main results list.

---
*PR created automatically by Jules for task [2111818842061663686](https://jules.google.com/task/2111818842061663686) started by @RainRat*