### PR TITLE
[DOCS] Clarify AI key requirements in CLI help text

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4467,7 +4467,7 @@ def main():
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
-    ai_group.add_argument('-g', '--use-gpt', action='store_true', help='Use AI to create detailed reports for suspicious files. Note: This requires an API key for OpenAI and OpenRouter.')
+    ai_group.add_argument('-g', '--use-gpt', action='store_true', help='Use AI to create detailed reports for suspicious files. Note: This requires an API key for OpenAI and OpenRouter, but not for Ollama.')
     ai_group.add_argument(
         '--provider',
         type=str,


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the help text for the `--use-gpt` command-line option in `gptscan.py`.
* **Why:** Clarified that an API key is required for OpenAI and OpenRouter, but not for Ollama, helping users understand when they need credentials versus when they can run locally.

---
*PR created automatically by Jules for task [14842768153358239338](https://jules.google.com/task/14842768153358239338) started by @RainRat*