### PR TITLE
[TEST] Add import_results_generator coverage and fix test regressions

### DIFF
--- a/tests/test_filter_navigation.py
+++ b/tests/test_filter_navigation.py
@@ -21,7 +21,8 @@ def test_focus_filter_sets_focus_and_selects_all(mock_ui_env):
     res = gptscan.focus_filter()
 
     mock_ui_env['filter_entry'].focus_set.assert_called_once()
-    mock_ui_env['filter_entry'].selection_range.assert_called_once_with(0, tk.END)
+    # tk.END is mocked to "end" in conftest.py
+    mock_ui_env['filter_entry'].selection_range.assert_called_once_with(0, "end")
     assert res == "break"
 
 def test_focus_filter_handles_none_entry(monkeypatch):

--- a/tests/test_import_generator.py
+++ b/tests/test_import_generator.py
@@ -1,0 +1,122 @@
+import pytest
+import json
+import os
+from gptscan import import_results_generator
+
+@pytest.fixture
+def temp_json_report(tmp_path):
+    report_file = tmp_path / "report.json"
+    data = [
+        {
+            "path": "test.py",
+            "own_conf": "80%",
+            "admin_desc": "Suspicious",
+            "end-user_desc": "Warning",
+            "gpt_conf": "85%",
+            "snippet": "dangerous_code()",
+            "line": "10"
+        }
+    ]
+    report_file.write_text(json.dumps(data))
+    return str(report_file)
+
+def test_import_generator_sarif(temp_sarif_report):
+    """Test import_results_generator with a SARIF report."""
+    events = list(import_results_generator(temp_sarif_report))
+
+    # Verify result event mapping
+    # 0: progress (loading)
+    # 1: progress (item)
+    # 2: result
+    # 3: summary
+    result_event = events[2]
+    assert result_event[0] == 'result'
+    data = result_event[1]
+    assert data[0] == "malicious.py"
+    assert data[1] == "95%"
+    assert data[2] == "Detected threat"
+    assert data[4] == "99%"
+    assert data[5] == "os.system('rm -rf /')"
+    assert data[6] == "42"
+
+def test_import_generator_empty_file(tmp_path):
+    """Test import_results_generator with an empty file."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("")
+    events = list(import_results_generator(str(empty_file)))
+
+    # Should yield a progress event with an error message
+    assert events[0][0] == 'progress'
+    assert "Error" in events[0][1][2]
+
+def test_import_generator_invalid_format(tmp_path):
+    """Test import_results_generator with an invalid JSON file."""
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{invalid: json}")
+    events = list(import_results_generator(str(bad_file)))
+
+    assert events[0][0] == 'progress'
+    assert "Error" in events[0][1][2]
+
+def test_import_generator_non_existent_file():
+    """Test import_results_generator with a non-existent file."""
+    events = list(import_results_generator("non_existent.json"))
+
+    assert events[0][0] == 'progress'
+    assert "Error" in events[0][1][2]
+
+def test_import_generator_json(temp_json_report):
+    """Test import_results_generator with a standard JSON report."""
+    events = list(import_results_generator(temp_json_report))
+
+    # Verify progress events
+    assert events[0][0] == 'progress'
+    assert events[1][0] == 'progress'
+
+    # Verify result event
+    result_event = events[2]
+    assert result_event[0] == 'result'
+    data = result_event[1]
+    assert data[0] == "test.py"
+    assert data[1] == "80%"
+    assert data[2] == "Suspicious"
+    assert data[3] == "Warning"
+    assert data[4] == "85%"
+    assert data[5] == "dangerous_code()"
+    assert data[6] == "10"
+
+    # Verify summary event
+    summary_event = events[3]
+    assert summary_event[0] == 'summary'
+    assert summary_event[1][0] == 1  # Total results
+
+@pytest.fixture
+def temp_sarif_report(tmp_path):
+    report_file = tmp_path / "report.sarif"
+    data = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "results": [
+                    {
+                        "message": {"text": "Detected threat"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "malicious.py"},
+                                    "region": {"startLine": 42}
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "own_conf": "95%",
+                            "gpt_conf": "99%",
+                            "snippet": "os.system('rm -rf /')"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    report_file.write_text(json.dumps(data))
+    return str(report_file)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -78,7 +78,7 @@ def test_dataloader_load_file_padding(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -95,7 +95,7 @@ def test_dataloader_load_file_truncation(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -115,7 +115,7 @@ def test_dataloader_load_dataset(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=2.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -139,7 +139,7 @@ def test_dataloader_load_prediction_files(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -160,7 +160,7 @@ def test_model_builder_mappings():
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -189,7 +189,7 @@ def test_model_builder_build_model():
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -212,7 +212,7 @@ def test_model_builder_too_large(capsys):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=10,
         pad_value=0
     )
@@ -227,7 +227,7 @@ def test_model_builder_print_architecture(capsys):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -257,8 +257,7 @@ def test_load_config(tmp_path):
             'threshold': 0.5
         },
         'weights': {
-            'positive_sample_weight': 2.0,
-            'positive_class_weight': 1.0
+            'positive_sample_weight': 2.0
         },
         'hyperparameters': {
             'embedding_scale': 0.5, 'rnn_scale': 0.5, 'pooling_type': 0.5,
@@ -282,7 +281,7 @@ def test_trainer_save_load_hp(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     trainer = Trainer(config)
@@ -306,7 +305,7 @@ def test_predictor_predict(mock_load_model, tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="predict", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
 
@@ -330,7 +329,7 @@ def test_predictor_predict_below_threshold(mock_load_model, tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="predict", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
 


### PR DESCRIPTION
This PR increases test coverage for the `gptscan.py` CLI import feature and resolves regressions in the existing test suite.

### Changes:
1. **New Tests:** Added `tests/test_import_generator.py` which targets the `import_results_generator` function. This covers:
    - Successful parsing of standard JSON reports.
    - Successful parsing of SARIF format reports.
    - Error handling for empty files, invalid formats, and non-existent files.
2. **Test Fixes:**
    - Updated `tests/test_train.py` to match the `ModelConfig` dataclass in `train.py`. The tests previously expected a `positive_class_weight` parameter that does not exist in the source code, causing them to fail.
    - Adjusted `tests/test_filter_navigation.py` to use the mocked `"end"` string instead of `tk.END` (which is mocked as a MagicMock in some contexts but as `"end"` in `conftest.py`), ensuring reliable assertions.

All 352 tests in the repository now pass successfully.

---
*PR created automatically by Jules for task [17163277498007488962](https://jules.google.com/task/17163277498007488962) started by @RainRat*