### PR TITLE
[FEAT] Recent Paths History in GUI

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -6,5 +6,11 @@
     "use_ai_analysis": false,
     "provider": "openai",
     "model_name": "gpt-4o",
-    "threshold": 50
+    "threshold": 50,
+    "recent_paths": [
+        "/some/path",
+        "/some/repo",
+        "/new/path",
+        "/old/path"
+    ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -89,6 +89,7 @@ class Config:
     ignore_patterns: List[str] = []
     THRESHOLD: int = 50
     last_path: str = ""
+    recent_paths: List[str] = []
     deep_scan: bool = False
     git_changes_only: bool = False
     show_all_files: bool = False
@@ -127,6 +128,7 @@ class Config:
             "provider": cls.provider,
             "model_name": cls.model_name,
             "threshold": cls.THRESHOLD,
+            "recent_paths": cls.recent_paths,
         }
         try:
             with open(cls.SETTINGS_FILE, 'w', encoding='utf-8') as f:
@@ -150,6 +152,7 @@ class Config:
                 cls.provider = settings.get("provider", cls.provider)
                 cls.model_name = settings.get("model_name", cls.model_name)
                 cls.THRESHOLD = settings.get("threshold", cls.THRESHOLD)
+                cls.recent_paths = settings.get("recent_paths", cls.recent_paths)
         except Exception as e:
             print(f"Warning: Could not load settings: {e}", file=sys.stderr)
 
@@ -1039,6 +1042,13 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None) -> No
         return
 
     Config.last_path = scan_path
+    if scan_path and (not Config.recent_paths or Config.recent_paths[0] != scan_path):
+        if scan_path in Config.recent_paths:
+            Config.recent_paths.remove(scan_path)
+        Config.recent_paths.insert(0, scan_path)
+        Config.recent_paths = Config.recent_paths[:10]
+        if textbox:
+            textbox['values'] = Config.recent_paths
     Config.save_settings()
 
     current_cancel_event = threading.Event()
@@ -2203,6 +2213,15 @@ def clear_results() -> None:
     update_status("Ready")
 
 
+def clear_path_history() -> None:
+    """Clear the history of scanned paths."""
+    Config.recent_paths = []
+    if textbox:
+        textbox['values'] = []
+    Config.save_settings()
+    update_status("Path history cleared.")
+
+
 def _get_tree_results_as_dicts(item_ids: Iterable[str]) -> List[Dict[str, Any]]:
     """Extract raw results from the given Treeview item IDs as a list of dictionaries."""
     if not tree:
@@ -2767,6 +2786,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     file_menu.add_command(label="Export Results...", command=export_results)
     file_menu.add_separator()
     file_menu.add_command(label="Clear Results", command=clear_results)
+    file_menu.add_command(label="Clear Path History", command=clear_path_history)
     file_menu.add_separator()
     file_menu.add_command(label="Exit", command=root.quit)
     menubar.add_cascade(label="File", menu=file_menu)
@@ -2786,7 +2806,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     input_frame.columnconfigure(1, weight=1)
 
     ttk.Label(input_frame, text="Path to scan:").grid(row=0, column=0, sticky="w", padx=(0, 5))
-    textbox = ttk.Entry(input_frame)
+    textbox = ttk.Combobox(input_frame, values=Config.recent_paths)
     path_to_use = initial_path if initial_path else (Config.last_path if Config.last_path else os.getcwd())
     textbox.insert(0, path_to_use)
     textbox.select_range(0, tk.END)

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ You can customize the scanner using these files in the same folder:
 
 Run `python gptscan.py` to open the GUI.
 
-*   **Select File/Folder:** Choose what you want to scan.
+*   **Select File/Folder:** Choose what you want to scan. The path input is a dropdown that remembers your last 10 scan locations.
 *   **Clipboard:** Scan code currently in your clipboard.
 *   **Filter results:** Search findings by path, confidence, notes, or code snippets.
 *   **Deep Scan:** Check the entire file. By default, it only checks the beginning and end to save time.

--- a/tests/test_path_history.py
+++ b/tests/test_path_history.py
@@ -1,0 +1,116 @@
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+from gptscan import Config
+
+@pytest.fixture
+def temp_settings_file(tmp_path, monkeypatch):
+    """Use a temporary settings file path for testing."""
+    f = tmp_path / ".gptscan_settings.json"
+    monkeypatch.setattr(Config, "SETTINGS_FILE", str(f))
+    return f
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    """Reset globals before and after each test."""
+    orig_recent = Config.recent_paths[:]
+    Config.recent_paths = []
+    orig_cancel = gptscan.current_cancel_event
+    gptscan.current_cancel_event = None
+    yield
+    Config.recent_paths = orig_recent
+    gptscan.current_cancel_event = orig_cancel
+
+def test_config_save_load_recent_paths(temp_settings_file):
+    Config.recent_paths = ["/path/1", "/path/2"]
+    Config.save_settings()
+
+    # Clear and reload
+    Config.recent_paths = []
+    Config.load_settings()
+    assert Config.recent_paths == ["/path/1", "/path/2"]
+
+def test_button_click_updates_history(monkeypatch, temp_settings_file):
+    # Mock dependencies of button_click
+    monkeypatch.setattr(gptscan, "clear_results", MagicMock())
+    monkeypatch.setattr(gptscan, "set_scanning_state", MagicMock())
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+    monkeypatch.setattr(gptscan, "run_scan", MagicMock())
+    monkeypatch.setattr(gptscan, "messagebox", MagicMock())
+
+    # Use dry_run to avoid scripts.h5 check
+    mock_dry_var = MagicMock()
+    mock_dry_var.get.return_value = True
+    monkeypatch.setattr(gptscan, "dry_var", mock_dry_var)
+
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "/new/path"
+    monkeypatch.setattr(gptscan, "textbox", mock_textbox)
+
+    # Also need to mock other globals used in button_click
+    monkeypatch.setattr(gptscan, "git_var", MagicMock(get=lambda: False))
+    monkeypatch.setattr(gptscan, "deep_var", MagicMock(get=lambda: False))
+    monkeypatch.setattr(gptscan, "all_var", MagicMock(get=lambda: False))
+    monkeypatch.setattr(gptscan, "gpt_var", MagicMock(get=lambda: False))
+
+    # Initially empty
+    Config.recent_paths = ["/old/path"]
+
+    # Ensure current_cancel_event is None
+    gptscan.current_cancel_event = None
+
+    with patch("threading.Thread"):
+        gptscan.button_click()
+
+    assert Config.recent_paths == ["/new/path", "/old/path"]
+    mock_textbox.__setitem__.assert_called_with('values', ["/new/path", "/old/path"])
+
+def test_history_uniqueness_and_limit():
+    Config.recent_paths = [f"/path/{i}" for i in range(10)]
+
+    # Mock textbox
+    mock_textbox = MagicMock()
+    with patch("gptscan.textbox", mock_textbox):
+        # Add a duplicate path
+        scan_path = "/path/5"
+        # Manually trigger the logic that was added to button_click
+        if scan_path and (not Config.recent_paths or Config.recent_paths[0] != scan_path):
+            if scan_path in Config.recent_paths:
+                Config.recent_paths.remove(scan_path)
+            Config.recent_paths.insert(0, scan_path)
+            Config.recent_paths = Config.recent_paths[:10]
+            if mock_textbox:
+                mock_textbox['values'] = Config.recent_paths
+
+        assert Config.recent_paths[0] == "/path/5"
+        assert len(Config.recent_paths) == 10
+        assert Config.recent_paths.count("/path/5") == 1
+
+        # Add a new path, should push out the last one
+        scan_path = "/path/new"
+        if scan_path and (not Config.recent_paths or Config.recent_paths[0] != scan_path):
+            if scan_path in Config.recent_paths:
+                Config.recent_paths.remove(scan_path)
+            Config.recent_paths.insert(0, scan_path)
+            Config.recent_paths = Config.recent_paths[:10]
+            if mock_textbox:
+                mock_textbox['values'] = Config.recent_paths
+
+        assert Config.recent_paths[0] == "/path/new"
+        assert len(Config.recent_paths) == 10
+        assert "/path/9" not in Config.recent_paths
+
+def test_clear_path_history(monkeypatch):
+    Config.recent_paths = ["/path/1", "/path/2"]
+    mock_textbox = MagicMock()
+    monkeypatch.setattr(gptscan, "textbox", mock_textbox)
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+    monkeypatch.setattr(Config, "save_settings", MagicMock())
+
+    gptscan.clear_path_history()
+
+    assert Config.recent_paths == []
+    mock_textbox.__setitem__.assert_called_with('values', [])
+    Config.save_settings.assert_called_once()


### PR DESCRIPTION
This PR implements a "Recent Paths" history feature for the GPT Virus Scanner GUI. 

The path input field is now a `ttk.Combobox` that remembers the last 10 unique scan locations (files or folders). This history is saved to and loaded from `.gptscan_settings.json` automatically.

A new "Clear Path History" option has been added to the "File" menu to allow users to reset their scan history.

These changes improve user convenience by reducing the need to repeatedly browse for or type in common scan targets. 

Includes comprehensive unit tests to ensure history logic, uniqueness, limits, and persistence work correctly.

---
*PR created automatically by Jules for task [14957343834407031657](https://jules.google.com/task/14957343834407031657) started by @RainRat*