### PR TITLE
[UI/UX] Consolidate AI Analysis settings into a single row

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3610,18 +3610,17 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         messagebox.showwarning("AI Analysis Disabled",
                                        "task.txt not found. AI Analysis is disabled.")
 
-    provider_row = ttk.Frame(provider_frame)
-    provider_row.pack(side=tk.TOP, fill=tk.X, padx=10, pady=2)
-    ttk.Label(provider_row, text="Provider:", width=10).pack(side=tk.LEFT)
-    provider_var = tk.StringVar(value=Config.provider)
-    provider_combo = ttk.Combobox(provider_row, textvariable=provider_var, values=["openai", "openrouter", "ollama"], state="readonly", width=12)
-    provider_combo.pack(side=tk.LEFT, padx=5)
+    settings_row = ttk.Frame(provider_frame)
+    settings_row.pack(side=tk.TOP, fill=tk.X, padx=10, pady=2)
 
-    model_row = ttk.Frame(provider_frame)
-    model_row.pack(side=tk.TOP, fill=tk.X, padx=10, pady=2)
-    ttk.Label(model_row, text="Model:", width=10).pack(side=tk.LEFT)
+    ttk.Label(settings_row, text="Provider:").pack(side=tk.LEFT)
+    provider_var = tk.StringVar(value=Config.provider)
+    provider_combo = ttk.Combobox(settings_row, textvariable=provider_var, values=["openai", "openrouter", "ollama"], state="readonly", width=12)
+    provider_combo.pack(side=tk.LEFT, padx=(5, 15))
+
+    ttk.Label(settings_row, text="Model:").pack(side=tk.LEFT)
     model_var = tk.StringVar(value=Config.model_name)
-    model_combo = ttk.Combobox(model_row, textvariable=model_var, width=20)
+    model_combo = ttk.Combobox(settings_row, textvariable=model_var, width=20)
     model_combo.pack(side=tk.LEFT, padx=5)
 
     toggle_ai_controls()


### PR DESCRIPTION
### [UI/UX] Consolidate AI Analysis settings into a single row

**Context:** GUI

**Problem:** 
The "Provider" and "Model" selection widgets in the AI Analysis frame were previously organized into separate vertical rows. This layout created unnecessary vertical clutter and made the configuration area feel less cohesive, especially when compared to other more compact UI elements.

**Solution:** 
Consolidated the "Provider" and "Model" selection fields into a single horizontal `settings_row`. 
- Improved information density by grouping related AI configuration settings together.
- Reduced the vertical footprint of the `provider_frame`.
- Enhanced visual alignment and hierarchy by removing redundant label widths and using consistent horizontal spacing.

**Changes:**
- In `gptscan.py`, replaced two separate `provider_row` and `model_row` frames with a single `settings_row`.
- Updated packing logic to place labels and comboboxes horizontally.
- Removed fixed `width=10` from labels to allow a more compact and natural fit.
- Adjusted padding for optimal separation between the Provider and Model sections.

---
*PR created automatically by Jules for task [13646896707448152736](https://jules.google.com/task/13646896707448152736) started by @RainRat*