### PR TITLE
Refactor standardize_result_dict for conciseness and safety

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2398,16 +2398,10 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
     if not isinstance(item, dict):
         return {k: "" for k in mapping}
 
-    standardized = {}
-    for standard_key, alternatives in mapping.items():
-        val = None
-        for alt in alternatives:
-            if alt in item:
-                val = item[alt]
-                break
-        standardized[standard_key] = str(val) if val is not None else ""
-
-    return standardized
+    return {
+        key: next((str(item[alt]) if item[alt] is not None else "" for alt in alts if alt in item), "")
+        for key, alts in mapping.items()
+    }
 
 
 def parse_report_content(content: str, filename_hint: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/tests/test_import_robustness.py
+++ b/tests/test_import_robustness.py
@@ -14,6 +14,12 @@ def test_standardize_result_dict_non_dict():
     for val in result.values():
         assert val == ""
 
+def test_standardize_result_dict_none_values():
+    item = {"path": "test.py", "own_conf": None}
+    result = standardize_result_dict(item)
+    assert result["path"] == "test.py"
+    assert result["own_conf"] == ""
+
 def test_parse_report_content_with_null_elements():
     content = '[{"path": "test.py", "own_conf": "50%"}, null, {"path": "test2.py", "own_conf": "60%"}]'
     results = parse_report_content(content, filename_hint="test.json")


### PR DESCRIPTION
This PR refactors the `standardize_result_dict` function in `gptscan.py` to improve code quality and readability.

Key changes:
1.  **Refactoring**: The manual loop for mapping report keys to the internal format has been replaced with a more concise dictionary comprehension. This uses `next()` with a generator to safely retrieve the first matching alternative key from the input dictionary.
2.  **Safety**: The refactored logic explicitly handles `None` values (e.g., from JSON `null` entries) by converting them to empty strings, maintaining functional parity with the original implementation.
3.  **Verification**: A new test case `test_standardize_result_dict_none_values` was added to `tests/test_import_robustness.py` to ensure that `None` values are handled correctly and do not regress to string literals like `"None"`.

All existing import and robustness tests pass with these changes.

---
*PR created automatically by Jules for task [14105484838010778831](https://jules.google.com/task/14105484838010778831) started by @RainRat*