### PR TITLE
Handle Markdown-wrapped JSON in GPT responses

### DIFF
--- a/.gptscan_cache.json
+++ b/.gptscan_cache.json
@@ -1,7 +1,7 @@
 {
-    "c961e56142c0e2771271fdc84e59ce81e0c27d0b83888a77b0a9032d554e9b26": {
-        "administrator": "Admin",
-        "end-user": "User",
-        "threat-level": 70
+    "f2a8f03ec838f83cd6f52aa8f1c1758a82eb9162d2d4efa3c0522a842025c74a": {
+        "administrator": "A",
+        "end-user": "U",
+        "threat-level": 10
     }
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -472,6 +472,11 @@ def extract_data_from_gpt_response(response: Any) -> Union[Dict, str]:
     """
     content = response.choices[0].message.content
 
+    # Extract JSON from markdown blocks if present
+    json_match = re.search(r'```(?:json)?\s*(.*?)\s*```', content, re.DOTALL)
+    if json_match:
+        content = json_match.group(1)
+
     try:
         json_data = json.loads(content)
     except json.JSONDecodeError as exc:

--- a/tests/test_gpt_edge_cases.py
+++ b/tests/test_gpt_edge_cases.py
@@ -58,6 +58,38 @@ def test_extract_data_invalid_structure():
     with pytest.raises(AttributeError):
         extract_data_from_gpt_response(object())
 
+def test_extract_data_markdown_json(mock_response):
+    content = """
+Here is the analysis:
+```json
+{
+  "administrator": "admin notes",
+  "end-user": "user notes",
+  "threat-level": 25
+}
+```
+"""
+    response = mock_response(content)
+    result = extract_data_from_gpt_response(response)
+    assert isinstance(result, dict)
+    assert result["threat-level"] == 25
+    assert result["administrator"] == "admin notes"
+
+def test_extract_data_markdown_no_lang(mock_response):
+    content = """
+```
+{
+  "administrator": "a",
+  "end-user": "u",
+  "threat-level": 50
+}
+```
+"""
+    response = mock_response(content)
+    result = extract_data_from_gpt_response(response)
+    assert isinstance(result, dict)
+    assert result["threat-level"] == 50
+
 class MockRateLimitError(Exception):
     def __init__(self):
         self.status_code = 429


### PR DESCRIPTION
The AI models often wrap JSON responses in Markdown code blocks, which previously caused the `json.loads` call to fail in `gptscan.py`. This change introduces a regex-based extraction to isolate the JSON content before parsing. New unit tests ensure this behavior works as expected for various Markdown block formats.

---
*PR created automatically by Jules for task [8597856041061844286](https://jules.google.com/task/8597856041061844286) started by @RainRat*