### PR TITLE
[DOCS] Add OPENROUTER_API_KEY to README setup instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ Follow these steps to get the scanner running:
     pip install "tensorflow<2.16" openai
     ```
     *Linux users:* You may also need to install Tkinter (for example: `sudo apt-get install python3-tk`).
-    *   **OpenAI/OpenRouter:** Create a file named `apikey.txt` and paste your API key on the first line. Alternatively, set the `OPENAI_API_KEY` environment variable.
+    *   **OpenAI/OpenRouter:** Create a file named `apikey.txt` and paste your API key on the first line. Alternatively, set the `OPENAI_API_KEY` or `OPENROUTER_API_KEY` environment variable.
     *   **Ollama:** Download [Ollama](https://ollama.com/) and run it locally. Pull a model before starting (e.g., `ollama pull llama3.2`).
 
 *Privacy Note:* Your code is only sent to an AI service if you enable "Use AI Analysis."


### PR DESCRIPTION
This documentation improvement updates the `readme.md` file to include `OPENROUTER_API_KEY` in the API key setup instructions. 

Previously, only `OPENAI_API_KEY` was mentioned as an environment variable alternative to the `apikey.txt` file. Since the tool also supports OpenRouter, explicitly documenting the `OPENROUTER_API_KEY` variable makes the setup process clearer for users choosing that provider.

The change follows the Plain English style guidelines:
- **Simplicity:** Uses short, direct sentences.
- **Truth First:** Matches the actual code implementation in `gptscan.py`.
- **Casual but Professional:** Maintains a helpful, professional tone.

---
*PR created automatically by Jules for task [14245191842512971758](https://jules.google.com/task/14245191842512971758) started by @RainRat*