### PR TITLE
[UI/UX] Add "Open" button to Results footer

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -43,6 +43,7 @@ scan_button: Optional[ttk.Button] = None
 cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
+open_button: Optional[ttk.Button] = None
 analyze_button: Optional[ttk.Button] = None
 exclude_button: Optional[ttk.Button] = None
 reveal_button: Optional[ttk.Button] = None
@@ -1013,7 +1014,7 @@ def set_scanning_state(is_scanning: bool) -> None:
 
     # Disable all footer buttons during a scan
     footer_buttons = [
-        view_button, rescan_button, analyze_button, exclude_button,
+        view_button, rescan_button, open_button, analyze_button, exclude_button,
         reveal_button, import_button, export_button, clear_button
     ]
     for btn in footer_buttons:
@@ -3523,7 +3524,7 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
     has_selection = bool(tree.selection())
 
     # Buttons that depend on having one or more items selected
-    dependent_buttons = [view_button, rescan_button, exclude_button, reveal_button]
+    dependent_buttons = [view_button, open_button, rescan_button, exclude_button, reveal_button]
     for btn in dependent_buttons:
         if btn:
             btn.config(state="normal" if has_selection else "disabled")
@@ -3662,7 +3663,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3966,34 +3967,38 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     view_button.grid(row=0, column=1, padx=2, ipady=5)
     bind_hover_message(view_button, "Show full analysis and code for the selected result.")
 
+    open_button = ttk.Button(footer_frame, text="Open", command=open_file)
+    open_button.grid(row=0, column=2, padx=2, ipady=5)
+    bind_hover_message(open_button, "Open the selected file in its default application. (Shift+Enter)")
+
     rescan_button = ttk.Button(footer_frame, text="Rescan", command=rescan_selected)
-    rescan_button.grid(row=0, column=2, padx=2, ipady=5)
+    rescan_button.grid(row=0, column=3, padx=2, ipady=5)
     bind_hover_message(rescan_button, "Re-scan the currently selected items.")
 
     analyze_button = ttk.Button(footer_frame, text="Analyze", command=analyze_selected_with_ai)
-    analyze_button.grid(row=0, column=3, padx=2, ipady=5)
+    analyze_button.grid(row=0, column=4, padx=2, ipady=5)
     bind_hover_message(analyze_button, "Use AI to analyze the currently selected items.")
 
     exclude_button = ttk.Button(footer_frame, text="Exclude", command=exclude_selected)
-    exclude_button.grid(row=0, column=4, padx=2, ipady=5)
+    exclude_button.grid(row=0, column=5, padx=2, ipady=5)
     bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
 
     reveal_button = ttk.Button(footer_frame, text="Reveal", command=show_in_folder)
-    reveal_button.grid(row=0, column=5, padx=2, ipady=5)
+    reveal_button.grid(row=0, column=6, padx=2, ipady=5)
     bind_hover_message(reveal_button, "Reveal the selected file in the system file manager.")
 
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=6, sticky="ns", padx=5)
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=7, sticky="ns", padx=5)
 
     import_button = ttk.Button(footer_frame, text="Import", command=import_results)
-    import_button.grid(row=0, column=7, padx=2, ipady=5)
+    import_button.grid(row=0, column=8, padx=2, ipady=5)
     bind_hover_message(import_button, "Load results from a JSON or CSV file.")
 
     export_button = ttk.Button(footer_frame, text="Export", command=export_results)
-    export_button.grid(row=0, column=8, padx=2, ipady=5)
+    export_button.grid(row=0, column=9, padx=2, ipady=5)
     bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
 
     clear_button = ttk.Button(footer_frame, text="Clear", command=clear_results)
-    clear_button.grid(row=0, column=9, padx=(2, 0), ipady=5)
+    clear_button.grid(row=0, column=10, padx=(2, 0), ipady=5)
     bind_hover_message(clear_button, "Clear all results from the list.")
 
     # --- Context Menu ---

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+
+def test_open_button_management(monkeypatch):
+    """Test that open_button is managed by set_scanning_state and update_button_states."""
+    mock_open_button = MagicMock()
+    mock_tree = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'open_button', mock_open_button)
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+
+    # Mock other buttons to avoid None errors if they are used without check
+    monkeypatch.setattr(gptscan, 'view_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'rescan_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'analyze_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'import_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'export_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'clear_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
+
+    # Test set_scanning_state(True)
+    gptscan.set_scanning_state(True)
+    mock_open_button.config.assert_called_with(state="disabled")
+
+    # Test set_scanning_state(False)
+    gptscan.set_scanning_state(False)
+    # Note: set_scanning_state(False) calls update_button_states()
+    # which we test below based on selection.
+
+    # Test update_button_states with selection
+    mock_tree.selection.return_value = ("item1",)
+    gptscan.update_button_states()
+    mock_open_button.config.assert_called_with(state="normal")
+
+    # Test update_button_states without selection
+    mock_tree.selection.return_value = ()
+    gptscan.update_button_states()
+    mock_open_button.config.assert_called_with(state="disabled")


### PR DESCRIPTION
**PR Title:** [UI/UX] Add "Open" button to Results footer

**Description:**
* **Context:** GUI
* **Problem:** The workflow for opening a suspicious file from the scan results was inefficient. Users had to either know the `Shift+Return` shortcut or open the "View Details" window first. This added unnecessary friction to a common post-scan action.
* **Solution:** Added a dedicated "Open" button to the main Results footer. This provides a clear, discoverable way to open files in their default system application directly from the results list. The button is correctly managed by the application's state logic, ensuring it is disabled during active scans and only enabled when a result is selected.

**Changes:**
- **gptscan.py**:
    - Added `open_button` as a global variable.
    - Updated `create_gui` to create and grid the "Open" button at column 2 in the footer, shifting subsequent buttons.
    - Updated `set_scanning_state` to include `open_button` in the list of footer buttons disabled during scans.
    - Updated `update_button_states` to include `open_button` in the selection-dependent buttons list.
- **tests/test_open_button.py**:
    - New test file verifying that the "Open" button's state is correctly managed by the UI logic.

---
*PR created automatically by Jules for task [13176126028932677986](https://jules.google.com/task/13176126028932677986) started by @RainRat*