### PR TITLE
Fix logic bugs in text wrapping and scan cancellation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -559,19 +559,24 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
 
     measure = measure or tkinter.font.Font(font='TkDefaultFont').measure
     words = val.split()
-    lines: List[Union[str, List[str]]] = [[]]
+    if not words:
+        return val
+
+    lines: List[List[str]] = [[]]
     for word in words:
-        line = lines[-1] + [word]
-        if not lines[-1] or measure(' '.join(line)) < (width - pad):
-            lines[-1].append(word)
+        current_line = lines[-1]
+        if not current_line:
+            current_line.append(word)
         else:
-            lines[-1] = ' '.join(lines[-1])
-            lines.append([word])
+            # Check if adding this word would exceed the width
+            test_line = ' '.join(current_line + [word])
+            if measure(test_line) < (width - pad):
+                current_line.append(word)
+            else:
+                # Start a new line
+                lines.append([word])
 
-    if isinstance(lines[-1], list):
-        lines[-1] = ' '.join(lines[-1])
-
-    return '\n'.join(lines)
+    return '\n'.join([' '.join(line) for line in lines])
 
 
 def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optional[Callable[[str], int]] = None, col_widths: Optional[List[int]] = None) -> List[Any]:
@@ -1636,10 +1641,8 @@ def _consume_scan_events(
                 metrics['elapsed_time'] = elapsed_time
     finally:
         if cancel_event.is_set():
-            enqueue_ui_update(set_scanning_state, False)
+            enqueue_ui_update(finish_scan_state)
             enqueue_ui_update(update_status, f"Scan cancelled after {current_scanned} files.")
-            enqueue_ui_update(update_tree_columns)
-            enqueue_ui_update(_auto_select_best_result)
         else:
             enqueue_ui_update(
                 finish_scan_state,

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -64,8 +64,8 @@ def test_run_scan_cancellation(monkeypatch):
 
     enqueued_funcs = [call[0][0] for call in mock_enqueue.call_args_list]
     assert gptscan.insert_tree_row not in enqueued_funcs
-    # In the new code, finish_scan_state is skipped on cancellation
-    assert gptscan.finish_scan_state not in enqueued_funcs
+    # finish_scan_state should be called even on cancellation to reset state
+    assert gptscan.finish_scan_state in enqueued_funcs
     # Instead, update_status should be called with "Scan cancelled..."
     assert gptscan.update_status in enqueued_funcs
     


### PR DESCRIPTION
This PR resolves two specific logic bugs in `gptscan.py`:

1.  **Text Wrapping Bug:** The `adjust_newlines` function had a logic flaw where it could attempt to concatenate a list to a string in its second iteration of wrapping, leading to a `TypeError`. The implementation was refactored to use a clean `List[List[str]]` structure, improving both robustness and readability.
2.  **Scan Cancellation Bug:** When a scan was cancelled by the user, the global `current_cancel_event` was not being reset to `None`. This prevented any subsequent scans from being started without restarting the application. The fix ensures `finish_scan_state` is called even on the cancellation path, correctly resetting the application's scanning state.

The unit test suite has been updated to reflect these improvements, specifically `test_run_scan_cancellation`. All relevant tests passed.

---
*PR created automatically by Jules for task [327622931878285627](https://jules.google.com/task/327622931878285627) started by @RainRat*