### PR TITLE
[FEAT] Add support for scanning Jupyter Notebooks (.ipynb)

### DIFF
--- a/extensions.txt
+++ b/extensions.txt
@@ -70,3 +70,4 @@
 .xml
 .yaml
 .yml
+.ipynb

--- a/gptscan.py
+++ b/gptscan.py
@@ -131,7 +131,7 @@ class Config:
     scan_all_files: bool = False
     use_ai_analysis: bool = False
 
-    DEFAULT_EXTENSIONS = ['.py', '.js', '.bat', '.ps1']
+    DEFAULT_EXTENSIONS = ['.py', '.js', '.bat', '.ps1', '.ipynb']
 
     apikey_missing_message = (
         "No API key found. AI analysis with OpenAI or OpenRouter is disabled, but local scans and Ollama still work."
@@ -1658,6 +1658,21 @@ def scan_files(
                                 if Config.is_supported_file(member.name, is_member=True, content=header):
                                     f_mem.seek(0)
                                     extra_snippets.append((f"{str(f_path)}[{member.name}]", f_mem.read()))
+            except Exception:
+                non_archive_files.append(f_path)
+        elif path_s.endswith('.ipynb'):
+            try:
+                with open(f_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    notebook = json.load(f)
+                    cells = notebook.get('cells', [])
+                    cell_count = 0
+                    for cell in cells:
+                        if cell.get('cell_type') == 'code':
+                            source = cell.get('source', [])
+                            code = "".join(source) if isinstance(source, list) else str(source)
+                            if code.strip():
+                                cell_count += 1
+                                extra_snippets.append((f"{str(f_path)} [Cell {cell_count}]", code.encode('utf-8')))
             except Exception:
                 non_archive_files.append(f_path)
         else:

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ GPT Virus Scanner uses AI to find malicious code in script files.
 *   **Local Scan:** A fast, built-in model checks files on your computer.
 *   **AI Analysis:** If a file looks suspicious, the tool can send it to an AI service (like OpenAI) for a detailed report.
 
-**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell) but does not analyze compiled programs or compressed files (like .zip).
+**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell), Jupyter Notebooks (.ipynb), and archives (.zip, .tar), but does not analyze compiled programs.
 
 ## Quick Start
 
@@ -69,8 +69,9 @@ Once your provider is ready, you must enable the feature when you run a scan:
 
 ## Supported Files
 
-The scanner finds scripts in two ways:
-*   **By file type:** It recognizes over 70 common script types (like `.py`, `.js`, `.sh`, and `.ps1`) using the included `extensions.txt` file.
+The scanner finds scripts in three ways:
+*   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
+*   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By the first line of the file:** If a file does not have an extension, the tool checks the very first line to identify the script type (for example, a line starting with `#!/bin/bash`).
 
 ## Configuration

--- a/tests/test_ipynb_scan.py
+++ b/tests/test_ipynb_scan.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+from pathlib import Path
+from gptscan import scan_files, Config
+
+def test_ipynb_parsing(tmp_path):
+    # Create a dummy Jupyter Notebook
+    notebook_path = tmp_path / "test.ipynb"
+    notebook_content = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "source": ["import os\n", "os.system('rm -rf /')"]
+            },
+            {
+                "cell_type": "markdown",
+                "source": ["# This is a markdown cell"]
+            },
+            {
+                "cell_type": "code",
+                "source": "print('hello world')"
+            }
+        ]
+    }
+    with open(notebook_path, "w") as f:
+        json.dump(notebook_content, f)
+
+    # Mock Config.is_supported_file to return True for our notebook
+    # (Actually it should already work since we added .ipynb to defaults)
+
+    events = list(scan_files(
+        scan_targets=[str(tmp_path)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False,
+        dry_run=True
+    ))
+
+    # Look for results in events
+    results = [data for event_type, data in events if event_type == 'result']
+
+    # We expect 2 results from the 2 code cells
+    assert len(results) == 2
+    assert any("test.ipynb [Cell 1]" in r[0] for r in results)
+    assert any("test.ipynb [Cell 2]" in r[0] for r in results)
+    # In dry_run, r[5] contains "(Snippet would be scanned, size: ...)"
+    assert any("(Snippet would be scanned" in r[5] for r in results)
+
+def test_invalid_ipynb_handled(tmp_path):
+    # Create an invalid JSON file with .ipynb extension
+    notebook_path = tmp_path / "invalid.ipynb"
+    with open(notebook_path, "w") as f:
+        f.write("{invalid json")
+
+    events = list(scan_files(
+        scan_targets=[str(tmp_path)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False,
+        dry_run=True
+    ))
+
+    # The file should be skipped by the ipynb parser but might be picked up
+    # as a regular file if extensions.txt says it's supported.
+    # However, our logic in scan_files for .ipynb should catch the exception.
+    results = [data for event_type, data in events if event_type == 'result']
+
+    # Since it's invalid, it should NOT have [Cell X] results.
+    # It might still be scanned as raw text if it falls through to the 'else' branch,
+    # but my code does `non_archive_files.append(f_path)` in the Exception block.
+    # Wait, my code does:
+    # except Exception:
+    #     non_archive_files.append(f_path)
+    # So it will be scanned as raw text if parsing fails. This is acceptable fallback.
+
+    assert not any("[Cell" in r[0] for r in results)


### PR DESCRIPTION
This PR adds specialized support for scanning Jupyter Notebook files (`.ipynb`) for malicious code.

### Changes:
1.  **Notebook Parsing**: The scanner now detects `.ipynb` files and parses their JSON structure to extract source code from all `code` cells. Each cell is scanned as a virtual snippet (e.g., `path/to/file.ipynb [Cell 1]`).
2.  **Configuration**: Added `.ipynb` to `extensions.txt` and `Config.DEFAULT_EXTENSIONS` to ensure native support is active by default.
3.  **Documentation**: Updated `readme.md` to reflect support for Jupyter Notebooks and corrected a statement to clarify that archives (.zip, .tar) are indeed supported.
4.  **Testing**: Added `tests/test_ipynb_scan.py` to verify cell extraction and error handling for invalid notebooks.

### Why:
Jupyter Notebooks are a common format for sharing executable code but are structured as JSON. Scanning them as raw text can lead to poor results or missing malicious payloads buried in the `source` fields. This feature ensures that each block of code within a notebook is analyzed properly by the local model and AI providers.

---
*PR created automatically by Jules for task [13605084286862883255](https://jules.google.com/task/13605084286862883255) started by @RainRat*