### PR TITLE
[FEAT] Add 'Copy as CLI Command' to GUI

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -7,6 +7,7 @@ import json
 import os
 import queue
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -3368,6 +3369,59 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
         analyze_button.config(state="normal" if has_selection and ai_available else "disabled")
 
 
+def get_cli_command() -> str:
+    """Generate a CLI command equivalent to the current GUI settings.
+
+    Returns
+    -------
+    str
+        A string representing the `python gptscan.py ...` command.
+    """
+    cmd_parts = ["python", "gptscan.py"]
+
+    # Target path
+    target = textbox.get() if textbox else Config.last_path
+    if target:
+        cmd_parts.append(shlex.quote(target))
+
+    cmd_parts.append("--cli")
+
+    # Scan Options
+    if deep_var and deep_var.get():
+        cmd_parts.append("--deep")
+    if git_var and git_var.get():
+        cmd_parts.append("--git-changes")
+    if dry_var and dry_var.get():
+        cmd_parts.append("--dry-run")
+    if all_var and all_var.get():
+        cmd_parts.append("--show-all")
+
+    # Threshold
+    if Config.THRESHOLD != 50:
+        cmd_parts.extend(["--threshold", str(Config.THRESHOLD)])
+
+    # AI Analysis
+    if gpt_var and gpt_var.get():
+        cmd_parts.append("--use-gpt")
+        if Config.provider != "openai":
+            cmd_parts.extend(["--provider", Config.provider])
+        if Config.model_name:
+            cmd_parts.extend(["--model", Config.model_name])
+        if Config.api_base:
+            cmd_parts.extend(["--api-base", Config.api_base])
+
+    return " ".join(cmd_parts)
+
+
+def copy_cli_command(event: Optional[tk.Event] = None) -> None:
+    """Copy the equivalent CLI command to the system clipboard."""
+    cmd = get_cli_command()
+    if root:
+        root.clipboard_clear()
+        root.clipboard_append(cmd)
+        update_status("CLI command copied to clipboard.")
+
+
 def on_root_return(event: Optional[tk.Event] = None) -> None:
     """Trigger a scan if the focus is not on a widget that handles Return."""
     if not root:
@@ -3458,6 +3512,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     file_menu.add_command(label="Import Results...", command=import_results)
     file_menu.add_command(label="Import from Clipboard", command=import_from_clipboard)
     file_menu.add_command(label="Export Results...", command=export_results)
+    file_menu.add_command(label="Copy as CLI Command", command=copy_cli_command)
     file_menu.add_separator()
     file_menu.add_command(label="Clear Results", command=clear_results)
     file_menu.add_command(label="Clear AI Cache", command=clear_ai_cache)
@@ -3612,6 +3667,10 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     cancel_button = ttk.Button(actions_frame, text="Cancel", command=cancel_scan, state="disabled")
     cancel_button.pack(side=tk.TOP, fill=tk.X, pady=2)
     bind_hover_message(cancel_button, "Stop the current scan.")
+
+    copy_cmd_button = ttk.Button(actions_frame, text="Copy CLI Command", command=copy_cli_command)
+    copy_cmd_button.pack(side=tk.TOP, fill=tk.X, pady=2)
+    bind_hover_message(copy_cmd_button, "Copy the current scan settings as a CLI command for use in scripts or automation.")
 
     if Config.extensions_missing:
         default_exts = ', '.join(sorted(Config.extensions_set)) if Config.extensions_set else 'none'
@@ -3787,6 +3846,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     # Bind selection and rescan keys
     root.bind('<Return>', on_root_return)
+    root.bind('<Control-Shift-E>', copy_cli_command)
+    root.bind('<Command-Shift-E>', copy_cli_command)
     root.bind('<Control-v>', import_from_clipboard)
     root.bind('<Command-v>', import_from_clipboard)
     root.bind('<Control-f>', focus_filter)

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Run `python gptscan.py` to open the GUI.
 *   **F5 / R:** Rescan selected files.
 *   **Double-click / Enter / Space:** View detailed analysis and code.
 *   **Shift+Enter:** Open selected file.
+*   **Ctrl+Shift+E / Cmd+Shift+E:** Copy the current scan settings as a CLI command.
 *   **Esc:** Cancel the active scan.
 
 ### Using the Command Line (CLI)

--- a/tests/test_copy_cli_command.py
+++ b/tests/test_copy_cli_command.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from gptscan import get_cli_command, Config, deep_var, git_var, dry_var, all_var, gpt_var, textbox
+
+@pytest.fixture
+def mock_gui_vars():
+    """Mock the Tkinter variables used by get_cli_command."""
+    with patch('gptscan.deep_var', MagicMock()) as mock_deep, \
+         patch('gptscan.git_var', MagicMock()) as mock_git, \
+         patch('gptscan.dry_var', MagicMock()) as mock_dry, \
+         patch('gptscan.all_var', MagicMock()) as mock_all, \
+         patch('gptscan.gpt_var', MagicMock()) as mock_gpt, \
+         patch('gptscan.textbox', MagicMock()) as mock_textbox:
+
+        # Default mock values
+        mock_deep.get.return_value = False
+        mock_git.get.return_value = False
+        mock_dry.get.return_value = False
+        mock_all.get.return_value = False
+        mock_gpt.get.return_value = False
+        mock_textbox.get.return_value = "/test/path"
+
+        yield {
+            'deep': mock_deep,
+            'git': mock_git,
+            'dry': mock_dry,
+            'all': mock_all,
+            'gpt': mock_gpt,
+            'textbox': mock_textbox
+        }
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    """Reset Config settings between tests."""
+    orig_threshold = Config.THRESHOLD
+    orig_provider = Config.provider
+    orig_model = Config.model_name
+    orig_api_base = Config.api_base
+    orig_last_path = Config.last_path
+
+    yield
+
+    Config.THRESHOLD = orig_threshold
+    Config.provider = orig_provider
+    Config.model_name = orig_model
+    Config.api_base = orig_api_base
+    Config.last_path = orig_last_path
+
+def test_get_cli_command_basic(mock_gui_vars):
+    command = get_cli_command()
+    assert command == "python gptscan.py /test/path --cli"
+
+def test_get_cli_command_with_spaces_in_path(mock_gui_vars):
+    mock_gui_vars['textbox'].get.return_value = "/path with spaces/script.py"
+    command = get_cli_command()
+    assert "python gptscan.py '/path with spaces/script.py' --cli" in command
+
+def test_get_cli_command_all_options(mock_gui_vars):
+    mock_gui_vars['deep'].get.return_value = True
+    mock_gui_vars['git'].get.return_value = True
+    mock_gui_vars['dry'].get.return_value = True
+    mock_gui_vars['all'].get.return_value = True
+    Config.THRESHOLD = 75
+
+    command = get_cli_command()
+    assert "--deep" in command
+    assert "--git-changes" in command
+    assert "--dry-run" in command
+    assert "--show-all" in command
+    assert "--threshold 75" in command
+
+def test_get_cli_command_ai_options(mock_gui_vars):
+    mock_gui_vars['gpt'].get.return_value = True
+    Config.provider = "ollama"
+    Config.model_name = "llama3.2"
+    Config.api_base = "http://localhost:11434/v1"
+
+    command = get_cli_command()
+    assert "--use-gpt" in command
+    assert "--provider ollama" in command
+    assert "--model llama3.2" in command
+    assert "--api-base http://localhost:11434/v1" in command
+
+def test_get_cli_command_default_provider_omitted(mock_gui_vars):
+    mock_gui_vars['gpt'].get.return_value = True
+    Config.provider = "openai"
+
+    command = get_cli_command()
+    assert "--use-gpt" in command
+    assert "--provider" not in command
+
+def test_copy_cli_command(mock_gui_vars):
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status') as mock_update_status:
+
+        from gptscan import copy_cli_command
+        copy_cli_command()
+
+        mock_root.clipboard_clear.assert_called_once()
+        mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
+        mock_update_status.assert_called_once_with("CLI command copied to clipboard.")


### PR DESCRIPTION
I have implemented the "Copy as CLI Command" feature in `gptscan.py`. This feature enables users to seamlessly transition from the GUI to the CLI by generating and copying the equivalent shell command for their current scan settings. It includes full GUI integration, keyboard shortcuts, documentation updates, and comprehensive unit tests.

---
*PR created automatically by Jules for task [1285380533511785775](https://jules.google.com/task/1285380533511785775) started by @RainRat*