### PR TITLE
[FEAT] Show Full Source in Result Details

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2824,7 +2824,12 @@ def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool =
 
 
 def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None) -> None:
-    """Open a detailed view of the selected scan result."""
+    """Open a detailed view of the selected scan result.
+
+    This window displays technical and user-focused analysis, the suspicious
+    code snippet, and allows toggling to the full source code with highlighting
+     of the detected line.
+    """
     if item_id is None:
         selection = tree.selection()
         if not selection:
@@ -2900,6 +2905,61 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font=('Courier', 10), wrap=tk.NONE)
     snippet_text.pack(fill=tk.BOTH, expand=True)
+    snippet_text.tag_configure("highlight", background="yellow", foreground="black")
+
+    showing_full_source = False
+
+    def toggle_source():
+        nonlocal showing_full_source
+        vals = _get_item_raw_values(current_item_id)
+        if not vals:
+            return
+        path = vals[0]
+        line = vals[6] if len(vals) > 6 and vals[6] != "-" else 1
+        snippet = vals[5]
+
+        if not showing_full_source:
+            if path.startswith("["):
+                messagebox.showinfo("Full Source", "Full source is not available for virtual files or clipboard content.")
+                return
+
+            if not os.path.exists(path):
+                messagebox.showerror("Error", f"File not found: {path}")
+                return
+
+            try:
+                file_size = os.path.getsize(path)
+                if file_size > 2 * 1024 * 1024: # 2MB limit
+                    if not messagebox.askyesno("Large File", f"The file is {format_bytes(file_size)}. Loading it might be slow. Continue?"):
+                        return
+
+                with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                    content = f.read()
+
+                snippet_text.config(state='normal')
+                snippet_text.delete('1.0', tk.END)
+                snippet_text.insert(tk.END, content)
+
+                # Highlight and scroll to line
+                if str(line).isdigit():
+                    line_idx = f"{line}.0"
+                    snippet_text.tag_add("highlight", line_idx, f"{line}.end")
+                    snippet_text.see(line_idx)
+
+                snippet_text.config(state='disabled')
+                showing_full_source = True
+                source_toggle_btn.config(text="Show Snippet")
+                snippet_frame.config(text="Full Source")
+            except Exception as e:
+                messagebox.showerror("Error", f"Could not read file: {e}")
+        else:
+            snippet_text.config(state='normal')
+            snippet_text.delete('1.0', tk.END)
+            snippet_text.insert(tk.END, snippet)
+            snippet_text.config(state='disabled')
+            showing_full_source = False
+            source_toggle_btn.config(text="Show Full Source")
+            snippet_frame.config(text="Code Snippet")
 
     # Footer buttons
     btn_frame = ttk.Frame(main_frame)
@@ -2997,6 +3057,9 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     ttk.Button(btn_frame, text="Copy Analysis", command=copy_analysis).pack(side=tk.LEFT, padx=5)
     ttk.Button(btn_frame, text="VirusTotal", command=lambda: check_virustotal(path_entry.get())).pack(side=tk.LEFT, padx=5)
 
+    source_toggle_btn = ttk.Button(btn_frame, text="Show Full Source", command=toggle_source)
+    source_toggle_btn.pack(side=tk.LEFT, padx=5)
+
     analyze_btn = ttk.Button(btn_frame, text="Analyze with AI", command=on_analyze_now)
     analyze_btn.pack(side=tk.LEFT, padx=5)
     if not Config.GPT_ENABLED:
@@ -3081,6 +3144,11 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
                 user_text.pack_forget()
         else:
             analysis_frame.pack_forget()
+
+        nonlocal showing_full_source
+        showing_full_source = False
+        source_toggle_btn.config(text="Show Full Source")
+        snippet_frame.config(text="Code Snippet")
 
         snippet_text.config(state='normal')
         snippet_text.delete('1.0', tk.END)


### PR DESCRIPTION
**What:** Added a "Show Full Source" toggle to the Result Details window. This allows users to view the complete content of a scanned script, with the detected malicious line highlighted and automatically scrolled into view.

**Why:** The previous implementation only showed a 1024-byte snippet. While useful for quick triage, security analysts often need the full context of the file to confirm a threat. This provides that context safely within the GUI, avoiding the need to open the file in external tools.

**Changes:**
- Added `source_toggle_btn` to the Result Details UI in `gptscan.py`.
- Implemented `toggle_source` function within `view_details` to handle safe file reading (UTF-8 with replacement, 2MB size limit) and line highlighting.
- Modified `refresh_content` to reset the view to "Snippet" mode whenever the user navigates to a new result.
- Updated the `view_details` docstring to reflect the new functionality.
- Removed development artifacts and verified the changes with existing tests.

---
*PR created automatically by Jules for task [10433279046118911837](https://jules.google.com/task/10433279046118911837) started by @RainRat*