### PR TITLE
Refactor standardize_result_dict to remove redundant validation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2395,14 +2395,16 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
         "line": ["line", "Line", "startLine"]
     }
 
+    if not isinstance(item, dict):
+        return {k: "" for k in mapping}
+
     standardized = {}
     for standard_key, alternatives in mapping.items():
         val = None
-        if isinstance(item, dict):
-            for alt in alternatives:
-                if alt in item:
-                    val = item[alt]
-                    break
+        for alt in alternatives:
+            if alt in item:
+                val = item[alt]
+                break
         standardized[standard_key] = str(val) if val is not None else ""
 
     return standardized


### PR DESCRIPTION
**What:** Moved a redundant `isinstance(item, dict)` check from the inner loop of `standardize_result_dict` to a guard clause at the top.
**Why:** Improves code clarity and performance. The external behavior remains identical; if the input is not a dictionary, it returns the same default dictionary of empty strings.

---
*PR created automatically by Jules for task [12508029900862299381](https://jules.google.com/task/12508029900862299381) started by @RainRat*