### PR TITLE
Deduplicate scan targets in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1661,9 +1661,11 @@ def scan_files(
             prediction = modelscript.predict(tf_data, batch_size=1, steps=1)[0][0]
             return float(prediction), bytes(padded_data)
 
-    # Identify which files were explicitly passed as targets
+    # Identify which files were explicitly passed as targets and deduplicate them
     if isinstance(scan_targets, (str, Path)):
         scan_targets = [scan_targets]
+
+    scan_targets = list(dict.fromkeys(scan_targets))
 
     url_targets = [str(t) for t in scan_targets if str(t).startswith(('http://', 'https://'))]
     local_targets = [t for t in scan_targets if str(t) not in url_targets]


### PR DESCRIPTION
The `scan_files` function now deduplicates its input `scan_targets` at the very beginning. This resolves a logic redundancy where providing the same file or URL multiple times (e.g., via command-line arguments) would cause the tool to fetch and scan it multiple times, leading to inflated progress counts and duplicate entries in the results.

Key changes:
- Added `scan_targets = list(dict.fromkeys(scan_targets))` in `scan_files` to remove duplicates while preserving order.
- Ensured consistent behavior for both local paths and URLs.
- Verified that 415 tests pass and that progress reporting is now correct for duplicate inputs.

---
*PR created automatically by Jules for task [3787747752486756326](https://jules.google.com/task/3787747752486756326) started by @RainRat*