### PR TITLE
[DOCS] Standardize terminology to Plain English in local scanner documentation and scripts

### DIFF
--- a/train.md
+++ b/train.md
@@ -1,6 +1,6 @@
 # Training the Local Scanner
 
-This tool trains the local "brain" (the file classifier) used by the GPT Virus Scanner. It learns to recognize the difference between safe and malicious files by studying many examples.
+This tool trains the local model (the file classifier) used by the GPT Virus Scanner. It learns to recognize the difference between safe and malicious files by studying many examples.
 
 ## Features
 
@@ -33,7 +33,7 @@ model:
   name: "scripts"           # Name used for saved model files (e.g., scripts.h5)
   max_length: 1024          # Number of bytes analyzed from each file
   pad_value: 13             # Byte value used for padding small files
-  max_params: 1000000       # Maximum allowed parameters (brain size)
+  max_params: 1000000       # Maximum allowed parameters (model size)
 
 training:
   batch_size: 32            # Files processed at once
@@ -50,26 +50,26 @@ weights:
   positive_class_weight: 1.0  # Weight applied to malicious files
 
 # AI settings for the automatic optimization process.
-# These values (0.0 to 1.0) control how the brain is built.
+# These values (0.0 to 1.0) control how the model is built.
 # The script will automatically adjust and improve these over time.
 hyperparameters:
   embedding_scale: 0.5        # Size of the memory for byte patterns
   rnn_scale: 0.5              # Memory capacity for long sequences
   pooling_type: 0.5           # How patterns are summarized
-  dropout1: 0.2               # Prevents the brain from memorizing specific files
+  dropout1: 0.2               # Prevents the model from memorizing specific files
   dense_scale: 0.5            # Complexity of the final decision layer
-  activation: 0.1             # Mathematical style of the neurons
+  activation: 0.1             # Mathematical style of the connections
   dropout2: 0.2               # Additional prevention of over-memorization
   spatial_dropout: 0.1        # Pattern-based memorization prevention
   rnn_type: 0.1               # Type of memory layers used (LSTM or GRU)
   use_conv: 0.6               # Whether to use "vision" layers for patterns
   conv_filters_scale: 0.5     # Number of "vision" patterns to look for
   conv_padding: 0.1           # How patterns at the edges are handled
-  kernel_init: 0.1            # Starting state of the brain's connections
+  kernel_init: 0.1            # Starting state of the model's connections
   rnn_dropout: 0.1            # Reliability of memory connections
   rnn_recurrent_dropout: 0.1  # Reliability of internal memory feedback
   conv_kernel_scale: 0.5      # Size of the patterns to look for
-  optimizer: 0.5              # How the brain learns from its mistakes
+  optimizer: 0.5              # How the model learns from its mistakes
 ```
 
 ## Directory Structure
@@ -178,7 +178,7 @@ python train.py --config config.yml \
 ## Output Files
 
 **Training mode produces:**
-- `{model_name}.h5` - The trained "brain" (detection model).
+- `{model_name}.h5` - The trained detection model.
 - `{model_name}_best_hp.yml` - The best settings found during training.
 
 **Prediction mode produces:**
@@ -202,7 +202,7 @@ python train.py --config config.yml \
 
 ### Prediction Process
 
-1. **Loads the Brain:** The script loads your trained model.
+1. **Loads the Model:** The script loads your trained model.
 2. **Scans New Files:** It looks at all files in your input folder.
 3. **Assigns Scores:** It calculates how likely each file is to be malicious.
 4. **Filters Results:** Any file that crosses your "threat" threshold is copied to the output folder for you to review.
@@ -211,7 +211,7 @@ python train.py --config config.yml \
 
 The script automatically tries different ways to build and train the model:
 
-- **Structure:** How the "brain" is organized and how much it can remember.
+- **Structure:** How the model is organized and how much it can remember.
 - **Learning Style:** How it learns from its mistakes and how it processes information.
 - **Special Layers:** Optional parts that can help it see patterns in the data more clearly.
 - **Training Method:** The specific mathematical approaches used to improve the model's accuracy.

--- a/train.py
+++ b/train.py
@@ -35,7 +35,7 @@ class ModelConfig:
 
 @dataclass
 class Hyperparameters:
-    """Settings that control how the AI 'brain' is built and trained."""
+    """Settings that control how the AI model is built and trained."""
     embedding_scale: float
     rnn_scale: float
     pooling_type: float
@@ -162,14 +162,14 @@ class DataLoader:
 
 
 class ModelBuilder:
-    """Builds neural network models based on hyperparameters."""
+    """Builds neural network models based on AI settings."""
     
     def __init__(self, config: ModelConfig):
         self.config = config
         self.max_length = config.max_length
     
     def _get_activation(self, value: float) -> str:
-        """Map hyperparameter to activation function."""
+        """Map AI setting to activation function."""
         if value < 0.25:
             return "relu"
         elif value < 0.5:
@@ -180,7 +180,7 @@ class ModelBuilder:
             return "hard_sigmoid"
     
     def _get_initializer(self, value: float) -> str:
-        """Map hyperparameter to kernel initializer."""
+        """Map AI setting to kernel initializer."""
         thresholds = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         initializers = [
             "glorot_normal", "glorot_uniform", "he_normal", "he_uniform",
@@ -193,7 +193,7 @@ class ModelBuilder:
         return initializers[-1]
     
     def _get_optimizer(self, value: float) -> str:
-        """Map hyperparameter to optimizer."""
+        """Map AI setting to optimizer."""
         if value < 0.2:
             return "sgd"
         elif value < 0.4:
@@ -206,7 +206,7 @@ class ModelBuilder:
             return "nadam"
     
     def _get_pooling_type(self, value: float) -> str:
-        """Map hyperparameter to pooling type."""
+        """Map AI setting to pooling type."""
         if value > 0.75:
             return "avg"
         elif value > 0.50:
@@ -217,7 +217,7 @@ class ModelBuilder:
             return "none"
     
     def build_model(self, hp: Hyperparameters) -> Optional[Model]:
-        """Build model from hyperparameters."""
+        """Build model from AI settings."""
         try:
             # Get derived parameters
             dp = hp.get_derived_params()
@@ -342,7 +342,7 @@ class ModelBuilder:
 
 
 class Trainer:
-    """Handles model training with genetic algorithm optimization."""
+    """Handles model training with an automatic optimization process."""
     
     def __init__(self, config: ModelConfig):
         self.config = config
@@ -354,10 +354,10 @@ class Trainer:
     
     def train(self, x_train: np.ndarray, y_train: np.ndarray, 
               sample_weights: np.ndarray, initial_hp: Optional[Hyperparameters] = None):
-        """Train models using genetic algorithm optimization."""
+        """Train models using an automatic optimization process."""
         current_hp = initial_hp
         if current_hp is None:
-            raise ValueError("No initial hyperparameters provided. Load from config or provide starting values.")
+            raise ValueError("No initial AI settings provided. Load from config or provide starting values.")
         
         self.best_hp = current_hp
         should_mutate = False
@@ -504,7 +504,7 @@ def load_config(config_path: str) -> Tuple[ModelConfig, Optional[Hyperparameters
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Train or run predictions with a binary file classifier using genetic algorithm optimization.',
+        description='Train or run predictions with a binary file classifier using an automatic optimization process.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -518,7 +518,7 @@ Examples:
   python script.py --config config.yml --model-name my_model
   
   # Use custom data directories
-  python script.py --config config.yml --positive-dir data/positive --negative-dir data/negative
+  python script.py --config config.yml --positive-dir data/malicious --negative-dir data/safe
         """
     )
     
@@ -526,7 +526,7 @@ Examples:
         '--config', '-c',
         type=str,
         required=True,
-        help='Path to YAML configuration file'
+        help='Path to YAML settings file'
     )
     
     parser.add_argument(
@@ -545,13 +545,13 @@ Examples:
     parser.add_argument(
         '--positive-dir',
         type=str,
-        help='Directory containing positive examples (class 1)'
+        help='Directory with malicious files'
     )
     
     parser.add_argument(
         '--negative-dir',
         type=str,
-        help='Directory containing negative examples (class 0)'
+        help='Directory with safe files'
     )
     
     parser.add_argument(
@@ -622,8 +622,8 @@ def main():
         # Training mode
         print(f"Running training mode")
         print(f"Model: {config.model_name}")
-        print(f"Positive examples: {positive_dir}")
-        print(f"Negative examples: {negative_dir}")
+        print(f"Malicious files: {positive_dir}")
+        print(f"Safe files: {negative_dir}")
         
         trainer = Trainer(config)
         data_loader = DataLoader(config)
@@ -635,8 +635,8 @@ def main():
         )
         
         print(f"Loaded {len(x_train)} samples")
-        print(f"Positive samples: {np.sum(y_train)}")
-        print(f"Negative samples: {len(y_train) - np.sum(y_train)}")
+        print(f"Malicious files: {np.sum(y_train)}")
+        print(f"Safe files: {len(y_train) - np.sum(y_train)}")
         
         # Load best hyperparameters if available
         hp_file = f'{config.model_name}_best_hp.yml'
@@ -649,7 +649,7 @@ def main():
                 "No hyperparameters found. Please provide 'hyperparameters' section in config.yml"
             )
         
-        print("Starting training with genetic algorithm optimization...")
+        print("Starting training with an automatic optimization process...")
         # Train
         trainer.train(x_train, y_train, sample_weights, initial_hp)
 


### PR DESCRIPTION
This submission standardizes the terminology used in the local scanner's training documentation and scripts to follow Plain English guidelines.

### Changes:
- **`train.md`**: Replaced biological metaphors ("brain", "neurons") with technical terms ("model", "connections"). Simplified descriptions of the optimization process.
- **`train.py`**:
    - Updated internal docstrings and comments to use accessible language.
    - Improved CLI help text (`--help`) by replacing technical jargon like "hyperparameters" with "AI settings" and "positive/negative examples" with "malicious/safe files".
    - Standardized terminal output messages to use clear, professional terminology.

These improvements ensure the codebase remains accessible to a global audience of developers and casual users while maintaining a professional and helpful tone.

---
*PR created automatically by Jules for task [12160498214218614021](https://jules.google.com/task/12160498214218614021) started by @RainRat*