### PR TITLE
Fix inconsistent shebang detection for in-memory content

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -285,7 +285,7 @@ class Config:
             first_line = None
             if content is not None:
                 if content.startswith(b'#!'):
-                    first_line = content.split(b'\n', 1)[0][:128].decode('utf-8', errors='ignore').lower()
+                    first_line = content[2:].split(b'\n', 1)[0][:126].decode('utf-8', errors='ignore').lower()
             elif file_path.is_file():
                 with open(file_path, 'rb') as f:
                     if f.read(2) == b'#!':

--- a/tests/test_shebang_fix.py
+++ b/tests/test_shebang_fix.py
@@ -1,0 +1,17 @@
+from gptscan import Config
+
+def test_is_supported_file_shebang_memory():
+    # Test that in-memory content with shebang is correctly identified
+    # even when it's just #!python without a space or /
+
+    # Cases that used to fail because #! was not stripped and regex required / or space or start of string
+    assert Config.is_supported_file("virtual.txt", content=b"#!python\n") is True
+    assert Config.is_supported_file("virtual.txt", content=b"#!node\n") is True
+
+    # Cases that always worked
+    assert Config.is_supported_file("virtual.txt", content=b"#!/usr/bin/python\n") is True
+    assert Config.is_supported_file("virtual.txt", content=b"#! /usr/bin/python\n") is True
+
+    # Negative cases
+    assert Config.is_supported_file("virtual.txt", content=b"#!notaninterpreter\n") is False
+    assert Config.is_supported_file("virtual.txt", content=b"plain text\n") is False


### PR DESCRIPTION
* **What:** Updated `Config.is_supported_file` in `gptscan.py` to strip the `#!` prefix from in-memory content buffers before regex matching. Added a new unit test file `tests/test_shebang_fix.py`.
* **Why:** This fix resolves an inconsistency where in-memory snippets (from URLs or archives) failed shebang detection if the interpreter followed the prefix without a space (e.g., `#!python`). By stripping the prefix, the logic now matches the behavior used for files on disk, ensuring reliable detection across all input sources without introducing breaking changes.

---
*PR created automatically by Jules for task [8285528726757567113](https://jules.google.com/task/8285528726757567113) started by @RainRat*