### PR TITLE
[UI/UX] [GUI] Add 'Exclude' button and improve selection flow during results review

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -42,6 +42,10 @@ scan_button: Optional[ttk.Button] = None
 cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
+exclude_button: Optional[ttk.Button] = None
+import_button: Optional[ttk.Button] = None
+export_button: Optional[ttk.Button] = None
+clear_button: Optional[ttk.Button] = None
 context_menu: Optional[tk.Menu] = None
 _all_results_cache: List[Tuple[Any, ...]] = []
 _last_scan_summary: str = ""
@@ -969,9 +973,18 @@ def set_scanning_state(is_scanning: bool) -> None:
         scan_button.config(state="disabled" if is_scanning else "normal")
         cancel_button.config(state="normal" if is_scanning else "disabled")
 
-    if view_button and rescan_button:
-        view_button.config(state="disabled" if is_scanning else "normal")
-        rescan_button.config(state="disabled" if is_scanning else "normal")
+    # Disable all footer buttons during a scan
+    footer_buttons = [
+        view_button, rescan_button, exclude_button,
+        import_button, export_button, clear_button
+    ]
+    for btn in footer_buttons:
+        if btn:
+            btn.config(state="disabled" if is_scanning else "normal")
+
+    if not is_scanning:
+        # Re-evaluate selection-dependent buttons when scan ends
+        update_button_states()
 
 
 def finish_scan_state(total_scanned: Optional[int] = None, threats_found: Optional[int] = None, total_bytes: Optional[int] = None, elapsed_time: Optional[float] = None, high_risk: int = 0, medium_risk: int = 0) -> None:
@@ -1207,13 +1220,28 @@ def exclude_selected() -> None:
     if not selection:
         return
 
+    # Capture current list and index to handle transition correctly
+    all_visible = list(tree.get_children())
+    try:
+        current_idx = all_visible.index(selection[0])
+    except (ValueError, IndexError):
+        current_idx = -1
+
     excluded_paths = []
     for item_id in selection:
         values = _get_item_raw_values(item_id)
         if values:
             excluded_paths.append(values[0])
 
-    exclude_paths(excluded_paths, confirm=True)
+    if exclude_paths(excluded_paths, confirm=True):
+        # After exclusion, list changes. Select the next item at the same index.
+        new_visible = list(tree.get_children())
+        if new_visible and current_idx != -1:
+            new_idx = min(current_idx, len(new_visible) - 1)
+            new_item_id = new_visible[new_idx]
+            tree.selection_set(new_item_id)
+            tree.focus(new_item_id)
+            tree.see(new_item_id)
 
 
 def iter_windows(fh, size: int, deep_scan: bool, maxlen: Optional[int] = None) -> Generator[Tuple[int, bytes], None, None]:
@@ -3003,12 +3031,16 @@ def show_context_menu(event: tk.Event) -> None:
 
 def update_button_states(event: Optional[tk.Event] = None) -> None:
     """Enable or disable selection-dependent buttons."""
-    if not tree or not view_button or not rescan_button:
+    if not tree:
         return
 
     has_selection = bool(tree.selection())
-    view_button.config(state="normal" if has_selection else "disabled")
-    rescan_button.config(state="normal" if has_selection else "disabled")
+
+    # Buttons that depend on having one or more items selected
+    dependent_buttons = [view_button, rescan_button, exclude_button]
+    for btn in dependent_buttons:
+        if btn:
+            btn.config(state="normal" if has_selection else "disabled")
 
 
 def on_root_return(event: Optional[tk.Event] = None) -> None:
@@ -3085,7 +3117,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, exclude_button, import_button, export_button, clear_button, default_font_measure
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3372,16 +3404,22 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     rescan_button.grid(row=0, column=2, padx=2)
     bind_hover_message(rescan_button, "Re-scan the currently selected items.")
 
+    exclude_button = ttk.Button(footer_frame, text="Exclude Selected", command=exclude_selected)
+    exclude_button.grid(row=0, column=3, padx=2)
+    bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
+
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=4, sticky="ns", padx=5)
+
     import_button = ttk.Button(footer_frame, text="Import Results...", command=import_results)
-    import_button.grid(row=0, column=3, padx=2)
+    import_button.grid(row=0, column=5, padx=2)
     bind_hover_message(import_button, "Load results from a JSON or CSV file.")
 
     export_button = ttk.Button(footer_frame, text="Export Results...", command=export_results)
-    export_button.grid(row=0, column=4, padx=2)
+    export_button.grid(row=0, column=6, padx=2)
     bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
 
     clear_button = ttk.Button(footer_frame, text="Clear Results", command=clear_results)
-    clear_button.grid(row=0, column=5, padx=(2, 0))
+    clear_button.grid(row=0, column=7, padx=(2, 0))
     bind_hover_message(clear_button, "Clear all results from the list.")
 
     # --- Context Menu ---

--- a/tests/test_exclude_ui_ux.py
+++ b/tests/test_exclude_ui_ux.py
@@ -1,0 +1,78 @@
+import json
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+@pytest.fixture
+def mock_gui(monkeypatch):
+    """Mock GUI globals and relevant methods."""
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree)
+
+    # Mock exclude_paths to return True (success)
+    monkeypatch.setattr("gptscan.exclude_paths", MagicMock(return_value=True))
+
+    return {"tree": mock_tree}
+
+def test_exclude_selected_advances_selection(mock_gui):
+    """Verify that exclude_selected advances selection to the next item."""
+    # initial items: item1, item2, item3
+    # user selects item2 and excludes it
+    # expected: item3 is selected
+
+    initial_items = ["item1", "item2", "item3"]
+    mock_gui["tree"].get_children.side_effect = [
+        initial_items,            # Before exclusion
+        ["item1", "item3"]        # After exclusion
+    ]
+    mock_gui["tree"].selection.return_value = ["item2"]
+
+    # Mock item values to satisfy exclude_selected's data gathering
+    def mock_item(iid, option=None):
+        return {"values": [f"{iid}.py", "10%", "", "", "", "print('hi')", "1", ""]}
+    mock_gui["tree"].item.side_effect = mock_item
+
+    gptscan.exclude_selected()
+
+    # Verify new selection is item3 (which was at index 2, now at index 1)
+    mock_gui["tree"].selection_set.assert_called_with("item3")
+    mock_gui["tree"].focus.assert_called_with("item3")
+    mock_gui["tree"].see.assert_called_with("item3")
+
+def test_exclude_selected_handles_last_item(mock_gui):
+    """Verify that exclude_selected selects the new last item if the end is reached."""
+    # initial items: item1, item2
+    # user selects item2 and excludes it
+    # expected: item1 is selected
+
+    initial_items = ["item1", "item2"]
+    mock_gui["tree"].get_children.side_effect = [
+        initial_items,     # Before exclusion
+        ["item1"]          # After exclusion
+    ]
+    mock_gui["tree"].selection.return_value = ["item2"]
+
+    # Mock item values
+    mock_gui["tree"].item.return_value = {"values": ["item2.py", "10%", "", "", "", "", "1", ""]}
+
+    gptscan.exclude_selected()
+
+    # Index of item2 was 1. New list has length 1. min(1, 1-1) = 0.
+    # item1 (index 0) should be selected.
+    mock_gui["tree"].selection_set.assert_called_with("item1")
+
+def test_exclude_selected_handles_empty_result(mock_gui):
+    """Verify that exclude_selected handles the case where no items remain."""
+    initial_items = ["item1"]
+    mock_gui["tree"].get_children.side_effect = [
+        initial_items,     # Before
+        []                 # After
+    ]
+    mock_gui["tree"].selection.return_value = ["item1"]
+    mock_gui["tree"].item.return_value = {"values": ["item1.py", "10%", "", "", "", "", "1", ""]}
+
+    # Should not crash
+    gptscan.exclude_selected()
+
+    # selection_set should not be called if list is empty
+    mock_gui["tree"].selection_set.assert_not_called()

--- a/tests/test_filter_navigation.py
+++ b/tests/test_filter_navigation.py
@@ -21,7 +21,8 @@ def test_focus_filter_sets_focus_and_selects_all(mock_ui_env):
     res = gptscan.focus_filter()
 
     mock_ui_env['filter_entry'].focus_set.assert_called_once()
-    mock_ui_env['filter_entry'].selection_range.assert_called_once_with(0, tk.END)
+    # The mocked tk.END value is "end" (see tests/conftest.py)
+    mock_ui_env['filter_entry'].selection_range.assert_called_once_with(0, "end")
     assert res == "break"
 
 def test_focus_filter_handles_none_entry(monkeypatch):

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -78,7 +78,7 @@ def test_dataloader_load_file_padding(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -95,7 +95,7 @@ def test_dataloader_load_file_truncation(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -115,7 +115,7 @@ def test_dataloader_load_dataset(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=2.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -139,7 +139,7 @@ def test_dataloader_load_prediction_files(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     loader = DataLoader(config)
@@ -160,7 +160,7 @@ def test_model_builder_mappings():
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -189,7 +189,7 @@ def test_model_builder_build_model():
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -212,7 +212,7 @@ def test_model_builder_too_large(capsys):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=10,
         pad_value=0
     )
@@ -227,7 +227,7 @@ def test_model_builder_print_architecture(capsys):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     builder = ModelBuilder(config)
@@ -282,7 +282,7 @@ def test_trainer_save_load_hp(tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="train", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
     trainer = Trainer(config)
@@ -306,7 +306,7 @@ def test_predictor_predict(mock_load_model, tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="predict", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
 
@@ -330,7 +330,7 @@ def test_predictor_predict_below_threshold(mock_load_model, tmp_path):
     config = ModelConfig(
         model_name="test", max_length=10, batch_size=32, epochs=1,
         mode="predict", predict_threshold=0.5, positive_sample_weight=1.0,
-        positive_class_weight=1.0, validation_split=0.2, patience=3,
+        validation_split=0.2, patience=3,
         max_params=1000000, pad_value=0
     )
 


### PR DESCRIPTION
### [UI/UX] [GUI] Add 'Exclude' button and improve selection flow during results review

#### Context
This PR improves the GUI user experience, specifically focusing on the **results review workflow**.

#### Problem
Previously, when a user identified a result as a false positive and wanted to "Exclude" it, they had to use a context menu or the Delete key. This action would clear the current selection and focus, forcing the user to manually find and select the next item to continue their review. Furthermore, the lack of a dedicated button in the footer made the "Exclude" feature less discoverable compared to "View Details" or "Rescan".

#### Solution
1.  **Added 'Exclude Selected' Button:** A new button is now available in the results footer, providing immediate access to the exclusion feature.
2.  **Selection-Advance Logic:** Refactored the exclusion handler to capture the current selection index and automatically select/focus the next available item in the refreshed list. This allows for rapid, sequential triage of findings.
3.  **Improved Visual Hierarchy:** Reorganized the footer buttons into logical groups (Selection-based vs. Global) separated by a vertical divider.
4.  **UI Consistency:** Updated scanning state management to ensure all results-related buttons are consistently disabled during active scans.
5.  **Test Stability:** Fixed pre-existing test bugs in `tests/test_filter_navigation.py` (mocked constant mismatch) and `tests/test_train.py` (obsolete parameter usage) to ensure a 100% pass rate for the suite.

#### Changes
- **gptscan.py**: Added global button variables, updated `create_gui`, `exclude_selected`, `set_scanning_state`, and `update_button_states`.
- **tests/test_filter_navigation.py**: Fixed mock expectation for `tk.END`.
- **tests/test_train.py**: Removed unsupported `positive_class_weight` from `ModelConfig` tests.
- **tests/test_exclude_ui_ux.py**: New tests for the improved exclusion workflow.

---
*PR created automatically by Jules for task [12024893092064244846](https://jules.google.com/task/12024893092064244846) started by @RainRat*