### PR TITLE
[UI/UX] Persist 'Full Source' view during result navigation

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -11,7 +11,8 @@
     "recent_paths": [
         "/some/path",
         "/some/repo",
-        "/new/path",
-        "/old/path"
+        "1",
+        "2",
+        "three"
     ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -3293,57 +3293,63 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     showing_full_source = False
 
-    def toggle_source():
+    def load_display_code(path, line, snippet, silent_fallback=False):
+        """Load and display either the snippet or full source code."""
         nonlocal showing_full_source
-        vals = _get_item_raw_values(current_item_id)
-        if not vals:
-            return
-        path = vals[0]
-        line = vals[6] if len(vals) > 6 and vals[6] != "-" else 1
-        snippet = vals[5]
-
-        if not showing_full_source:
+        if showing_full_source:
             if path.startswith("["):
-                messagebox.showinfo("Full Source", "Full source is not available for virtual files or clipboard content.")
-                return
+                if not silent_fallback:
+                    messagebox.showinfo("Full Source", "Full source is not available for virtual files or clipboard content.")
+            elif not os.path.exists(path):
+                if not silent_fallback:
+                    messagebox.showerror("Error", f"File not found: {path}")
+            else:
+                try:
+                    file_size = os.path.getsize(path)
+                    if file_size > 2 * 1024 * 1024: # 2MB limit
+                        if not messagebox.askyesno("Large File", f"The file is {format_bytes(file_size)}. Loading it might be slow. Continue?"):
+                            raise ValueError("Cancelled")
 
-            if not os.path.exists(path):
-                messagebox.showerror("Error", f"File not found: {path}")
-                return
+                    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                        content = f.read()
 
-            try:
-                file_size = os.path.getsize(path)
-                if file_size > 2 * 1024 * 1024: # 2MB limit
-                    if not messagebox.askyesno("Large File", f"The file is {format_bytes(file_size)}. Loading it might be slow. Continue?"):
-                        return
+                    snippet_text.config(state='normal')
+                    snippet_text.delete('1.0', tk.END)
+                    snippet_text.insert(tk.END, content)
 
-                with open(path, 'r', encoding='utf-8', errors='replace') as f:
-                    content = f.read()
+                    # Highlight and scroll to line
+                    if str(line).isdigit():
+                        line_idx = f"{line}.0"
+                        snippet_text.tag_add("highlight", line_idx, f"{line}.end")
+                        snippet_text.see(line_idx)
 
-                snippet_text.config(state='normal')
-                snippet_text.delete('1.0', tk.END)
-                snippet_text.insert(tk.END, content)
+                    snippet_text.config(state='disabled')
+                    source_toggle_btn.config(text="Show Snippet")
+                    snippet_frame.config(text="Full Source")
+                    return
+                except Exception as e:
+                    if not silent_fallback and str(e) != "Cancelled":
+                        messagebox.showerror("Error", f"Could not read file: {e}")
 
-                # Highlight and scroll to line
-                if str(line).isdigit():
-                    line_idx = f"{line}.0"
-                    snippet_text.tag_add("highlight", line_idx, f"{line}.end")
-                    snippet_text.see(line_idx)
+        # Default to snippet view
+        snippet_text.config(state='normal')
+        snippet_text.delete('1.0', tk.END)
+        snippet_text.insert(tk.END, snippet)
+        snippet_text.config(state='disabled')
+        showing_full_source = False
+        source_toggle_btn.config(text="Show Full Source")
+        snippet_frame.config(text="Code Snippet")
 
-                snippet_text.config(state='disabled')
-                showing_full_source = True
-                source_toggle_btn.config(text="Show Snippet")
-                snippet_frame.config(text="Full Source")
-            except Exception as e:
-                messagebox.showerror("Error", f"Could not read file: {e}")
-        else:
-            snippet_text.config(state='normal')
-            snippet_text.delete('1.0', tk.END)
-            snippet_text.insert(tk.END, snippet)
-            snippet_text.config(state='disabled')
-            showing_full_source = False
-            source_toggle_btn.config(text="Show Full Source")
-            snippet_frame.config(text="Code Snippet")
+    def toggle_source():
+        """Toggle between snippet and full source view."""
+        nonlocal showing_full_source
+        showing_full_source = not showing_full_source
+        vals = _get_item_raw_values(current_item_id)
+        if vals:
+            path = vals[0]
+            line = vals[6] if len(vals) > 6 and vals[6] != "-" else 1
+            snippet = vals[5]
+            load_display_code(path, line, snippet)
 
     # Footer buttons
     btn_frame = ttk.Frame(main_frame)
@@ -3529,15 +3535,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         else:
             analysis_frame.pack_forget()
 
-        nonlocal showing_full_source
-        showing_full_source = False
-        source_toggle_btn.config(text="Show Full Source")
-        snippet_frame.config(text="Code Snippet")
-
-        snippet_text.config(state='normal')
-        snippet_text.delete('1.0', tk.END)
-        snippet_text.insert(tk.END, snippet)
-        snippet_text.config(state='disabled')
+        load_display_code(path, line, snippet, silent_fallback=True)
 
     def on_prev():
         all_visible = tree.get_children()

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -28,6 +28,10 @@ def mock_view_details_env(monkeypatch):
     mock_toplevel = MagicMock()
     monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock(return_value=mock_toplevel))
 
+    # Mock Entry
+    mock_entry = MagicMock()
+    monkeypatch.setattr(gptscan.ttk, 'Entry', MagicMock(return_value=mock_entry))
+
     # Mock tk.Label for risk_badge
     mock_label = MagicMock()
     monkeypatch.setattr(gptscan.tk, 'Label', MagicMock(return_value=mock_label))
@@ -200,7 +204,8 @@ def test_toggle_source_virtual_file(mock_view_details_env):
     toggle_cmd()
 
     mock_msgbox.showinfo.assert_called_with("Full Source", "Full source is not available for virtual files or clipboard content.")
-    mock_st.insert.assert_not_called()
+    # In the refactored version, load_display_code falls back to snippet view, which calls insert
+    mock_st.insert.assert_called_with(ANY, "snippet")
 
 def test_toggle_source_missing_file(mock_view_details_env, monkeypatch):
     captured, mock_st, mock_msgbox, mock_tree, mock_toplevel, mock_label = mock_view_details_env
@@ -228,7 +233,8 @@ def test_toggle_source_large_file_cancel(mock_view_details_env, monkeypatch):
     toggle_cmd()
 
     mock_msgbox.askyesno.assert_called()
-    mock_st.insert.assert_not_called()
+    # In the refactored version, load_display_code falls back to snippet view, which calls insert
+    mock_st.insert.assert_called_with(ANY, "snippet")
 
 def test_toggle_source_read_error(mock_view_details_env, monkeypatch):
     captured, mock_st, mock_msgbox, mock_tree, mock_toplevel, mock_label = mock_view_details_env
@@ -337,3 +343,35 @@ def test_view_details_analyze_now(mock_view_details_env, monkeypatch):
     contents = [call[0][1] for call in calls]
     assert "New Admin Info" in contents
     assert "New User Info" in contents
+
+def test_view_details_persistent_full_source(mock_view_details_env, monkeypatch):
+    captured, mock_st, mock_msgbox, mock_tree, mock_toplevel, mock_label = mock_view_details_env
+
+    # Setup 2 items
+    raw1 = ["file1.py", "10%", "", "", "", "snippet1", 1]
+    mock_tree._item_values["item1"] = ["file1.py", "10%", "", "", "", "snippet1", 1, json.dumps(raw1)]
+    raw2 = ["file2.py", "20%", "", "", "", "snippet2", 1]
+    mock_tree._item_values["item2"] = ["file2.py", "20%", "", "", "", "snippet2", 1, json.dumps(raw2)]
+
+    mock_tree.get_children.return_value = ["item1", "item2"]
+    monkeypatch.setattr(os.path, "exists", lambda x: True)
+    monkeypatch.setattr(os.path, "getsize", lambda x: 100)
+
+    gptscan.view_details(item_id="item1")
+
+    toggle_cmd = captured["btn_Show Full Source"][1]
+
+    # Toggle to full source
+    with patch("builtins.open", mock_open(read_data="full content 1")):
+        toggle_cmd()
+
+    assert "full content 1" in [call[0][1] for call in mock_st.insert.call_args_list]
+    mock_st.insert.reset_mock()
+
+    # Move to next item
+    next_cmd = captured["btn_Next >"][1]
+    with patch("builtins.open", mock_open(read_data="full content 2")):
+        next_cmd()
+
+    # Verify that it automatically loaded full source for item 2
+    assert "full content 2" in [call[0][1] for call in mock_st.insert.call_args_list]


### PR DESCRIPTION
### Context
GUI (Tkinter)

### Problem
When auditing multiple suspicious files, users often need to see the full context of each file. Previously, navigating between results via the "Next" or "Previous" buttons would reset the view to the "Code Snippet" mode. This required users to manually click "Show Full Source" for every single file, creating significant friction during large audits.

### Solution
Implemented a persistent viewing state in the Result Details window. The code-loading logic was refactored into a `load_display_code` helper that handles both snippet and full-source rendering. When a user navigates to a new result, the window now checks the current viewing mode; if "Full Source" is active, it automatically attempts to load the new file's full content. The system fallback to "Code Snippet" view if the source is unavailable (e.g., for virtual clipboard results or missing files) ensures robustness.

### Changes
- Modified `view_details` in `gptscan.py` to include the `load_display_code` nested helper.
- Updated `toggle_source` and `refresh_content` to utilize the new helper.
- Enhanced `tests/test_view_details.py` with test cases for viewing state persistence.

---
*PR created automatically by Jules for task [17525259569659527553](https://jules.google.com/task/17525259569659527553) started by @RainRat*