### PR TITLE
[DOCS] Align training documentation with implementation and fix CLI examples

### DIFF
--- a/train.md
+++ b/train.md
@@ -47,7 +47,6 @@ prediction:
 
 weights:
   positive_sample_weight: 1.0 # Importance of malicious examples during training
-  positive_class_weight: 1.0  # Weight applied to malicious files
 
 # AI settings for the automatic optimization process.
 # These values (0.0 to 1.0) control how the model is built.

--- a/train.py
+++ b/train.py
@@ -509,16 +509,16 @@ def parse_args():
         epilog="""
 Examples:
   # Train with config file
-  python script.py --config config.yml --mode train
+  python train.py --config config.yml --mode train
   
   # Predict with config file
-  python script.py --config config.yml --mode predict
+  python train.py --config config.yml --mode predict
   
   # Override model name
-  python script.py --config config.yml --model-name my_model
+  python train.py --config config.yml --model-name my_model
   
   # Use custom data directories
-  python script.py --config config.yml --positive-dir data/malicious --negative-dir data/safe
+  python train.py --config config.yml --positive-dir data/malicious --negative-dir data/safe
         """
     )
     


### PR DESCRIPTION
This PR improves the accuracy of the training documentation and internal help text.

**Changes:**
1.  **Project Documentation (`train.md`):** Removed the `positive_class_weight` parameter from the example configuration. This parameter was present in the documentation but is not supported by the `ModelConfig` dataclass or the training logic in `train.py`.
2.  **Internal Help Strings (`train.py`):** Updated the `argparse` epilog to use `train.py` instead of the generic `script.py` in all usage examples.

**Why:**
- Eliminates confusion for users who might try to use the unsupported weighting parameter.
- Provides accurate, copy-pasteable examples in the terminal help output.

Verified that `train.py` still passes all unit tests in `tests/test_train.py`.

---
*PR created automatically by Jules for task [7915868575592391427](https://jules.google.com/task/7915868575592391427) started by @RainRat*