### PR TITLE
[UI/UX] Streamline Search-and-Navigate Keyboard Workflow

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2951,6 +2951,27 @@ def on_root_return(event: Optional[tk.Event] = None) -> None:
         button_click()
 
 
+def focus_filter(event: Optional[tk.Event] = None) -> str:
+    """Set focus to the filter entry and select all text for easy replacement."""
+    if filter_entry:
+        filter_entry.focus_set()
+        filter_entry.selection_range(0, tk.END)
+    return "break"
+
+
+def on_filter_return(event: Optional[tk.Event] = None) -> str:
+    """Move focus from the filter entry to the results tree."""
+    if tree:
+        tree.focus_set()
+        # If nothing is selected, select the first item to allow immediate keyboard navigation
+        if not tree.selection() and tree.get_children():
+            first_item = tree.get_children()[0]
+            tree.selection_set(first_item)
+            tree.focus(first_item)
+            tree.see(first_item)
+    return "break"
+
+
 def select_all_items(event: Optional[tk.Event] = None) -> str:
     """Select all items currently visible in the Results Treeview."""
     if tree:
@@ -2994,7 +3015,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, gpt_var, dry_var, git_var, filter_var, tree, scan_button, cancel_button, view_button, rescan_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, default_font_measure
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3177,6 +3198,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     filter_entry = ttk.Entry(filter_frame, textvariable=filter_var)
     filter_entry.grid(row=0, column=1, sticky="ew")
     filter_entry.bind('<KeyRelease>', _apply_filter)
+    filter_entry.bind('<Return>', on_filter_return)
     bind_hover_message(filter_entry, "Search results by any column (path, confidence, analysis, snippet).")
 
     def clear_filter():
@@ -3319,8 +3341,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     # Bind selection and rescan keys
     root.bind('<Return>', on_root_return)
-    root.bind('<Control-f>', lambda e: filter_entry.focus_set())
-    root.bind('<Command-f>', lambda e: filter_entry.focus_set())
+    root.bind('<Control-f>', focus_filter)
+    root.bind('<Command-f>', focus_filter)
     root.bind('<Control-j>', copy_as_json)
     root.bind('<Command-j>', copy_as_json)
     tree.bind('<<TreeviewSelect>>', update_button_states)

--- a/tests/test_filter_navigation.py
+++ b/tests/test_filter_navigation.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import tkinter as tk
+
+@pytest.fixture
+def mock_ui_env(monkeypatch):
+    mock_tree = MagicMock()
+    mock_filter_entry = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'filter_entry', mock_filter_entry)
+
+    return {
+        'tree': mock_tree,
+        'filter_entry': mock_filter_entry
+    }
+
+def test_focus_filter_sets_focus_and_selects_all(mock_ui_env):
+    """Test that focus_filter sets focus to filter_entry and selects all text."""
+    res = gptscan.focus_filter()
+
+    mock_ui_env['filter_entry'].focus_set.assert_called_once()
+    mock_ui_env['filter_entry'].selection_range.assert_called_once_with(0, tk.END)
+    assert res == "break"
+
+def test_focus_filter_handles_none_entry(monkeypatch):
+    """Test focus_filter doesn't crash if filter_entry is None."""
+    monkeypatch.setattr(gptscan, 'filter_entry', None)
+    res = gptscan.focus_filter()
+    assert res == "break"
+
+def test_on_filter_return_transitions_to_tree(mock_ui_env):
+    """Test that on_filter_return sets focus to the tree."""
+    mock_ui_env['tree'].selection.return_value = ("item1",) # Something already selected
+
+    res = gptscan.on_filter_return()
+
+    mock_ui_env['tree'].focus_set.assert_called_once()
+    # Should NOT select first item if something is already selected
+    mock_ui_env['tree'].selection_set.assert_not_called()
+    assert res == "break"
+
+def test_on_filter_return_selects_first_item_if_none_selected(mock_ui_env):
+    """Test that on_filter_return selects the first item if tree selection is empty."""
+    mock_ui_env['tree'].selection.return_value = ()
+    mock_ui_env['tree'].get_children.return_value = ("item1", "item2")
+
+    res = gptscan.on_filter_return()
+
+    mock_ui_env['tree'].focus_set.assert_called_once()
+    mock_ui_env['tree'].selection_set.assert_called_with("item1")
+    mock_ui_env['tree'].focus.assert_called_with("item1")
+    mock_ui_env['tree'].see.assert_called_with("item1")
+    assert res == "break"
+
+def test_on_filter_return_handles_empty_tree(mock_ui_env):
+    """Test on_filter_return transitions focus even if tree is empty."""
+    mock_ui_env['tree'].selection.return_value = ()
+    mock_ui_env['tree'].get_children.return_value = ()
+
+    res = gptscan.on_filter_return()
+
+    mock_ui_env['tree'].focus_set.assert_called_once()
+    mock_ui_env['tree'].selection_set.assert_not_called()
+    assert res == "break"
+
+def test_on_filter_return_handles_none_tree(monkeypatch):
+    """Test on_filter_return doesn't crash if tree is None."""
+    monkeypatch.setattr(gptscan, 'tree', None)
+    res = gptscan.on_filter_return()
+    assert res == "break"


### PR DESCRIPTION
Improved keyboard navigation by streamlining the transition from filtering results to browsing them. `Ctrl+F` now handles text selection for faster search replacement, and `Enter` allows users to immediately jump into the result list with focus and selection, enabling a seamless keyboard-only experience. Fixes critical scoping and event propagation issues identified during code review.

---
*PR created automatically by Jules for task [1629714580254683806](https://jules.google.com/task/1629714580254683806) started by @RainRat*