### PR TITLE
Implement numerical sorting for 'line' column in Results Treeview

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -871,6 +871,8 @@ def sort_column(tv: ttk.Treeview, col: str, reverse: bool) -> None:
     values_with_ids = [(tv.set(k, col), k) for k in tv.get_children("")]
     if col in {"own_conf", "gpt_conf"}:
         values_with_ids = [(parse_percent(val), k) for val, k in values_with_ids]
+    elif col == "line":
+        values_with_ids = [(int(val) if str(val).isdigit() else -1, k) for val, k in values_with_ids]
 
     values_with_ids.sort(key=lambda item: item[0], reverse=reverse)
 

--- a/tests/test_line_sorting.py
+++ b/tests/test_line_sorting.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+from tkinter import ttk
+
+class _FakeTree:
+    def __init__(self, rows, column_map=None):
+        self.data = rows
+        self.order = list(rows.keys())
+        self.heading_calls = {}
+        self.column_map = column_map or {}
+
+    def set(self, iid, col):
+        # In gptscan, tree.set(k, col) returns the value of that column
+        # Our mock needs to know which index the column corresponds to
+        return self.data[iid]["values"][self.column_map.get(col, 0)]
+
+    def get_children(self, *_):
+        return tuple(self.order)
+
+    def move(self, iid, _, index):
+        self.order.remove(iid)
+        self.order.insert(index, iid)
+
+    def heading(self, col, command=None):
+        self.heading_calls[col] = command
+
+def test_sort_column_line_numerical():
+    # Setup data with line numbers that would sort incorrectly as strings
+    # "1", "10", "2" -> sorted as strings: "1", "10", "2"
+    # sorted as numbers: 1, 2, 10
+    rows = {
+        "item1": {"values": ("file1.py", "10", "90%")},
+        "item2": {"values": ("file2.py", "2", "80%")},
+        "item3": {"values": ("file3.py", "1", "100%")},
+        "item4": {"values": ("file4.py", "-", "0%")}
+    }
+    column_map = {"path": 0, "line": 1, "own_conf": 2}
+    tree = _FakeTree(rows, column_map)
+
+    # Sort by line, ascending
+    gptscan.sort_column(tree, "line", False)
+
+    # Expected order: item4 (-1), item3 (1), item2 (2), item1 (10)
+    assert tree.order == ["item4", "item3", "item2", "item1"]
+
+    # Sort by line, descending
+    gptscan.sort_column(tree, "line", True)
+    assert tree.order == ["item1", "item2", "item3", "item4"]
+
+def test_sort_column_own_conf():
+    rows = {
+        "item1": {"values": ("file1.py", "1", "90%")},
+        "item2": {"values": ("file2.py", "2", "100%")},
+        "item3": {"values": ("file3.py", "3", "80%")}
+    }
+    column_map = {"path": 0, "line": 1, "own_conf": 2}
+    tree = _FakeTree(rows, column_map)
+
+    # Sort by own_conf, ascending
+    gptscan.sort_column(tree, "own_conf", False)
+    # Expected order: item3 (80), item1 (90), item2 (100)
+    assert tree.order == ["item3", "item1", "item2"]


### PR DESCRIPTION
Improved the `sort_column` function in `gptscan.py` to ensure the "line" column is sorted numerically. Previously, line numbers were treated as strings, causing incorrect sorting (e.g., "10" appearing before "2").

Changes:
- Updated `sort_column` to convert values in the "line" column to integers during sorting.
- Added `tests/test_line_sorting.py` to provide unit test coverage for numerical sorting of both line numbers and confidence percentages.

These changes are non-breaking and improve the usability of the scan results table.

---
*PR created automatically by Jules for task [7712299346323119775](https://jules.google.com/task/7712299346323119775) started by @RainRat*