### PR TITLE
[DOCS] Replace "shebang" jargon with plain English

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -230,7 +230,7 @@ class Config:
 
         Returns:
             True if scan_all_files is enabled, or if the file matches a known extension,
-            has a script shebang, or was explicitly requested.
+            has a script starting line (like #!/bin/bash), or was explicitly requested.
         """
         if is_explicit or cls.scan_all_files:
             return True
@@ -239,14 +239,14 @@ class Config:
         if extension in cls.extensions_set:
             return True
 
-        # Check shebang for files without recognized extension
+        # Check for a script starting line (like #!/bin/bash) for files without a recognized extension
         try:
-            # Avoid checking very large files for shebangs if they aren't scripts
+            # Avoid checking very large files for script starting lines if they are not scripts
             # but usually reading just the first line is safe.
             with open(file_path, 'rb') as f:
                 header = f.read(2)
                 if header == b'#!':
-                    # It has a shebang! Read the rest of the first line.
+                    # It has a script starting line! Read the rest of the first line.
                     first_line = f.readline(126).decode('utf-8', errors='ignore').lower()
                     # Common interpreters for supported or similar script types
                     interpreters = ['python', 'node', 'javascript', 'bash', 'sh', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell']
@@ -3766,7 +3766,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     scan_all_var = tk.BooleanVar(value=Config.scan_all_files)
     scan_all_checkbox = ttk.Checkbutton(options_frame, text="Scan all files", variable=scan_all_var)
     scan_all_checkbox.pack(side=tk.TOP, anchor='w', padx=10, pady=2)
-    bind_hover_message(scan_all_checkbox, "Scan all files regardless of their extension or whether they contain a script shebang.")
+    bind_hover_message(scan_all_checkbox, "Scan all files regardless of their extension or whether they contain a script starting line (like #!/bin/bash).")
 
     all_var = tk.BooleanVar(value=Config.show_all_files)
 

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Clipboard:** Scan code currently in your clipboard.
 *   **Filter results:** Search findings by path, confidence, notes, or code snippets.
 *   **Deep Scan:** Check the entire file. By default, the scanner only checks the first and last 1024 bytes to save time.
-*   **Scan all files:** Scan all files regardless of their extension or whether they contain a script shebang.
+*   **Scan all files:** Scan all files regardless of their extension or whether they contain a script starting line (like #!/bin/bash).
 *   **Minimum Threat Level:** Set the sensitivity. Higher values show only the most dangerous files.
 *   **Show all files:** See every scanned file, even safe ones.
 *   **Use AI Analysis:** Enable detailed reports for suspicious findings.
@@ -153,7 +153,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--threshold [0-100], -t [0-100]`: The lowest threat score to report (default: 50).
 *   `--fail-threshold [0-100]`: Exit with an error if any file meets this threat level.
 *   `--git-changes`: Only scan files that have changed in Git.
-*   `--all-files`: Scan all files regardless of their extension or whether they contain a script shebang.
+*   `--all-files`: Scan all files regardless of their extension or whether they contain a script starting line (like #!/bin/bash).
 *   `--exclude [patterns], -e [patterns]`: Skip files matching these patterns.
 *   `--extensions [types]`: Only scan specific file types (for example: `py,js`).
 *   `--import [file]`: Load results from a previous scan (JSON, CSV, or SARIF). Use `-` to read from standard input.


### PR DESCRIPTION
This change replaces the technical term "shebang" with "starting line (like #!/bin/bash)" across the project's documentation, GUI hover messages, and internal code comments. This improves accessibility for casual users and international developers by using plain English and avoiding Unix-specific jargon.

---
*PR created automatically by Jules for task [17381688269579784440](https://jules.google.com/task/17381688269579784440) started by @RainRat*