### PR TITLE
Fix Git path scoping bug in get_git_changed_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -611,48 +611,45 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
 
 def get_git_changed_files(path: str = ".") -> List[str]:
     """Get a list of changed files (staged, unstaged, untracked) from git."""
-    files = set()
+    abs_path = os.path.abspath(path)
+    search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
-    # Ensure we have a directory for cwd
-    if os.path.isfile(path):
-        cwd = os.path.abspath(os.path.dirname(path)) or "."
-        # If we are looking at a specific file, we only care about that file
-        targets = [os.path.basename(path)]
-    else:
-        cwd = os.path.abspath(path)
-        targets = []
-
-    # Check if we are in a git repository and get the root directory
     try:
         toplevel = subprocess.check_output(
             ["git", "rev-parse", "--show-toplevel"],
-            cwd=cwd,
+            cwd=search_dir,
             stderr=subprocess.PIPE,
             universal_newlines=True
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return []
 
+    try:
+        rel_target = os.path.relpath(abs_path, toplevel)
+        targets = [rel_target]
+    except ValueError:
+        return []
+
+    files = set()
     # Changed (staged and unstaged) relative to HEAD
     try:
         cmd = ["git", "diff", "--name-only", "HEAD", "--"] + targets
         output = subprocess.check_output(
             cmd,
-            cwd=cwd,
+            cwd=toplevel,
             stderr=subprocess.PIPE,
             universal_newlines=True
         )
         files.update(line.strip() for line in output.splitlines() if line.strip())
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        # HEAD might not exist (new repo)
         pass
 
     # Untracked files
     try:
-        cmd = ["git", "ls-files", "--others", "--exclude-standard", "--full-name", "--"] + targets
+        cmd = ["git", "ls-files", "--others", "--exclude-standard", "--"] + targets
         output = subprocess.check_output(
             cmd,
-            cwd=cwd,
+            cwd=toplevel,
             stderr=subprocess.PIPE,
             universal_newlines=True
         )

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -80,7 +80,8 @@ def test_path_argument_passed():
     """Test that the path argument is correctly passed to git command cwd."""
     with patch("subprocess.check_output") as mock_check_output, \
          patch("os.path.exists") as mock_exists:
-        mock_check_output.side_effect = ["", "changed.py", ""]
+        # First call is rev-parse to get toplevel
+        mock_check_output.side_effect = ["/some", "changed.py", ""]
         mock_exists.return_value = True
 
         target_dir = os.path.abspath("/some/path")
@@ -88,9 +89,11 @@ def test_path_argument_passed():
         with patch("os.path.exists", return_value=True):
             files = get_git_changed_files(target_dir)
 
-        # Verify cwd was set correctly in all calls (rev-parse, diff, ls-files)
-        for call in mock_check_output.call_args_list:
-            assert call[1]["cwd"] == target_dir
+        # First call is rev-parse, cwd should be search_dir (target_dir)
+        assert mock_check_output.call_args_list[0][1]["cwd"] == target_dir
+        # Subsequent calls (diff, ls-files) should have cwd as toplevel ("/some")
+        assert mock_check_output.call_args_list[1][1]["cwd"] == "/some"
+        assert mock_check_output.call_args_list[2][1]["cwd"] == "/some"
 
 def test_git_commands_use_relative_flag():
     """Verify that git commands are called correctly."""


### PR DESCRIPTION
### What:
Refactored the `get_git_changed_files` function in `gptscan.py` to correctly resolve the Git repository root using `git rev-parse --show-toplevel`. The function now calculates the relative path from the repository root to the search target and executes Git commands (`diff`, `ls-files`) from the root directory using this relative path.

### Why:
The original implementation had a logic bug where scanning a subdirectory within a Git repository would return all changes in the entire repository, regardless of the target. Additionally, targeting a specific file in a subdirectory could result in incorrect absolute paths if the working directory wasn't managed properly. This fix ensures that Git scans are correctly scoped to the user-specified path and that returned paths are robustly resolved to their absolute form.

### Safety:
This is a non-breaking logic fix. The external behavior (returning a list of absolute paths for changed files) remains consistent but is now correct for subdirectory targets. The existing unit test suite in `tests/test_git_integration.py` has been updated to verify these improvements.

---
*PR created automatically by Jules for task [10729488016739505982](https://jules.google.com/task/10729488016739505982) started by @RainRat*