### PR TITLE
[FEAT] Add 'Scan All File Types' functionality

### DIFF
--- a/.gptscan_cache.json
+++ b/.gptscan_cache.json
@@ -1,7 +1,7 @@
 {
-    "f2a8f03ec838f83cd6f52aa8f1c1758a82eb9162d2d4efa3c0522a842025c74a": {
-        "administrator": "A",
-        "end-user": "U",
-        "threat-level": 10
+    "c961e56142c0e2771271fdc84e59ce81e0c27d0b83888a77b0a9032d554e9b26": {
+        "administrator": "Admin",
+        "end-user": "User",
+        "threat-level": 70
     }
 }

--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -3,6 +3,7 @@
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
+    "scan_all_files": false,
     "use_ai_analysis": false,
     "provider": "openai",
     "model_name": "gpt-4o",

--- a/gptscan.py
+++ b/gptscan.py
@@ -33,6 +33,7 @@ progress_bar: Optional[ttk.Progressbar] = None
 status_label: Optional[ttk.Label] = None
 deep_var: Optional[tk.BooleanVar] = None
 all_var: Optional[tk.BooleanVar] = None
+scan_all_var: Optional[tk.BooleanVar] = None
 gpt_var: Optional[tk.BooleanVar] = None
 dry_var: Optional[tk.BooleanVar] = None
 git_var: Optional[tk.BooleanVar] = None
@@ -100,6 +101,7 @@ class Config:
     deep_scan: bool = False
     git_changes_only: bool = False
     show_all_files: bool = False
+    scan_all_files: bool = False
     use_ai_analysis: bool = False
 
     DEFAULT_EXTENSIONS = ['.py', '.js', '.bat', '.ps1']
@@ -131,6 +133,7 @@ class Config:
             "deep_scan": cls.deep_scan,
             "git_changes_only": cls.git_changes_only,
             "show_all_files": cls.show_all_files,
+            "scan_all_files": cls.scan_all_files,
             "use_ai_analysis": cls.use_ai_analysis,
             "provider": cls.provider,
             "model_name": cls.model_name,
@@ -155,6 +158,7 @@ class Config:
                 cls.deep_scan = settings.get("deep_scan", cls.deep_scan)
                 cls.git_changes_only = settings.get("git_changes_only", cls.git_changes_only)
                 cls.show_all_files = settings.get("show_all_files", cls.show_all_files)
+                cls.scan_all_files = settings.get("scan_all_files", cls.scan_all_files)
                 cls.use_ai_analysis = settings.get("use_ai_analysis", cls.use_ai_analysis)
                 cls.provider = settings.get("provider", cls.provider)
                 cls.model_name = settings.get("model_name", cls.model_name)
@@ -218,17 +222,17 @@ class Config:
 
     @classmethod
     def is_supported_file(cls, file_path: Path, is_explicit: bool = False) -> bool:
-        """Check if a file should be scanned based on extension, content or explicit request.
+        """Check if a file should be scanned based on extension, content, explicit request, or scan_all_files setting.
 
         Args:
             file_path: The path to the file to check.
             is_explicit: Whether the file was specifically requested by the user.
 
         Returns:
-            True if the file matches a known extension, has a script shebang,
-            or was explicitly requested.
+            True if scan_all_files is enabled, or if the file matches a known extension,
+            has a script shebang, or was explicitly requested.
         """
-        if is_explicit:
+        if is_explicit or cls.scan_all_files:
             return True
 
         extension = file_path.suffix.lower()
@@ -3467,6 +3471,8 @@ def get_cli_command() -> str:
         cmd_parts.append("--dry-run")
     if all_var and all_var.get():
         cmd_parts.append("--show-all")
+    if scan_all_var and scan_all_var.get():
+        cmd_parts.append("--all-files")
 
     # Threshold
     if Config.THRESHOLD != 50:
@@ -3568,7 +3574,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, analyze_button, exclude_button, import_button, export_button, clear_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, analyze_button, exclude_button, import_button, export_button, clear_button, default_font_measure
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3648,6 +3654,11 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     deep_checkbox = ttk.Checkbutton(options_frame, text="Deep scan", variable=deep_var)
     deep_checkbox.pack(side=tk.TOP, anchor='w', padx=10, pady=2)
     bind_hover_message(deep_checkbox, "Scan the whole file. This is slower but more thorough. Normally, the scanner only checks the beginning and end.")
+
+    scan_all_var = tk.BooleanVar(value=Config.scan_all_files)
+    scan_all_checkbox = ttk.Checkbutton(options_frame, text="Scan all files", variable=scan_all_var)
+    scan_all_checkbox.pack(side=tk.TOP, anchor='w', padx=10, pady=2)
+    bind_hover_message(scan_all_checkbox, "Scan all files regardless of their extension or whether they contain a script shebang.")
 
     all_var = tk.BooleanVar(value=Config.show_all_files)
 
@@ -3950,6 +3961,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         Config.deep_scan = deep_var.get()
         Config.git_changes_only = git_var.get()
         Config.show_all_files = all_var.get()
+        Config.scan_all_files = scan_all_var.get()
         Config.use_ai_analysis = gpt_var.get()
         Config.provider = provider_var.get()
         Config.model_name = model_var.get()
@@ -4007,6 +4019,11 @@ def main():
         '--git-changes',
         action='store_true',
         help='Only scan files that have changed in your Git repository.'
+    )
+    scan_group.add_argument(
+        '--all-files',
+        action='store_true',
+        help='Scan all files regardless of their extension or whether they contain a script shebang.'
     )
     scan_group.add_argument(
         '--fail-threshold',
@@ -4093,6 +4110,9 @@ def main():
     if args.extensions:
         extension_list = [ext.strip() for ext in args.extensions.split(',') if ext.strip()]
         Config.set_extensions(extension_list, missing=False)
+
+    if args.all_files:
+        Config.scan_all_files = True
 
     Config.THRESHOLD = args.threshold
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Clipboard:** Scan code currently in your clipboard.
 *   **Filter results:** Search findings by path, confidence, notes, or code snippets.
 *   **Deep Scan:** Check the entire file. By default, the scanner only checks the first and last 1024 bytes to save time.
+*   **Scan all files:** Scan all files regardless of their extension or whether they contain a script shebang.
 *   **Minimum Threat Level:** Set the sensitivity. Higher values show only the most dangerous files.
 *   **Show all files:** See every scanned file, even safe ones.
 *   **Use AI Analysis:** Enable detailed reports for suspicious findings.
@@ -143,6 +144,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--threshold [0-100], -t [0-100]`: The lowest threat score to report (default: 50).
 *   `--fail-threshold [0-100]`: Exit with an error if any file meets this threat level.
 *   `--git-changes`: Only scan files that have changed in Git.
+*   `--all-files`: Scan all files regardless of their extension or whether they contain a script shebang.
 *   `--exclude [patterns], -e [patterns]`: Skip files matching these patterns.
 *   `--extensions [types]`: Only scan specific file types (for example: `py,js`).
 *   `--import [file]`: Load results from a previous scan (JSON, CSV, or SARIF). Use `-` to read from standard input.

--- a/tests/test_scan_all_files.py
+++ b/tests/test_scan_all_files.py
@@ -1,0 +1,37 @@
+import pytest
+from pathlib import Path
+from gptscan import Config, scan_files
+
+def test_is_supported_file_with_scan_all_files(monkeypatch):
+    monkeypatch.setattr(Config, "scan_all_files", True)
+    # .txt is normally not supported without shebang
+    assert Config.is_supported_file(Path("test.txt")) is True
+
+    monkeypatch.setattr(Config, "scan_all_files", False)
+    # Ensure .txt is NOT in extensions_set for this test
+    monkeypatch.setattr(Config, "extensions_set", {".py", ".js"})
+    assert Config.is_supported_file(Path("test.txt")) is False
+    # .py is always supported
+    assert Config.is_supported_file(Path("test.py")) is True
+
+def test_scan_files_respects_scan_all_files(tmp_path, monkeypatch):
+    # Create a non-supported file
+    f = tmp_path / "test.txt"
+    f.write_text("plain text file")
+
+    # 1. scan_all_files = False (Default)
+    monkeypatch.setattr(Config, "scan_all_files", False)
+    monkeypatch.setattr(Config, "extensions_set", {".py"}) # Ensure .txt is not in there
+
+    results = list(scan_files(str(tmp_path), deep_scan=False, show_all=True, use_gpt=False, dry_run=True))
+
+    # Should be empty or at least not contain test.txt (except for progress/summary events)
+    result_paths = [data[0] for event, data in results if event == 'result']
+    assert str(f) not in result_paths
+
+    # 2. scan_all_files = True
+    monkeypatch.setattr(Config, "scan_all_files", True)
+    results = list(scan_files(str(tmp_path), deep_scan=False, show_all=True, use_gpt=False, dry_run=True))
+
+    result_paths = [data[0] for event, data in results if event == 'result']
+    assert str(f) in result_paths


### PR DESCRIPTION
The "Scan All File Types" feature allows users to perform thorough security audits by scanning files that might have non-standard or missing extensions (e.g., .txt files containing scripts). This feature is additive, defaults to disabled, and is fully integrated into both the CLI and GUI.

---
*PR created automatically by Jules for task [8212868870470332114](https://jules.google.com/task/8212868870470332114) started by @RainRat*