### PR TITLE
[UI/UX] Regroup and reorder results footer buttons with logical separators

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4023,42 +4023,48 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     status_label = ttk.Label(footer_frame, text="Ready", anchor="w")
     status_label.grid(row=0, column=0, sticky="ew")
 
-    view_button = ttk.Button(footer_frame, text="View", command=view_details)
+    view_button = ttk.Button(footer_frame, text="View", command=view_details, style='Primary.TButton')
     view_button.grid(row=0, column=1, padx=2, ipady=5)
     bind_hover_message(view_button, "Show full analysis and code for the selected result.")
 
-    open_button = ttk.Button(footer_frame, text="Open", command=open_file)
-    open_button.grid(row=0, column=2, padx=2, ipady=5)
-    bind_hover_message(open_button, "Open the selected file in its default application. (Shift+Enter)")
-
-    rescan_button = ttk.Button(footer_frame, text="Rescan", command=rescan_selected)
-    rescan_button.grid(row=0, column=3, padx=2, ipady=5)
-    bind_hover_message(rescan_button, "Re-scan the currently selected items.")
-
     analyze_button = ttk.Button(footer_frame, text="Analyze", command=analyze_selected_with_ai)
-    analyze_button.grid(row=0, column=4, padx=2, ipady=5)
+    analyze_button.grid(row=0, column=2, padx=2, ipady=5)
     bind_hover_message(analyze_button, "Use AI to analyze the currently selected items.")
 
-    exclude_button = ttk.Button(footer_frame, text="Exclude", command=exclude_selected)
-    exclude_button.grid(row=0, column=5, padx=2, ipady=5)
-    bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=5)
+
+    open_button = ttk.Button(footer_frame, text="Open", command=open_file)
+    open_button.grid(row=0, column=4, padx=2, ipady=5)
+    bind_hover_message(open_button, "Open the selected file in its default application. (Shift+Enter)")
 
     reveal_button = ttk.Button(footer_frame, text="Reveal", command=show_in_folder)
-    reveal_button.grid(row=0, column=6, padx=2, ipady=5)
+    reveal_button.grid(row=0, column=5, padx=2, ipady=5)
     bind_hover_message(reveal_button, "Reveal the selected file in the system file manager.")
 
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=7, sticky="ns", padx=5)
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=6, sticky="ns", padx=5)
+
+    rescan_button = ttk.Button(footer_frame, text="Rescan", command=rescan_selected)
+    rescan_button.grid(row=0, column=7, padx=2, ipady=5)
+    bind_hover_message(rescan_button, "Re-scan the currently selected items.")
+
+    exclude_button = ttk.Button(footer_frame, text="Exclude", command=exclude_selected)
+    exclude_button.grid(row=0, column=8, padx=2, ipady=5)
+    bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
+
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=9, sticky="ns", padx=5)
 
     import_button = ttk.Button(footer_frame, text="Import", command=import_results)
-    import_button.grid(row=0, column=8, padx=2, ipady=5)
+    import_button.grid(row=0, column=10, padx=2, ipady=5)
     bind_hover_message(import_button, "Load results from a JSON or CSV file.")
 
     export_button = ttk.Button(footer_frame, text="Export", command=export_results)
-    export_button.grid(row=0, column=9, padx=2, ipady=5)
+    export_button.grid(row=0, column=11, padx=2, ipady=5)
     bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
 
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=12, sticky="ns", padx=5)
+
     clear_button = ttk.Button(footer_frame, text="Clear", command=clear_results)
-    clear_button.grid(row=0, column=10, padx=(2, 0), ipady=5)
+    clear_button.grid(row=0, column=13, padx=(2, 0), ipady=5)
     bind_hover_message(clear_button, "Clear all results from the list.")
 
     # --- Context Menu ---

--- a/tests/test_exclusion_manager.py
+++ b/tests/test_exclusion_manager.py
@@ -13,7 +13,7 @@ def mock_gui(monkeypatch):
 def test_manage_exclusions_load(mock_gui, monkeypatch):
     monkeypatch.setattr(gptscan.Config, 'ignore_patterns', ['pattern1', 'pattern2'])
 
-    with patch('tkinter.Toplevel') as mock_toplevel:
+    with patch('gptscan.tk.Toplevel') as mock_toplevel:
         mock_win = MagicMock()
         mock_toplevel.return_value = mock_win
 


### PR DESCRIPTION
**Context:** GUI
**Problem:** The results footer buttons lacked a logical hierarchy and visual grouping, making it difficult for users to scan for specific actions (e.g., distinguishing between file management and data export). Additionally, the primary "View" action had no visual distinction from secondary utility buttons.
**Solution:** Reorganized the footer into logical clusters (Analysis, Files, Exclusions, Data, and System) separated by vertical `ttk.Separator` widgets. The "View" button now uses the `Primary.TButton` bold style to highlight it as the primary action for selected results.
**Additional Fixes:** Corrected a pre-existing test failure in `tests/test_exclusion_manager.py` by fixing a namespace patch for `tk.Toplevel`.

---
*PR created automatically by Jules for task [9894918640168391846](https://jules.google.com/task/9894918640168391846) started by @RainRat*