### PR TITLE
[TEST] Improve report import robustness and add coverage for malformed data

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2375,7 +2375,7 @@ def run_cli(targets: Union[str, List[str]], deep: bool, show_all: bool, use_gpt:
     return threats_found
 
 
-def standardize_result_dict(item: Dict[str, Any]) -> Dict[str, Any]:
+def standardize_result_dict(item: Any) -> Dict[str, Any]:
     """Map various report keys back to the standard internal format.
 
     Args:
@@ -2397,10 +2397,11 @@ def standardize_result_dict(item: Dict[str, Any]) -> Dict[str, Any]:
     standardized = {}
     for standard_key, alternatives in mapping.items():
         val = None
-        for alt in alternatives:
-            if alt in item:
-                val = item[alt]
-                break
+        if isinstance(item, dict):
+            for alt in alternatives:
+                if alt in item:
+                    val = item[alt]
+                    break
         standardized[standard_key] = str(val) if val is not None else ""
 
     return standardized
@@ -2481,7 +2482,8 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
         except json.JSONDecodeError:
             raise ValueError("Could not determine report format.")
 
-    return [standardize_result_dict(item) for item in data_to_import]
+    # Filter out non-dictionary items before standardizing
+    return [standardize_result_dict(item) for item in data_to_import if isinstance(item, dict)]
 
 
 def load_report_file(file_path: str) -> List[Dict[str, Any]]:

--- a/tests/test_import_robustness.py
+++ b/tests/test_import_robustness.py
@@ -1,0 +1,29 @@
+import json
+from gptscan import standardize_result_dict, parse_report_content
+import pytest
+
+def test_standardize_result_dict_none():
+    result = standardize_result_dict(None)
+    assert isinstance(result, dict)
+    for val in result.values():
+        assert val == ""
+
+def test_standardize_result_dict_non_dict():
+    result = standardize_result_dict(["not", "a", "dict"])
+    assert isinstance(result, dict)
+    for val in result.values():
+        assert val == ""
+
+def test_parse_report_content_with_null_elements():
+    content = '[{"path": "test.py", "own_conf": "50%"}, null, {"path": "test2.py", "own_conf": "60%"}]'
+    results = parse_report_content(content, filename_hint="test.json")
+    assert len(results) == 2
+    assert results[0]["path"] == "test.py"
+    assert results[1]["path"] == "test2.py"
+
+def test_parse_report_content_with_non_dict_elements():
+    content = '[{"path": "test.py", "own_conf": "50%"}, "string", 123, {"path": "test2.py", "own_conf": "60%"}]'
+    results = parse_report_content(content, filename_hint="test.json")
+    assert len(results) == 2
+    assert results[0]["path"] == "test.py"
+    assert results[1]["path"] == "test2.py"


### PR DESCRIPTION
This PR improves the reliability of the report import feature in `gptscan.py`. Previously, importing a JSON or NDJSON report containing `null` or non-dictionary elements (such as strings or integers) would cause a `TypeError`. 

I've implemented defensive checks in `standardize_result_dict` and added a filter in `parse_report_content` to skip invalid entries. I've also added a new test file, `tests/test_import_robustness.py`, which provides regression testing for these scenarios.

All 366 tests in the suite are passing.

---
*PR created automatically by Jules for task [15304026188685610209](https://jules.google.com/task/15304026188685610209) started by @RainRat*