### PR TITLE
Refactor exclude_paths logic and optimize cache updates

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1270,23 +1270,20 @@ def exclude_paths(paths: List[str], confirm: bool = True) -> bool:
             for path in paths:
                 path_str = str(path)
                 try:
-                    rel_path = os.path.relpath(path_str, os.getcwd())
-                    if rel_path not in existing_patterns:
-                        f.write(f"{rel_path}\n")
-                        existing_patterns.add(rel_path)
-                    if rel_path not in Config.ignore_patterns:
-                        Config.ignore_patterns.append(rel_path)
+                    p = os.path.relpath(path_str, os.getcwd())
                 except ValueError:
-                    if path_str not in existing_patterns:
-                        f.write(f"{path_str}\n")
-                        existing_patterns.add(path_str)
-                    if path_str not in Config.ignore_patterns:
-                        Config.ignore_patterns.append(path_str)
+                    p = path_str
+
+                if p not in existing_patterns:
+                    f.write(f"{p}\n")
+                    existing_patterns.add(p)
+                if p not in Config.ignore_patterns:
+                    Config.ignore_patterns.append(p)
 
         # Update cache and refresh view
         global _all_results_cache
-        for path in paths:
-            _all_results_cache = [v for v in _all_results_cache if v[0] != str(path)]
+        paths_to_remove = {str(p) for p in paths}
+        _all_results_cache = [v for v in _all_results_cache if v[0] not in paths_to_remove]
 
         _apply_filter()
         update_status(f"Excluded {len(paths)} file(s).")

--- a/tests/test_exclude_logic_fix.py
+++ b/tests/test_exclude_logic_fix.py
@@ -1,0 +1,56 @@
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import pytest
+import gptscan
+
+def test_exclude_paths_consolidated_logic(tmp_path, monkeypatch):
+    # Set up a dummy .gptscanignore
+    ignore_file = tmp_path / ".gptscanignore"
+    ignore_file.write_text("existing.py\n")
+
+    # Change CWD to tmp_path so relpath works predictably
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "exists", lambda p: str(p) == ".gptscanignore" or p == Path(".gptscanignore"))
+
+    # Mock Config
+    monkeypatch.setattr(gptscan.Config, "ignore_patterns", ["existing.py"])
+
+    # Mock messagebox
+    monkeypatch.setattr(gptscan.messagebox, "askyesno", lambda title, msg: True)
+
+    # Mock _apply_filter and update_status
+    monkeypatch.setattr(gptscan, "_apply_filter", MagicMock())
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+
+    # Initialize cache
+    gptscan._all_results_cache = [
+        ("file1.py", "10%", "", "", "", "print(1)", "1"),
+        ("file2.py", "20%", "", "", "", "print(2)", "1"),
+        ("existing.py", "30%", "", "", "", "print(3)", "1")
+    ]
+
+    # Test exclusion
+    paths_to_exclude = ["file1.py", "file2.py"]
+
+    # We need to mock open specifically for .gptscanignore in the current directory
+    # But it's easier to just let it use the real filesystem in tmp_path since we chdir'd
+
+    result = gptscan.exclude_paths(paths_to_exclude, confirm=False)
+
+    assert result is True
+
+    # Check .gptscanignore content
+    content = ignore_file.read_text()
+    assert "file1.py" in content
+    assert "file2.py" in content
+    assert content.count("file1.py") == 1
+
+    # Check Config.ignore_patterns
+    assert "file1.py" in gptscan.Config.ignore_patterns
+    assert "file2.py" in gptscan.Config.ignore_patterns
+
+    # Check _all_results_cache
+    assert len(gptscan._all_results_cache) == 1
+    assert gptscan._all_results_cache[0][0] == "existing.py"


### PR DESCRIPTION
This change refactors the `exclude_paths` function in `gptscan.py` to address two issues:
1. **Logic Duplication:** The path normalization and exclusion logic was duplicated across a `try/except` block. This has been consolidated into a single flow that handles both relative and absolute path fallbacks.
2. **Performance:** The removal of excluded items from the global `_all_results_cache` previously used a nested loop ($O(N \cdot M)$). It now uses a set for $O(1)$ lookups within a single list comprehension, resulting in $O(N + M)$ total complexity.

The change is verified by a new unit test suite and existing tests. No breaking changes were introduced.

---
*PR created automatically by Jules for task [10315830184385183099](https://jules.google.com/task/10315830184385183099) started by @RainRat*