### PR TITLE
[FEAT] Direct URL Scanning Support

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.request
 import webbrowser
 from collections import deque
 import tkinter.scrolledtext as scrolledtext
@@ -73,6 +74,29 @@ def load_file(filename: str, mode: str = 'single_line') -> Union[str, List[str]]
                 return file.read().splitlines()
     except (FileNotFoundError, PermissionError):
         return [] if mode == 'multi_line' else ''
+
+
+def fetch_url_content(url: str, timeout: int = 10, max_size: int = 5 * 1024 * 1024) -> bytes:
+    """Fetches content from a URL with safety limits.
+
+    Args:
+        url: The URL to fetch.
+        timeout: Connection timeout in seconds.
+        max_size: Maximum download size in bytes.
+
+    Returns:
+        The content as bytes.
+
+    Raises:
+        ValueError: If the response is too large or invalid.
+        urllib.error.URLError: If the fetch fails.
+    """
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        content_length = response.getheader('Content-Length')
+        if content_length and int(content_length) > max_size:
+            raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
+
+        return response.read(max_size)
 
 
 class Config:
@@ -1537,12 +1561,15 @@ def scan_files(
 
     # Identify which files were explicitly passed as targets
     if isinstance(scan_targets, (str, Path)):
-        explicit_targets = {Path(scan_targets)}
-    else:
-        explicit_targets = {Path(t) for t in scan_targets}
+        scan_targets = [scan_targets]
+
+    url_targets = [str(t) for t in scan_targets if str(t).startswith(('http://', 'https://'))]
+    local_targets = [t for t in scan_targets if str(t) not in url_targets]
+
+    explicit_targets = {Path(t) for t in local_targets}
     explicit_files = {f for f in explicit_targets if f.is_file()}
 
-    file_list = collect_files(scan_targets)
+    file_list = collect_files(local_targets)
 
     if exclude_patterns:
         file_list = [
@@ -1551,11 +1578,39 @@ def scan_files(
         ]
 
     extra_snippets = extra_snippets or []
-    total_progress = len(file_list) + len(extra_snippets)
+    num_urls = len(url_targets)
+    total_progress = len(file_list) + len(extra_snippets) + 2 * num_urls
     progress_count = 0
     total_bytes_scanned = 0
     actual_files_scanned = 0
     start_time = time.perf_counter()
+
+    # Process URL targets (Phase 1: Fetching)
+    for url in url_targets:
+        if cancel_event.is_set():
+            break
+        progress_count += 1
+        yield ('progress', (progress_count, total_progress, f"Fetching: {url}"))
+        try:
+            content = fetch_url_content(url)
+            extra_snippets.append((f"[URL] {url}", content))
+        except Exception as e:
+            # If fetch fails, we yield the error now and account for both phases
+            yield (
+                'result',
+                (
+                    url,
+                    'Fetch Error',
+                    '',
+                    '',
+                    '',
+                    f"Could not download script: {e}",
+                    '-',
+                )
+            )
+            # Increment again to account for the skipped Phase 2 (Scanning)
+            progress_count += 1
+
     yield ('progress', (progress_count, total_progress, "Collecting files..."))
 
     gpt_requests: List[Dict[str, Any]] = []
@@ -1593,11 +1648,11 @@ def scan_files(
                     )
                 )
 
-    for index, file_path in enumerate(file_list):
+    for file_path in file_list:
         if cancel_event.is_set():
             break
 
-        progress_count = index + 1
+        progress_count += 1
         yield ('progress', (progress_count, total_progress, f"Scanning: {file_path.name}"))
 
         is_explicit = file_path in explicit_files
@@ -4081,7 +4136,8 @@ def main():
                "  python gptscan.py ./my_scripts --cli --use-gpt\n"
                "  python gptscan.py ./my_script.py --cli --json\n"
                "  python gptscan.py --git-changes --cli --fail-threshold 50\n"
-               "  echo \"print('hello')\" | python gptscan.py --cli --stdin\n\n"
+               "  echo \"print('hello')\" | python gptscan.py --cli --stdin\n"
+               "  python gptscan.py https://example.com/script.sh --cli\n\n"
                "Note: Always run the script from inside its own folder so it can find its required data files (like scripts.h5).",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,9 @@ python gptscan.py ./my_scripts --cli --use-gpt --provider ollama --model llama3.
 # Save results to a JSON file
 python gptscan.py ./my_scripts --cli -o results.json --exclude "tests/*"
 
+# Scan a remote script via URL
+python gptscan.py https://example.com/script.sh --cli
+
 # Convert an existing JSON report to an HTML report
 python gptscan.py --cli --import results.json -o report.html
 ```

--- a/tests/test_url_scan.py
+++ b/tests/test_url_scan.py
@@ -1,0 +1,105 @@
+import io
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+from gptscan import scan_files, Config, fetch_url_content
+
+@pytest.fixture
+def mock_tf_env(monkeypatch):
+    """Setup mock TensorFlow and Model to avoid actual loading."""
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.5]] # 50%
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    mock_tf = MagicMock()
+    mock_tf.constant = lambda x: x
+    mock_tf.expand_dims = lambda x, axis: x
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+
+    # Mock collect_files to return empty list by default
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+
+    return mock_model
+
+def test_fetch_url_content_success():
+    """Test successful URL content fetching."""
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = "100"
+    mock_response.read.return_value = b"some content"
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        content = fetch_url_content("http://example.com/script.sh")
+        assert content == b"some content"
+
+def test_fetch_url_content_too_large():
+    """Test that fetch_url_content raises ValueError for large content."""
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = str(10 * 1024 * 1024) # 10MB
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        with pytest.raises(ValueError, match="Content too large"):
+            fetch_url_content("http://example.com/large.sh")
+
+def test_scan_files_with_url_target(mock_tf_env):
+    """Test that URLs in scan_targets are fetched and scanned."""
+    url = "https://example.com/malicious.py"
+    mock_content = b"print('malicious')"
+
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = str(len(mock_content))
+    mock_response.read.return_value = mock_content
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        events = list(scan_files(
+            scan_targets=[url],
+            deep_scan=False,
+            show_all=True,
+            use_gpt=False
+        ))
+
+    # Should have progress events for fetching and collecting
+    # Should have a result event for the fetched snippet
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 1
+    path, own_conf, admin, user, gpt, snippet, line = results[0]
+    assert path == f"[URL] {url}"
+    assert own_conf == "50%"
+    assert "print('malicious')" in snippet
+
+def test_scan_files_url_fetch_error(mock_tf_env):
+    """Test handling of URL fetch errors during scan."""
+    url = "https://example.com/missing.sh"
+
+    with patch("urllib.request.urlopen", side_effect=Exception("404 Not Found")):
+        events = list(scan_files(
+            scan_targets=[url],
+            deep_scan=False,
+            show_all=True,
+            use_gpt=False
+        ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 1
+    path, own_conf, admin, user, gpt, snippet, line = results[0]
+    assert path == url
+    assert own_conf == "Fetch Error"
+    assert "Could not download script" in snippet
+
+def test_cli_url_integration(monkeypatch):
+    """Test that a URL argument in CLI is correctly passed to run_cli as a target."""
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+
+    url = "https://example.com/script.sh"
+    test_args = ["gptscan.py", url, "--cli"]
+
+    with patch("sys.argv", test_args):
+        gptscan.main()
+
+    mock_run_cli.assert_called_once()
+    args, _ = mock_run_cli.call_args
+    # First arg of run_cli is 'targets'
+    assert url in args[0]


### PR DESCRIPTION
**FEAT: Direct URL Scanning Support**

**What:**
This feature allows the `gptscan` tool to fetch and analyze scripts directly from HTTP/HTTPS URLs. It integrates seamlessly into both the CLI and GUI by treating URLs as a new type of scan target. Remote content is fetched into memory with strict safety limits (10s timeout, 5MB max size) and processed through the same local AI and GPT analysis pipeline as local files.

**Why:**
I noticed that while the tool handles local files, standard input, and the clipboard, it lacked a direct way to scan remote scripts (e.g., from Pastebin or GitHub Gists). Users previously had to manually download these scripts or copy-paste them. By adding URL support, we complete the "Input Trinity" (Local, Buffered, Remote), providing immediate convenience and safety for analyzing common web-hosted malicious scripts.

**Changes:**
1.  **Helper function `fetch_url_content`**: Uses standard `urllib.request` (zero-config) to fetch remote content as bytes.
2.  **Logic update in `scan_files`**: Automatically detects URL patterns in the target list, fetches them in a dedicated Phase 1 (with progress reporting), and queues them for scanning in Phase 2.
3.  **CLI & Documentation**: Added URL examples to the CLI `--help` epilog and updated `readme.md`.
4.  **Testing**: Created `tests/test_url_scan.py` to verify success paths, error handling, and CLI integration.
5.  **Robustness**: Refined the progress bar calculation to account for the dual-phase nature of URL processing.

---
*PR created automatically by Jules for task [17453609525231682963](https://jules.google.com/task/17453609525231682963) started by @RainRat*