### PR TITLE
Fix path resolution bug in get_git_changed_files for subdirectories

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -612,9 +612,14 @@ def get_git_changed_files(path: str = ".") -> List[str]:
         cwd = os.path.abspath(path)
         targets = []
 
-    # Check if we are in a git repository
+    # Check if we are in a git repository and get the root directory
     try:
-        subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"], cwd=cwd, stderr=subprocess.PIPE)
+        toplevel = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return []
 
@@ -634,7 +639,7 @@ def get_git_changed_files(path: str = ".") -> List[str]:
 
     # Untracked files
     try:
-        cmd = ["git", "ls-files", "--others", "--exclude-standard", "--"] + targets
+        cmd = ["git", "ls-files", "--others", "--exclude-standard", "--full-name", "--"] + targets
         output = subprocess.check_output(
             cmd,
             cwd=cwd,
@@ -645,7 +650,7 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         pass
 
-    return [os.path.join(cwd, f) for f in files if os.path.exists(os.path.join(cwd, f))]
+    return [os.path.join(toplevel, f) for f in files if os.path.exists(os.path.join(toplevel, f))]
 
 
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -142,3 +142,33 @@ def test_get_git_changed_files_untracked_real_git(tmp_path):
 
     # It should find the untracked file.
     assert any(str(untracked) == os.path.abspath(r) for r in results)
+
+def test_get_git_changed_files_subdirectory_resolution(tmp_path):
+    """Verify that files in a subdirectory are correctly identified when scanning the subdirectory."""
+    # Initialize a git repo
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+
+    # Create a subdirectory and a file in it
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    f = subdir / "test.py"
+    f.write_text("print('hello')")
+
+    # Add and commit the file
+    subprocess.run(["git", "add", "subdir/test.py"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(tmp_path), check=True)
+
+    # Modify the file
+    f.write_text("print('hello')\n# change")
+
+    # Create an untracked file in the same subdirectory
+    untracked = subdir / "untracked.py"
+    untracked.write_text("untracked")
+
+    # Run get_git_changed_files on the subdirectory
+    results = get_git_changed_files(str(subdir))
+
+    # Both files should be found and paths should be correct
+    result_paths = [os.path.abspath(r) for r in results]
+    assert os.path.abspath(f) in result_paths
+    assert os.path.abspath(untracked) in result_paths


### PR DESCRIPTION
* **What:** Updated `get_git_changed_files` to use `git rev-parse --show-toplevel` for identifying the repository root and added `--full-name` to `git ls-files`. File paths are now constructed by joining the repository root with the paths returned by Git.
* **Why:** Previously, scanning a subdirectory within a Git repository using the `--git-changes` flag failed to correctly locate files because the code incorrectly joined Git's relative paths with the current working directory instead of the repository root. This fix ensures accurate file identification regardless of where the scan is initiated from within the repository. No breaking changes were introduced, and existing file/directory scan behaviors remain intact.

---
*PR created automatically by Jules for task [1295219500153798591](https://jules.google.com/task/1295219500153798591) started by @RainRat*