### PR TITLE
[TEST] Refactor UI handlers for testability and add coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2879,6 +2879,16 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
     rescan_button.config(state="normal" if has_selection else "disabled")
 
 
+def on_root_return(event: Optional[tk.Event] = None) -> None:
+    """Trigger a scan if the focus is not on a widget that handles Return."""
+    if not root:
+        return
+    # Trigger scan if focus is not on results tree, path textbox or filter entry
+    focused = root.focus_get()
+    if str(focused) not in (str(tree), str(textbox), str(filter_entry)):
+        button_click()
+
+
 def select_all_items(event: Optional[tk.Event] = None) -> str:
     """Select all items currently visible in the Results Treeview."""
     if tree:
@@ -3244,12 +3254,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tree.bind('<Menu>', show_context_menu)
 
     # Bind selection and rescan keys
-    def on_root_return(event):
-        # Trigger scan if focus is not on results tree, path textbox or filter entry
-        focused = root.focus_get()
-        if str(focused) not in (str(tree), str(textbox), str(filter_entry)):
-            button_click()
-
     root.bind('<Return>', on_root_return)
     root.bind('<Control-f>', lambda e: filter_entry.focus_set())
     root.bind('<Command-f>', lambda e: filter_entry.focus_set())

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -238,7 +238,8 @@ def test_copy_snippet_batch(mock_tree):
     gptscan.copy_snippet()
 
     mock_tree.clipboard_clear.assert_called_once()
-    mock_tree.clipboard_append.assert_called_with("code1\n---\ncode2")
+    expected = "--- path1.py ---\ncode1\n\n--- path2.js ---\ncode2"
+    mock_tree.clipboard_append.assert_called_with(expected)
 
 
 def test_copy_as_json(mock_tree, monkeypatch):

--- a/tests/test_ui_event_handlers.py
+++ b/tests/test_ui_event_handlers.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import tkinter as tk
+
+@pytest.fixture
+def mock_ui_env(monkeypatch):
+    mock_root = MagicMock()
+    mock_tree = MagicMock()
+    mock_textbox = MagicMock()
+    mock_filter_entry = MagicMock()
+    mock_view_button = MagicMock()
+    mock_rescan_button = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'root', mock_root)
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'textbox', mock_textbox)
+    monkeypatch.setattr(gptscan, 'filter_entry', mock_filter_entry)
+    monkeypatch.setattr(gptscan, 'view_button', mock_view_button)
+    monkeypatch.setattr(gptscan, 'rescan_button', mock_rescan_button)
+
+    # Mock __str__ for focused widget comparison
+    mock_tree.__str__.return_value = ".tree"
+    mock_textbox.__str__.return_value = ".textbox"
+    mock_filter_entry.__str__.return_value = ".filter"
+
+    return {
+        'root': mock_root,
+        'tree': mock_tree,
+        'textbox': mock_textbox,
+        'filter_entry': mock_filter_entry,
+        'view_button': mock_view_button,
+        'rescan_button': mock_rescan_button
+    }
+
+def test_on_root_return_triggers_scan(mock_ui_env, monkeypatch):
+    mock_focused = MagicMock()
+    mock_focused.__str__.return_value = ".some_other_widget"
+    mock_ui_env['root'].focus_get.return_value = mock_focused
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, 'button_click', mock_button_click)
+
+    gptscan.on_root_return()
+
+    mock_button_click.assert_called_once()
+
+def test_on_root_return_ignored_when_tree_focused(mock_ui_env, monkeypatch):
+    mock_ui_env['root'].focus_get.return_value = mock_ui_env['tree']
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, 'button_click', mock_button_click)
+
+    gptscan.on_root_return()
+
+    mock_button_click.assert_not_called()
+
+def test_on_root_return_ignored_when_textbox_focused(mock_ui_env, monkeypatch):
+    mock_ui_env['root'].focus_get.return_value = mock_ui_env['textbox']
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, 'button_click', mock_button_click)
+
+    gptscan.on_root_return()
+
+    mock_button_click.assert_not_called()
+
+def test_on_root_return_ignored_when_filter_focused(mock_ui_env, monkeypatch):
+    mock_ui_env['root'].focus_get.return_value = mock_ui_env['filter_entry']
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, 'button_click', mock_button_click)
+
+    gptscan.on_root_return()
+
+    mock_button_click.assert_not_called()
+
+def test_on_root_return_handles_none_root(monkeypatch):
+    monkeypatch.setattr(gptscan, 'root', None)
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, 'button_click', mock_button_click)
+
+    # Should just return without error
+    gptscan.on_root_return()
+    mock_button_click.assert_not_called()
+
+def test_update_button_states_enabled(mock_ui_env):
+    mock_ui_env['tree'].selection.return_value = ("item1",)
+
+    gptscan.update_button_states()
+
+    mock_ui_env['view_button'].config.assert_called_with(state="normal")
+    mock_ui_env['rescan_button'].config.assert_called_with(state="normal")
+
+def test_update_button_states_disabled(mock_ui_env):
+    mock_ui_env['tree'].selection.return_value = ()
+
+    gptscan.update_button_states()
+
+    mock_ui_env['view_button'].config.assert_called_with(state="disabled")
+    mock_ui_env['rescan_button'].config.assert_called_with(state="disabled")
+
+def test_update_button_states_handles_none(monkeypatch):
+    monkeypatch.setattr(gptscan, 'tree', None)
+    # Should not raise error
+    gptscan.update_button_states()


### PR DESCRIPTION
This PR improves the testability and coverage of the GPT Virus Scanner GUI logic. 

I refactored the `on_root_return` keyboard handler from a nested function to a top-level one, enabling unit testing of global shortcut logic (e.g., ensuring scans don't accidentally restart when focusing the filter entry). 

New tests in `tests/test_ui_event_handlers.py` provide coverage for:
- `on_root_return`: Verifies focus-dependent scan triggering.
- `update_button_states`: Verifies selection-dependent button state management (View Details, Rescan Selected).

Additionally, I fixed an existing failure in `tests/test_context_menu.py` where a batch snippet copy test had incorrect expectations regarding file headers and separators.

---
*PR created automatically by Jules for task [14545633593973941252](https://jules.google.com/task/14545633593973941252) started by @RainRat*