### PR TITLE
[DOCS] Improve CLI help strings for better clarity and accessibility

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3967,7 +3967,8 @@ def main():
                "  python gptscan.py ./my_scripts --cli --use-gpt\n"
                "  python gptscan.py ./my_script.py --cli --json\n"
                "  python gptscan.py --git-changes --cli --fail-threshold 50\n"
-               "  echo \"print('hello')\" | python gptscan.py --cli --stdin",
+               "  echo \"print('hello')\" | python gptscan.py --cli --stdin\n\n"
+               "Note: Always run the script from inside its own folder so it can find its required data files (like scripts.h5).",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {Config.VERSION}')
@@ -4005,7 +4006,7 @@ def main():
     scan_group.add_argument(
         '--all-files',
         action='store_true',
-        help='Scan all files regardless of their extension or whether they contain a script shebang.'
+        help='Scan every file, even if it does not have a script extension or a starting line (like #!/bin/bash).'
     )
     scan_group.add_argument(
         '--fail-threshold',
@@ -4030,7 +4031,7 @@ def main():
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
-    ai_group.add_argument('-g', '--use-gpt', action='store_true', help='Use AI to create detailed reports for suspicious files. This requires an API key.')
+    ai_group.add_argument('-g', '--use-gpt', action='store_true', help='Use AI to create detailed reports for suspicious files. Note: This requires an API key for OpenAI and OpenRouter.')
     ai_group.add_argument(
         '--provider',
         type=str,
@@ -4066,7 +4067,7 @@ def main():
     output_group.add_argument('-o', '--output', type=str, help='Save the scan results to a file. The tool chooses the format based on the file extension.')
     output_group.add_argument('-j', '--json', action='store_true', help='Output results in JSON format (one object per line).')
     output_group.add_argument('--csv', action='store_true', help='Output results in CSV format (default).')
-    output_group.add_argument('--sarif', action='store_true', help='Save results in SARIF format, a standard for security tools.')
+    output_group.add_argument('--sarif', action='store_true', help='Save results in SARIF format (a common format used by security tools).')
     output_group.add_argument('--html', action='store_true', help='Create an HTML report of the results.')
     output_group.add_argument('--md', '--markdown', action='store_true', dest='markdown', help='Create a Markdown report of the results.')
 


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** The `main()` function in `gptscan.py` (specifically the `argparse` configuration).
* **Why:** Replaced technical jargon like "shebang" with descriptive examples and clarified that API keys are only needed for specific providers (OpenAI/OpenRouter). Also added a helpful note about running the script from its own folder to ensure it can find required data files like `scripts.h5`.

---
*PR created automatically by Jules for task [16384430191654332577](https://jules.google.com/task/16384430191654332577) started by @RainRat*