### PR TITLE
[TEST] [BUGFIX] Improve type safety in configuration loading and add coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -203,8 +203,15 @@ class Config:
                 cls.use_ai_analysis = settings.get("use_ai_analysis", cls.use_ai_analysis)
                 cls.provider = settings.get("provider", cls.provider)
                 cls.model_name = settings.get("model_name", cls.model_name)
-                cls.THRESHOLD = settings.get("threshold", cls.THRESHOLD)
-                cls.recent_paths = settings.get("recent_paths", cls.recent_paths)
+                threshold = settings.get("threshold", cls.THRESHOLD)
+                try:
+                    cls.THRESHOLD = int(threshold)
+                except (ValueError, TypeError):
+                    pass
+
+                recent = settings.get("recent_paths", cls.recent_paths)
+                if isinstance(recent, list):
+                    cls.recent_paths = [str(p) for p in recent]
         except Exception as e:
             print(f"Warning: Could not load settings: {e}", file=sys.stderr)
 

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -132,3 +132,33 @@ def test_load_settings_partial_data(temp_settings_file):
     assert Config.last_path == "/partial"
     assert Config.THRESHOLD == 99
     assert Config.deep_scan is True
+
+def test_load_settings_type_safety(temp_settings_file):
+    settings = {
+        "threshold": "85",
+        "recent_paths": [1, 2, "three"],
+        "use_ai_analysis": "True"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.THRESHOLD = 50
+    Config.recent_paths = []
+
+    Config.load_settings()
+
+    assert Config.THRESHOLD == 85
+    assert isinstance(Config.THRESHOLD, int)
+    assert Config.recent_paths == ["1", "2", "three"]
+    assert all(isinstance(p, str) for p in Config.recent_paths)
+
+def test_load_settings_invalid_threshold_fallback(temp_settings_file):
+    settings = {
+        "threshold": "not a number"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.THRESHOLD = 42
+    Config.load_settings()
+    assert Config.THRESHOLD == 42 # Should remain unchanged


### PR DESCRIPTION
This PR addresses a gap in configuration robustness where malformed types in the `.gptscan_settings.json` file (specifically a string-typed `threshold`) could lead to runtime `TypeError` in the risk categorization logic. 

**Changes:**
1.  **Source Fix:** Modified `Config.load_settings` in `gptscan.py` to explicitly cast the loaded threshold to an integer and ensure all elements in the `recent_paths` list are strings.
2.  **New Coverage:** Added `test_load_settings_type_safety` and `test_load_settings_invalid_threshold_fallback` to `tests/test_config_persistence.py` to verify these defensive measures.

Verified by running the full test suite (415 tests passed).

---
*PR created automatically by Jules for task [12294948749048558454](https://jules.google.com/task/12294948749048558454) started by @RainRat*