### PR TITLE
[UI/UX] Streamline results footer and add Reveal button

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -46,6 +46,7 @@ view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
 analyze_button: Optional[ttk.Button] = None
 exclude_button: Optional[ttk.Button] = None
+reveal_button: Optional[ttk.Button] = None
 import_button: Optional[ttk.Button] = None
 export_button: Optional[ttk.Button] = None
 clear_button: Optional[ttk.Button] = None
@@ -1014,7 +1015,7 @@ def set_scanning_state(is_scanning: bool) -> None:
     # Disable all footer buttons during a scan
     footer_buttons = [
         view_button, rescan_button, analyze_button, exclude_button,
-        import_button, export_button, clear_button
+        reveal_button, import_button, export_button, clear_button
     ]
     for btn in footer_buttons:
         if btn:
@@ -3429,7 +3430,7 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
     has_selection = bool(tree.selection())
 
     # Buttons that depend on having one or more items selected
-    dependent_buttons = [view_button, rescan_button, exclude_button]
+    dependent_buttons = [view_button, rescan_button, exclude_button, reveal_button]
     for btn in dependent_buttons:
         if btn:
             btn.config(state="normal" if has_selection else "disabled")
@@ -3568,7 +3569,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, analyze_button, exclude_button, import_button, export_button, clear_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3864,34 +3865,38 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     status_label = ttk.Label(footer_frame, text="Ready", anchor="w")
     status_label.grid(row=0, column=0, sticky="ew")
 
-    view_button = ttk.Button(footer_frame, text="View Details...", command=view_details)
-    view_button.grid(row=0, column=1, padx=2)
+    view_button = ttk.Button(footer_frame, text="View", command=view_details)
+    view_button.grid(row=0, column=1, padx=2, ipady=5)
     bind_hover_message(view_button, "Show full analysis and code for the selected result.")
 
-    rescan_button = ttk.Button(footer_frame, text="Rescan Selected", command=rescan_selected)
-    rescan_button.grid(row=0, column=2, padx=2)
+    rescan_button = ttk.Button(footer_frame, text="Rescan", command=rescan_selected)
+    rescan_button.grid(row=0, column=2, padx=2, ipady=5)
     bind_hover_message(rescan_button, "Re-scan the currently selected items.")
 
-    analyze_button = ttk.Button(footer_frame, text="Analyze with AI", command=analyze_selected_with_ai)
-    analyze_button.grid(row=0, column=3, padx=2)
+    analyze_button = ttk.Button(footer_frame, text="Analyze", command=analyze_selected_with_ai)
+    analyze_button.grid(row=0, column=3, padx=2, ipady=5)
     bind_hover_message(analyze_button, "Use AI to analyze the currently selected items.")
 
-    exclude_button = ttk.Button(footer_frame, text="Exclude Selected", command=exclude_selected)
-    exclude_button.grid(row=0, column=4, padx=2)
+    exclude_button = ttk.Button(footer_frame, text="Exclude", command=exclude_selected)
+    exclude_button.grid(row=0, column=4, padx=2, ipady=5)
     bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
 
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=5, sticky="ns", padx=5)
+    reveal_button = ttk.Button(footer_frame, text="Reveal", command=show_in_folder)
+    reveal_button.grid(row=0, column=5, padx=2, ipady=5)
+    bind_hover_message(reveal_button, "Reveal the selected file in the system file manager.")
 
-    import_button = ttk.Button(footer_frame, text="Import Results...", command=import_results)
-    import_button.grid(row=0, column=6, padx=2)
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=6, sticky="ns", padx=5)
+
+    import_button = ttk.Button(footer_frame, text="Import", command=import_results)
+    import_button.grid(row=0, column=7, padx=2, ipady=5)
     bind_hover_message(import_button, "Load results from a JSON or CSV file.")
 
-    export_button = ttk.Button(footer_frame, text="Export Results...", command=export_results)
-    export_button.grid(row=0, column=7, padx=2)
+    export_button = ttk.Button(footer_frame, text="Export", command=export_results)
+    export_button.grid(row=0, column=8, padx=2, ipady=5)
     bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
 
-    clear_button = ttk.Button(footer_frame, text="Clear Results", command=clear_results)
-    clear_button.grid(row=0, column=8, padx=(2, 0))
+    clear_button = ttk.Button(footer_frame, text="Clear", command=clear_results)
+    clear_button.grid(row=0, column=9, padx=(2, 0), ipady=5)
     bind_hover_message(clear_button, "Clear all results from the list.")
 
     # --- Context Menu ---

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+
+def test_reveal_button_management(monkeypatch):
+    """Test that reveal_button is managed by set_scanning_state and update_button_states."""
+    mock_reveal_button = MagicMock()
+    mock_tree = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'reveal_button', mock_reveal_button)
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+
+    # Mock other buttons to avoid None errors if they are used without check
+    monkeypatch.setattr(gptscan, 'view_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'rescan_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'analyze_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'import_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'export_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'clear_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
+
+    # Test set_scanning_state(True)
+    gptscan.set_scanning_state(True)
+    mock_reveal_button.config.assert_called_with(state="disabled")
+
+    # Test set_scanning_state(False)
+    gptscan.set_scanning_state(False)
+    mock_reveal_button.config.assert_called_with(state="normal")
+
+    # Test update_button_states with selection
+    mock_tree.selection.return_value = ("item1",)
+    gptscan.update_button_states()
+    mock_reveal_button.config.assert_called_with(state="normal")
+
+    # Test update_button_states without selection
+    mock_tree.selection.return_value = ()
+    gptscan.update_button_states()
+    mock_reveal_button.config.assert_called_with(state="disabled")


### PR DESCRIPTION
Improved the GUI results footer by adding a "Reveal" button for quicker navigation, streamlining button labels for better information density, and applying consistent styling across all action buttons. Verified with unit tests and a scoping fix to ensure robust operation.

---
*PR created automatically by Jules for task [11026191566417790149](https://jules.google.com/task/11026191566417790149) started by @RainRat*