### PR TITLE
[UI/UX] Improve scanning feedback and control locking

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -53,6 +53,19 @@ reveal_button: Optional[ttk.Button] = None
 import_button: Optional[ttk.Button] = None
 export_button: Optional[ttk.Button] = None
 clear_button: Optional[ttk.Button] = None
+select_file_btn: Optional[ttk.Button] = None
+select_dir_btn: Optional[ttk.Button] = None
+select_clipboard_btn: Optional[ttk.Button] = None
+copy_cmd_button: Optional[ttk.Button] = None
+git_checkbox: Optional[ttk.Checkbutton] = None
+deep_checkbox: Optional[ttk.Checkbutton] = None
+scan_all_checkbox: Optional[ttk.Checkbutton] = None
+dry_checkbox: Optional[ttk.Checkbutton] = None
+gpt_checkbox: Optional[ttk.Checkbutton] = None
+all_checkbox: Optional[ttk.Checkbutton] = None
+threshold_spin: Optional[ttk.Spinbox] = None
+provider_combo: Optional[ttk.Combobox] = None
+model_combo: Optional[ttk.Combobox] = None
 context_menu: Optional[tk.Menu] = None
 _all_results_cache: List[Tuple[Any, ...]] = []
 _last_scan_summary: str = ""
@@ -464,6 +477,22 @@ def browse_dir_click() -> None:
     """Handle the directory selection dialog and populate the textbox."""
     folder_selected = filedialog.askdirectory()
     _set_scan_target(folder_selected)
+
+
+def toggle_ai_controls() -> None:
+    """Enable or disable AI analysis controls based on current settings and scan state."""
+    enabled = gpt_var.get() if gpt_var else False
+    is_scanning = current_cancel_event is not None
+
+    if provider_combo and model_combo:
+        if enabled and not is_scanning:
+            provider_combo.config(state="readonly")
+            model_combo.config(state="normal")
+        else:
+            provider_combo.config(state="disabled")
+            model_combo.config(state="disabled")
+
+    update_tree_columns()
 
 
 def browse_file_click() -> None:
@@ -1055,9 +1084,24 @@ def _auto_select_best_result() -> None:
 def set_scanning_state(is_scanning: bool) -> None:
     """Enable or disable controls based on scanning state."""
 
-    if scan_button and cancel_button:
-        scan_button.config(state="disabled" if is_scanning else "normal")
+    if scan_button:
+        scan_button.config(
+            text="Scanning..." if is_scanning else "Scan Now",
+            state="disabled" if is_scanning else "normal"
+        )
+    if cancel_button:
         cancel_button.config(state="normal" if is_scanning else "disabled")
+
+    # Disable/Enable configuration widgets during scan
+    config_widgets = [
+        textbox, select_file_btn, select_dir_btn, select_clipboard_btn,
+        git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox,
+        gpt_checkbox, provider_combo, model_combo, copy_cmd_button,
+        all_checkbox, threshold_spin
+    ]
+    for widget in config_widgets:
+        if widget:
+            widget.config(state="disabled" if is_scanning else "normal")
 
     # Disable all footer buttons during a scan
     footer_buttons = [
@@ -1067,6 +1111,9 @@ def set_scanning_state(is_scanning: bool) -> None:
     for btn in footer_buttons:
         if btn:
             btn.config(state="disabled" if is_scanning else "normal")
+
+    # Ensure AI-specific controls are correctly toggled based on gpt_var and scan state
+    toggle_ai_controls()
 
     if not is_scanning:
         # Re-evaluate selection-dependent buttons when scan ends
@@ -3803,7 +3850,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure, select_file_btn, select_dir_btn, select_clipboard_btn, copy_cmd_button, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, all_checkbox, threshold_spin
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -3919,16 +3966,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(5, 0))
-
-    def toggle_ai_controls():
-        enabled = gpt_var.get()
-        if enabled:
-            provider_combo.config(state="readonly")
-            model_combo.config(state="normal")
-        else:
-            provider_combo.config(state="disabled")
-            model_combo.config(state="disabled")
-        update_tree_columns()
 
     gpt_checkbox = ttk.Checkbutton(provider_frame, text="Use AI Analysis", variable=gpt_var, command=toggle_ai_controls)
     gpt_checkbox.pack(side=tk.TOP, anchor='w', padx=10, pady=2)

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -73,12 +73,12 @@ def test_set_scanning_state_updates_buttons(monkeypatch):
 
     # Test scanning=True
     gptscan.set_scanning_state(True)
-    mock_scan_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
     mock_cancel_button.config.assert_called_with(state="normal")
 
     # Test scanning=False
     gptscan.set_scanning_state(False)
-    mock_scan_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
     mock_cancel_button.config.assert_called_with(state="disabled")
 
 def test_finish_scan_state_resets_state(monkeypatch):
@@ -103,7 +103,7 @@ def test_finish_scan_state_resets_state(monkeypatch):
     # because it avoids overwriting a possible "Scan cancelled" status set by _consume_scan_events.
     mock_status_label.config.assert_not_called()
     assert gptscan.current_cancel_event is None
-    mock_scan_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
     mock_cancel_button.config.assert_called_with(state="disabled")
 
 def test_cancel_scan_triggers_event(monkeypatch):
@@ -211,7 +211,7 @@ def test_button_click_starts_scan(monkeypatch):
     # Assert
     mock_status_label.config.assert_called_with(text="Starting scan...")
     assert gptscan.current_cancel_event is not None
-    mock_scan_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
 
     # Check thread creation
     mock_thread_cls.assert_called_once()


### PR DESCRIPTION
This PR improves the user experience by providing clear visual feedback when a scan is in progress and preventing accidental modification of scan settings. 

Key changes:
- The 'Scan Now' button now displays 'Scanning...' and is disabled while a scan is running.
- All configuration widgets (path input, browse buttons, checkboxes, and AI provider/model dropdowns) are now correctly disabled during the scanning process.
- The `toggle_ai_controls` logic has been centralized to ensure AI-specific dropdowns respect both the user's 'Use AI Analysis' choice and the active scanning state.
- Existing tests in `tests/test_gui_logic.py` have been updated to verify these new UI behaviors.

---
*PR created automatically by Jules for task [6984656535418724158](https://jules.google.com/task/6984656535418724158) started by @RainRat*