### PR TITLE
Fix raw result retrieval in `_get_item_raw_values`

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2365,10 +2365,12 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
         return None
     values = list(tree.item(item_id, "values"))
 
-    # Try to return raw values from the hidden column (index 6) if available
-    if len(values) > 6 and values[6]:
+    # Try to return raw values from the hidden column (index 7) if available
+    if len(values) > 7 and values[7]:
         try:
-            return json.loads(values[6])
+            data = json.loads(values[7])
+            if isinstance(data, list):
+                return data
         except (json.JSONDecodeError, TypeError):
             pass
     # Fallback: unwrap display newlines by replacing them with spaces


### PR DESCRIPTION
* **What:** Updated `_get_item_raw_values` to use index 7 instead of 6 for retrieving the hidden raw result JSON from the Treeview item. Also added an explicit type check to ensure the deserialized data is a list.
* **Why:** Index 6 in the Treeview corresponds to the "Line" column, which often contains numeric strings that `json.loads` incorrectly parses as integers, breaking UI features like "View Details". Index 7 is the correct location for the raw result cache. This fix restores reliable access to raw finding data.

---
*PR created automatically by Jules for task [16972673026633662393](https://jules.google.com/task/16972673026633662393) started by @RainRat*