### PR TITLE
[TEST] Fix raw values retrieval and synchronize test suite schema

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2365,10 +2365,10 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
         return None
     values = list(tree.item(item_id, "values"))
 
-    # Try to return raw values from the hidden column (index 6) if available
-    if len(values) > 6 and values[6]:
+    # Try to return raw values from the hidden column (index 7) if available
+    if len(values) > 7 and values[7]:
         try:
-            return json.loads(values[6])
+            return json.loads(values[7])
         except (json.JSONDecodeError, TypeError):
             pass
     # Fallback: unwrap display newlines by replacing them with spaces

--- a/tests/test_adaptive_columns.py
+++ b/tests/test_adaptive_columns.py
@@ -6,7 +6,7 @@ import gptscan
 def test_update_tree_columns_hides_ai_when_disabled_and_no_data(monkeypatch):
     # Setup mocks
     mock_tree = MagicMock()
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line")
     mock_tree.get_children.return_value = []
 
     mock_gpt_var = MagicMock()
@@ -19,7 +19,7 @@ def test_update_tree_columns_hides_ai_when_disabled_and_no_data(monkeypatch):
     gptscan.update_tree_columns()
 
     # Verify
-    expected_cols = ("path", "own_conf", "snippet")
+    expected_cols = ("path", "own_conf", "snippet", "line")
     mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
 
 def test_update_tree_columns_shows_ai_when_enabled(monkeypatch):
@@ -37,7 +37,7 @@ def test_update_tree_columns_shows_ai_when_enabled(monkeypatch):
     gptscan.update_tree_columns()
 
     # Verify
-    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line")
     mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
 
 def test_update_tree_columns_shows_ai_when_data_present_even_if_disabled(monkeypatch):
@@ -49,7 +49,7 @@ def test_update_tree_columns_shows_ai_when_data_present_even_if_disabled(monkeyp
     mock_tree.get_children.return_value = [item_id]
     # values[4] is gpt_conf. We set it to something non-empty.
     # The code calls tree.item(item_id, 'values')
-    mock_tree.item.return_value = ("file.py", "10%", "Admin says bad", "User avoid", "90%", "snippet")
+    mock_tree.item.return_value = ("file.py", "10%", "Admin says bad", "User avoid", "90%", "snippet", "1")
 
     mock_gpt_var = MagicMock()
     mock_gpt_var.get.return_value = False
@@ -61,7 +61,7 @@ def test_update_tree_columns_shows_ai_when_data_present_even_if_disabled(monkeyp
     gptscan.update_tree_columns()
 
     # Verify
-    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    expected_cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line")
     mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)
 
 def test_update_tree_columns_hides_ai_when_disabled_and_data_is_empty(monkeypatch):
@@ -71,7 +71,7 @@ def test_update_tree_columns_hides_ai_when_disabled_and_data_is_empty(monkeypatc
     item_id = "item1"
     mock_tree.get_children.return_value = [item_id]
     # values[4] is gpt_conf. We set it to empty string.
-    mock_tree.item.return_value = ("file.py", "10%", "", "", "", "snippet")
+    mock_tree.item.return_value = ("file.py", "10%", "", "", "", "snippet", "1")
 
     mock_gpt_var = MagicMock()
     mock_gpt_var.get.return_value = False
@@ -83,5 +83,5 @@ def test_update_tree_columns_hides_ai_when_disabled_and_data_is_empty(monkeypatc
     gptscan.update_tree_columns()
 
     # Verify
-    expected_cols = ("path", "own_conf", "snippet")
+    expected_cols = ("path", "own_conf", "snippet", "line")
     mock_tree.__setitem__.assert_called_with("displaycolumns", expected_cols)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ def test_run_cli_output_csv_format(monkeypatch, capsys):
     # Mock scan_files to yield predictable results
     def mock_scan_files(*args, **kwargs):
         yield ('progress', (0, 1, None))
-        yield ('result', ("/path/file.py", "95%", "Admin Info", "User Info", "90%", "print('test')"))
+        yield ('result', ("/path/file.py", "95%", "Admin Info", "User Info", "90%", "print('test')", "1"))
         yield ('progress', (1, 1, None))
 
     monkeypatch.setattr(gptscan, "scan_files", mock_scan_files)
@@ -24,15 +24,15 @@ def test_run_cli_output_csv_format(monkeypatch, capsys):
     rows = list(reader)
 
     assert len(rows) == 2
-    assert rows[0] == ["path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet"]
-    assert rows[1] == ["/path/file.py", "95%", "Admin Info", "User Info", "90%", "print('test')"]
+    assert rows[0] == ["path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line"]
+    assert rows[1] == ["/path/file.py", "95%", "Admin Info", "User Info", "90%", "print('test')", "1"]
 
 def test_run_cli_handles_special_characters(monkeypatch, capsys):
     # Mock scan_files with special characters in snippet
     snippet_with_chars = 'line1, "quoted", \nline2'
 
     def mock_scan_files(*args, **kwargs):
-        yield ('result', ("/path/complex.py", "50%", "", "", "", snippet_with_chars))
+        yield ('result', ("/path/complex.py", "50%", "", "", "", snippet_with_chars, "10"))
 
     monkeypatch.setattr(gptscan, "scan_files", mock_scan_files)
 

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -26,8 +26,8 @@ def test_copy_path(mock_tree):
     mock_tree.selection.return_value = ["item1"]
     # Path is the first column. Wrapped for display.
     # Hidden orig_json stores the raw values.
-    raw_values = ["some/path/to/file.py", "90%", "Admin", "User", "80%", "print('hi')"]
-    mock_tree._item_values["item1"] = ("some/path/to/\nfile.py", "90%", "Admin", "User", "80%", "print('hi')", json.dumps(raw_values))
+    raw_values = ["some/path/to/file.py", "90%", "Admin", "User", "80%", "print('hi')", "1"]
+    mock_tree._item_values["item1"] = ("some/path/to/\nfile.py", "90%", "Admin", "User", "80%", "print('hi')", "1", json.dumps(raw_values))
 
     gptscan.copy_path()
 
@@ -37,8 +37,8 @@ def test_copy_path(mock_tree):
 def test_copy_snippet(mock_tree):
     mock_tree.selection.return_value = ["item1"]
     # Snippet is the last column. Wrapped for display.
-    raw_values = ["some/path", "90%", "Admin", "User", "80%", "print('wrapped\nsnippet')"]
-    mock_tree._item_values["item1"] = ("some/path", "90%", "Admin", "User", "80%", "print('wrapped\nsnippet')", json.dumps(raw_values))
+    raw_values = ["some/path", "90%", "Admin", "User", "80%", "print('wrapped\nsnippet')", "1"]
+    mock_tree._item_values["item1"] = ("some/path", "90%", "Admin", "User", "80%", "print('wrapped\nsnippet')", "1", json.dumps(raw_values))
 
     gptscan.copy_snippet()
 
@@ -195,10 +195,10 @@ def test_show_context_menu_no_item_no_selection(mock_tree, monkeypatch):
 
 def test_copy_path_batch(mock_tree):
     mock_tree.selection.return_value = ["item1", "item2"]
-    raw1 = ["path1.py", "50%", "", "", "", "code1"]
-    raw2 = ["path2.js", "60%", "", "", "", "code2"]
-    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", json.dumps(raw1))
-    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", json.dumps(raw2))
+    raw1 = ["path1.py", "50%", "", "", "", "code1", "1"]
+    raw2 = ["path2.js", "60%", "", "", "", "code2", "1"]
+    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", "1", json.dumps(raw1))
+    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", "1", json.dumps(raw2))
 
     gptscan.copy_path()
 
@@ -208,10 +208,10 @@ def test_copy_path_batch(mock_tree):
 
 def test_copy_sha256_batch(mock_tree, monkeypatch):
     mock_tree.selection.return_value = ["item1", "item2"]
-    raw1 = ["path1.py", "50%", "", "", "", "code1"]
-    raw2 = ["[Stdin]", "60%", "", "", "", "code2"]
-    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", json.dumps(raw1))
-    mock_tree._item_values["item2"] = ("[Stdin]", "60%", "", "", "", "code2", json.dumps(raw2))
+    raw1 = ["path1.py", "50%", "", "", "", "code1", "1"]
+    raw2 = ["[Stdin]", "60%", "", "", "", "code2", "1"]
+    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", "1", json.dumps(raw1))
+    mock_tree._item_values["item2"] = ("[Stdin]", "60%", "", "", "", "code2", "1", json.dumps(raw2))
 
     monkeypatch.setattr(os.path, 'exists', lambda p: True if p == "path1.py" else False)
 
@@ -230,10 +230,10 @@ def test_copy_sha256_batch(mock_tree, monkeypatch):
 
 def test_copy_snippet_batch(mock_tree):
     mock_tree.selection.return_value = ["item1", "item2"]
-    raw1 = ["path1.py", "50%", "", "", "", "code1"]
-    raw2 = ["path2.js", "60%", "", "", "", "code2"]
-    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", json.dumps(raw1))
-    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", json.dumps(raw2))
+    raw1 = ["path1.py", "50%", "", "", "", "code1", "1"]
+    raw2 = ["path2.js", "60%", "", "", "", "code2", "1"]
+    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", "1", json.dumps(raw1))
+    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", "1", json.dumps(raw2))
 
     gptscan.copy_snippet()
 
@@ -244,9 +244,9 @@ def test_copy_snippet_batch(mock_tree):
 
 def test_copy_as_json(mock_tree, monkeypatch):
     mock_tree.selection.return_value = ["item1"]
-    raw = ["path1.py", "50%", "admin", "user", "60%", "code1"]
-    mock_tree._item_values["item1"] = ("path1.py", "50%", "admin", "user", "60%", "code1", json.dumps(raw))
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet")
+    raw = ["path1.py", "50%", "admin", "user", "60%", "code1", "1"]
+    mock_tree._item_values["item1"] = ("path1.py", "50%", "admin", "user", "60%", "code1", "1", json.dumps(raw))
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line")
 
     gptscan.copy_as_json()
 
@@ -260,10 +260,10 @@ def test_copy_as_json(mock_tree, monkeypatch):
 
 def test_check_virustotal_batch(mock_tree, monkeypatch):
     mock_tree.selection.return_value = ["item1", "item2"]
-    raw1 = ["path1.py", "50%", "", "", "", "code1"]
-    raw2 = ["path2.js", "60%", "", "", "", "code2"]
-    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", json.dumps(raw1))
-    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", json.dumps(raw2))
+    raw1 = ["path1.py", "50%", "", "", "", "code1", "1"]
+    raw2 = ["path2.js", "60%", "", "", "", "code2", "1"]
+    mock_tree._item_values["item1"] = ("path1.py", "50%", "", "", "", "code1", "1", json.dumps(raw1))
+    mock_tree._item_values["item2"] = ("path2.js", "60%", "", "", "", "code2", "1", json.dumps(raw2))
 
     monkeypatch.setattr(os.path, 'exists', lambda p: True)
     monkeypatch.setattr(gptscan, 'get_file_sha256', lambda p: "hash_" + p)

--- a/tests/test_dry_run_feature.py
+++ b/tests/test_dry_run_feature.py
@@ -44,7 +44,7 @@ def test_dry_run_skips_model_and_yields_results(monkeypatch, tmp_path):
     assert len(results) == 2, "Should yield a result for each file"
 
     for _, data in results:
-        path, status, admin, user, gpt, snippet = data
+        path, status, admin, user, gpt, snippet, line = data
         assert status == "Dry Run"
         assert "(File would be scanned" in snippet
         # Confirm no analysis data

--- a/tests/test_exclude_ui.py
+++ b/tests/test_exclude_ui.py
@@ -40,12 +40,12 @@ def test_exclude_selected_logic(tmp_path, monkeypatch, mock_gui):
     # Mock item values
     # Item 1 has raw data in hidden column
     path1 = str(tmp_path / "bad1.py")
-    raw_data1 = [path1, "90%", "Malicious", "Dangerous", "95%", "print('evil')"]
+    raw_data1 = [path1, "90%", "Malicious", "Dangerous", "95%", "print('evil')", "1"]
 
     def mock_item(iid, option=None):
         data = {
-            "item1": {"values": ["bad1.py", "90%", "Malicious", "Dangerous", "95%", "print('evil')", json.dumps(raw_data1)]},
-            "item2": {"values": ["bad2.py", "80%", "Sus", "Bad", "", "exec('code')", ""]} # No hidden column
+            "item1": {"values": ["bad1.py", "90%", "Malicious", "Dangerous", "95%", "print('evil')", "1", json.dumps(raw_data1)]},
+            "item2": {"values": ["bad2.py", "80%", "Sus", "Bad", "", "exec('code')", "1", ""]} # No hidden column
         }
         if option == "values":
             return data[iid]["values"]
@@ -59,9 +59,9 @@ def test_exclude_selected_logic(tmp_path, monkeypatch, mock_gui):
     # Mock _all_results_cache
     path2 = "bad2.py"
     gptscan._all_results_cache = [
-        (path1, "90%", "Malicious", "Dangerous", "95%", "print('evil')"),
-        (path2, "80%", "Sus", "Bad", "", "exec('code')"),
-        ("safe.py", "5%", "", "", "", "print('hi')")
+        (path1, "90%", "Malicious", "Dangerous", "95%", "print('evil')", "1"),
+        (path2, "80%", "Sus", "Bad", "", "exec('code')", "1"),
+        ("safe.py", "5%", "", "", "", "print('hi')", "1")
     ]
 
     # Execute

--- a/tests/test_extra_snippets.py
+++ b/tests/test_extra_snippets.py
@@ -38,7 +38,7 @@ def test_scan_files_extra_snippets_basic(mock_tf_env):
     results = [data for event, data in events if event == 'result']
 
     assert len(results) == 1
-    path, own_conf, admin, user, gpt, snippet = results[0]
+    path, own_conf, admin, user, gpt, snippet, line = results[0]
     assert path == "[Clipboard]"
     assert own_conf == "50%"
     assert "print('hello world')" in snippet
@@ -110,7 +110,7 @@ def test_scan_files_extra_snippets_gpt_trigger(mock_tf_env, monkeypatch):
 
     results = [data for event, data in events if event == 'result']
     assert len(results) == 1
-    path, own, admin, user, gpt, snippet = results[0]
+    path, own, admin, user, gpt, snippet, line = results[0]
     assert path == "[Stdin]"
     assert admin == "Admin analysis"
     assert gpt == "85%"

--- a/tests/test_markdown_coverage.py
+++ b/tests/test_markdown_coverage.py
@@ -63,7 +63,7 @@ def test_generate_markdown_escaping():
 def test_run_cli_markdown(monkeypatch, capsys):
     """Test run_cli with markdown output format (covers line 1547)."""
     def mock_scan_files(*args, **kwargs):
-        yield ('result', ("test.py", "90%", "Admin", "User", "95%", "print('hi')"))
+        yield ('result', ("test.py", "90%", "Admin", "User", "95%", "print('hi')", "1"))
 
     monkeypatch.setattr(gptscan, "scan_files", mock_scan_files)
 
@@ -74,17 +74,17 @@ def test_run_cli_markdown(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "# GPT Scan Results" in captured.out
-    assert "| test.py | 95% | **Admin:** Admin<br>**User:** User | `print('hi')` |" in captured.out
+    assert "| test.py | 1 | 95% | **Admin:** Admin<br>**User:** User | `print('hi')` |" in captured.out
 
 def test_export_results_markdown(monkeypatch, tmp_path):
     """Test export_results with .md extension (covers line 1725)."""
     mock_tree = MagicMock()
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "orig_json")
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line", "orig_json")
     mock_tree.get_children.return_value = ["item1"]
 
     # Case where orig_json is present
-    raw_values = ["test.py", "90%", "Admin", "User", "95%", "print('hi')"]
-    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi')", json.dumps(raw_values))
+    raw_values = ["test.py", "90%", "Admin", "User", "95%", "print('hi')", "1"]
+    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi')", "1", json.dumps(raw_values))
     def mock_item(iid, option=None):
         if option == "values": return vals
         return {"values": vals}
@@ -106,11 +106,11 @@ def test_export_results_markdown(monkeypatch, tmp_path):
 def test_copy_as_markdown_fallback(monkeypatch):
     """Test copy_as_markdown fallback when orig_json is missing (covers lines 1817-1818)."""
     mock_tree = MagicMock()
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "orig_json")
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line", "orig_json")
     mock_tree.selection.return_value = ["item1"]
 
-    # Case where orig_json is missing or empty (6 columns only or 7th is empty)
-    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi\nwrapped')")
+    # Case where orig_json is missing or empty (7 columns only or 8th is empty)
+    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi\nwrapped')", "1")
     def mock_item(iid, option=None):
         if option == "values": return vals
         return {"values": vals}
@@ -148,10 +148,10 @@ def test_get_selected_row_values_no_tree(monkeypatch):
 def test_export_results_sarif(monkeypatch, tmp_path):
     """Test export_results with .sarif extension (covers lines 1720-1722)."""
     mock_tree = MagicMock()
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "orig_json")
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line", "orig_json")
     mock_tree.get_children.return_value = ["item1"]
 
-    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi')")
+    vals = ("test.py", "90%", "Admin", "User", "95%", "print('hi')", "1")
     def mock_item(iid, option=None):
         if option == "values": return vals
         return {"values": vals}

--- a/tests/test_raw_values_logic.py
+++ b/tests/test_raw_values_logic.py
@@ -1,0 +1,82 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+
+@pytest.fixture
+def mock_tree(monkeypatch):
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    return mock_tree
+
+def test_get_item_raw_values_from_cache(mock_tree):
+    # Mock item values with valid JSON in index 7
+    raw_data = ["path/to/file", "90%", "Admin Notes", "User Notes", "85%", "print('hello')", "10"]
+    item_values = ["path/to/file", "90%", "Admin Notes", "User Notes", "85%", "print('hello')", "10", json.dumps(raw_data)]
+
+    mock_tree.exists.return_value = True
+    # mock_tree.item(iid, "values") returns the list of values directly
+    mock_tree.item.return_value = item_values
+
+    result = gptscan._get_item_raw_values("item1")
+
+    assert result == raw_data
+    mock_tree.exists.assert_called_once_with("item1")
+    mock_tree.item.assert_called_once_with("item1", "values")
+
+def test_get_item_raw_values_fallback(mock_tree):
+    # Mock item values without cache (or too short)
+    item_values = ["path/to/file", "90%", "Admin Notes", "User Notes", "85%", "snippet\nwith\nnewline", "10"]
+
+    mock_tree.exists.return_value = True
+    mock_tree.item.return_value = item_values
+
+    result = gptscan._get_item_raw_values("item1")
+
+    # Fallback should replace newlines with spaces and take first 7 elements
+    expected = ["path/to/file", "90%", "Admin Notes", "User Notes", "85%", "snippet with newline", "10"]
+    assert result == expected
+
+def test_get_item_raw_values_invalid_cache(mock_tree):
+    # Mock item values with invalid JSON in index 7
+    item_values = ["p", "o", "a", "u", "g", "s", "l", "invalid-json"]
+
+    mock_tree.exists.return_value = True
+    mock_tree.item.return_value = item_values
+
+    result = gptscan._get_item_raw_values("item1")
+
+    # Should fallback to basic parsing
+    assert result == ["p", "o", "a", "u", "g", "s", "l"]
+
+def test_get_item_raw_values_none_tree(monkeypatch):
+    monkeypatch.setattr(gptscan, 'tree', None)
+    assert gptscan._get_item_raw_values("item1") is None
+
+def test_get_item_raw_values_item_not_exists(mock_tree):
+    mock_tree.exists.return_value = False
+    assert gptscan._get_item_raw_values("non-existent") is None
+
+def test_get_item_raw_values_empty_values(mock_tree):
+    mock_tree.exists.return_value = True
+    mock_tree.item.return_value = []
+
+    result = gptscan._get_item_raw_values("item1")
+    assert result == []
+
+def test_get_selected_row_values(mock_tree, monkeypatch):
+    raw_data = ["path", "conf"]
+    # Mock _get_item_raw_values to return our data
+    monkeypatch.setattr(gptscan, "_get_item_raw_values", lambda iid: raw_data if iid == "sel1" else None)
+
+    mock_tree.selection.return_value = ("sel1",)
+
+    assert gptscan._get_selected_row_values() == raw_data
+
+    # Test no selection
+    mock_tree.selection.return_value = ()
+    assert gptscan._get_selected_row_values() is None
+
+def test_get_selected_row_values_no_tree(monkeypatch):
+    monkeypatch.setattr(gptscan, 'tree', None)
+    assert gptscan._get_selected_row_values() is None

--- a/tests/test_risk_analysis.py
+++ b/tests/test_risk_analysis.py
@@ -42,38 +42,38 @@ def test_get_effective_confidence(own, gpt, expected):
 
 def test_prepare_tree_row(monkeypatch):
     mock_tree = MagicMock()
-    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin", "user", "gpt_conf", "snippet")
+    mock_tree.__getitem__.return_value = ("path", "own_conf", "admin", "user", "gpt_conf", "snippet", "line")
     mock_tree.column.return_value = {'width': 100}
     monkeypatch.setattr("gptscan.tree", mock_tree)
     monkeypatch.setattr(Config, "THRESHOLD", 50)
     monkeypatch.setattr("gptscan.default_font_measure", lambda x: 10)
 
     # Test High Risk
-    values = ("high.py", "90%", "Admin Notes", "User Notes", "85%", "Snippet")
+    values = ("high.py", "90%", "Admin Notes", "User Notes", "85%", "Snippet", 10)
     wrapped, tags = _prepare_tree_row(values)
 
     assert tags == ('high-risk',)
     assert wrapped[0] == "high.py"
     assert wrapped[4] == "85%"
-    # 7th column should be raw JSON of first 6 columns
-    assert json.loads(wrapped[6]) == list(values)
+    # 8th column (index 7) should be raw JSON of first 7 elements
+    assert json.loads(wrapped[7]) == list(values)
 
     # Test Medium Risk
-    values = ("medium.py", "60%", "Admin", "User", "", "Snippet")
+    values = ("medium.py", "60%", "Admin", "User", "", "Snippet", 1)
     wrapped, tags = _prepare_tree_row(values)
     assert tags == ('medium-risk',)
 
     # Test Safe
-    values = ("safe.py", "10%", "", "", "", "Snippet")
+    values = ("safe.py", "10%", "", "", "", "Snippet", 1)
     wrapped, tags = _prepare_tree_row(values)
     assert tags == ()
 
     # Test boundary 80%
-    values = ("boundary.py", "80%", "", "", "", "Snippet")
+    values = ("boundary.py", "80%", "", "", "", "Snippet", 1)
     wrapped, tags = _prepare_tree_row(values)
     assert tags == ('high-risk',)
 
     # Test boundary Threshold
-    values = ("threshold.py", "50%", "", "", "", "Snippet")
+    values = ("threshold.py", "50%", "", "", "", "Snippet", 1)
     wrapped, tags = _prepare_tree_row(values)
     assert tags == ('medium-risk',)

--- a/tests/test_scan_gpt_integration_extended.py
+++ b/tests/test_scan_gpt_integration_extended.py
@@ -55,12 +55,12 @@ def test_scan_files_gpt_processing_flow(mock_gpt_env, monkeypatch):
     assert len(gpt_results) == 2
 
     res1 = next(r for r in gpt_results if "test1.py" in r[0])
-    path1, own1, admin1, user1, gpt1, snip1 = res1
+    path1, own1, admin1, user1, gpt1, snip1, line1 = res1
     assert admin1 == "Admin Hello"
     assert gpt1 == "90%"
 
     res2 = next(r for r in gpt_results if "test2.py" in r[0])
-    path2, own2, admin2, user2, gpt2, snip2 = res2
+    path2, own2, admin2, user2, gpt2, snip2, line2 = res2
     assert admin2 == "JSON Parse Error"
     assert gpt2 == "JSON Parse Error"
 

--- a/tests/test_scan_logic.py
+++ b/tests/test_scan_logic.py
@@ -122,7 +122,7 @@ def test_scan_files_metadata_error(monkeypatch, tmp_path, mock_scan_dependencies
     event_type, event_data = results[2]
     assert event_type == 'result'
 
-    path, own_conf, admin, user, gpt, snippet = event_data
+    path, own_conf, admin, user, gpt, snippet, line = event_data
     assert path == "/path/to/bad_file.bin"
     assert own_conf == 'Error'
     assert "Metadata inaccessible" in snippet


### PR DESCRIPTION
This PR addresses a functional bug in result retrieval and fills a critical test coverage gap.

### Changes:
- **Bug Fix:** Updated `gptscan.py`: `_get_item_raw_values` now correctly uses index 7 to retrieve the raw data cache from the hidden `orig_json` column.
- **New Test Coverage:** Created `tests/test_raw_values_logic.py` which validates:
    - Successful extraction of raw data from the JSON cache.
    - Robust fallback to display value parsing (with newline-to-space conversion) when the cache is missing or invalid.
    - Edge cases for non-existent items and missing UI components.
- **Test Suite Synchronization:** Updated 10 existing test files to match the current data schema. These tests were previously failing due to unpacking errors (expecting 6 elements instead of 7) or column index mismatches.

All relevant tests (92 items across the impacted modules) are now passing.

---
*PR created automatically by Jules for task [11746772349958735255](https://jules.google.com/task/11746772349958735255) started by @RainRat*