### PR TITLE
[UI/UX] Improve visual hierarchy by relocating scan buttons

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3297,6 +3297,9 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.title("GPT Virus Scanner")
     default_font_measure = tkinter.font.Font(font='TkDefaultFont').measure
 
+    style = ttk.Style(root)
+    style.configure('Primary.TButton', font=('TkDefaultFont', 9, 'bold'))
+
     # --- Menu Bar ---
     menubar = tk.Menu(root)
     file_menu = tk.Menu(menubar, tearoff=0)
@@ -3345,20 +3348,12 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     select_clipboard_btn.grid(row=0, column=4, sticky="e", padx=(5, 0))
     bind_hover_message(select_clipboard_btn, "Scan code currently in your clipboard.")
 
-    scan_button = ttk.Button(input_frame, text="Scan Now", command=button_click, default='active')
-    scan_button.grid(row=0, column=5, sticky="e", padx=(5, 0))
-    bind_hover_message(scan_button, "Start the scan.")
-
-    cancel_button = ttk.Button(input_frame, text="Cancel", command=cancel_scan, state="disabled")
-    cancel_button.grid(row=0, column=6, sticky="e", padx=(5, 0))
-    bind_hover_message(cancel_button, "Stop the current scan.")
-
     # --- Settings Container ---
     settings_frame = ttk.Frame(root)
     settings_frame.grid(row=1, column=0, sticky="ew", padx=10, pady=5)
 
     # --- Options Frame ---
-    options_frame = ttk.LabelFrame(settings_frame, text="Scan Options")
+    options_frame = ttk.LabelFrame(settings_frame, text="Scan Options", padding=10)
     options_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=False, padx=(0, 5))
 
     gpt_var = tk.BooleanVar(value=Config.use_ai_analysis)
@@ -3381,7 +3376,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     bind_hover_message(dry_checkbox, "Simulate the scan process without running checks.")
 
     # --- Provider Frame ---
-    provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis")
+    provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(5, 0))
 
     def toggle_ai_controls():
@@ -3452,6 +3447,18 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     model_var.trace_add("write", on_model_change)
 
+    # --- Actions Frame ---
+    actions_frame = ttk.Frame(settings_frame)
+    actions_frame.pack(side=tk.LEFT, fill=tk.Y, padx=(10, 0))
+
+    scan_button = ttk.Button(actions_frame, text="Scan Now", command=button_click, style='Primary.TButton', default='active')
+    scan_button.pack(side=tk.TOP, fill=tk.X, pady=2, ipady=5)
+    bind_hover_message(scan_button, "Start the scan.")
+
+    cancel_button = ttk.Button(actions_frame, text="Cancel", command=cancel_scan, state="disabled")
+    cancel_button.pack(side=tk.TOP, fill=tk.X, pady=2)
+    bind_hover_message(cancel_button, "Stop the current scan.")
+
     if Config.extensions_missing:
         default_exts = ', '.join(sorted(Config.extensions_set)) if Config.extensions_set else 'none'
         messagebox.showwarning(
@@ -3507,7 +3514,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Treeview ---
-    style = ttk.Style(root)
     style.configure('Scanner.Treeview', rowheight=50)
 
     # Configure tags for row highlighting


### PR DESCRIPTION
This pull request improves the visual hierarchy and usability of the GPT Virus Scanner GUI. 

The primary change relocates the **Scan Now** and **Cancel** buttons from the top input row (where they were crowded next to file/folder selectors) to a dedicated actions area within the settings section. This layout creates a logical horizontal flow from scan parameters (options and AI settings) to the final execution step.

Additionally:
- A new `Primary.TButton` style is used for the **Scan Now** button, using a bold font to clearly mark it as the primary action.
- Internal padding was added to the **Scan Options** and **AI Analysis** containers to improve visual grouping.
- The interface now feels more balanced and follows standard "Configuration on the left, Execution on the right" design patterns.

Verified via manual inspection of the refactored code and by running the automated test suite to ensure no event bindings or global variables were broken during the transition.

---
*PR created automatically by Jules for task [11400055393277893611](https://jules.google.com/task/11400055393277893611) started by @RainRat*