### PR TITLE
[TEST] Expand shebang detection and fix test reliability

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -303,7 +303,7 @@ class Config:
                         first_line = f.readline(126).decode('utf-8', errors='ignore').lower()
 
             if first_line:
-                interpreters = ['python', 'node', 'javascript', 'bash', 'sh', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell']
+                interpreters = ['python', 'node', 'nodejs', 'javascript', 'bash', 'sh', 'ash', 'dash', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell', 'lua', 'osascript', 'ipython']
                 escaped_interpreters = [re.escape(i) for i in interpreters]
                 pattern = r'(?:/|\s|^)(?:' + '|'.join(escaped_interpreters) + r')\d*\b'
                 if re.search(pattern, first_line):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 from unittest.mock import MagicMock
 
 # Create a mock object for tkinter
@@ -50,3 +51,10 @@ mock_ttk.Frame = MockFrame
 sys.modules['tkinter.ttk'] = mock_ttk
 sys.modules['tkinter.messagebox'] = MagicMock()
 sys.modules['tkinter.scrolledtext'] = MagicMock()
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    import gptscan
+    gptscan.current_cancel_event = None
+    gptscan._all_results_cache = []
+    yield

--- a/tests/test_on_demand_ai.py
+++ b/tests/test_on_demand_ai.py
@@ -43,6 +43,10 @@ def test_request_single_gpt_analysis_error(monkeypatch):
 
 def test_on_analyze_now_ui_flow(monkeypatch):
     """Test the 'Analyze with AI' button flow in the details window."""
+    # Reset global state to ensure clean start
+    gptscan.current_cancel_event = None
+    gptscan._all_results_cache = []
+
     # 1. Setup Config and basic UI mocks
     monkeypatch.setattr(gptscan.Config, "GPT_ENABLED", True)
     monkeypatch.setattr(gptscan, "root", MagicMock())

--- a/tests/test_shebang_detection.py
+++ b/tests/test_shebang_detection.py
@@ -70,6 +70,31 @@ def test_is_supported_file_shebang(tmp_path):
         f11.write_bytes(b"#!/usr/bin/mysh\n")
         assert Config.is_supported_file(f11) is False
 
+        # New interpreters
+        f12 = tmp_path / "lua_script"
+        f12.write_bytes(b"#!/usr/bin/lua\n")
+        assert Config.is_supported_file(f12) is True
+
+        f13 = tmp_path / "nodejs_script"
+        f13.write_bytes(b"#!/usr/bin/nodejs\n")
+        assert Config.is_supported_file(f13) is True
+
+        f14 = tmp_path / "ipython_script"
+        f14.write_bytes(b"#!/usr/bin/ipython\n")
+        assert Config.is_supported_file(f14) is True
+
+        f15 = tmp_path / "ash_script"
+        f15.write_bytes(b"#!/bin/ash\n")
+        assert Config.is_supported_file(f15) is True
+
+        f16 = tmp_path / "dash_script"
+        f16.write_bytes(b"#!/bin/dash\n")
+        assert Config.is_supported_file(f16) is True
+
+        f17 = tmp_path / "osascript_script"
+        f17.write_bytes(b"#!/usr/bin/osascript\n")
+        assert Config.is_supported_file(f17) is True
+
     finally:
         Config.extensions_set = original_exts
 


### PR DESCRIPTION
This PR addresses a gap in the shebang detection logic and improves the reliability of the test suite.

### Changes:
1.  **Gap Analysis & Fix:** Expanded the `interpreters` list in `gptscan.py` to include common interpreters like `lua`, `nodejs`, `ipython`, `ash`, `dash`, and `osascript`. This allows the scanner to correctly identify scripts that don't have a supported file extension but do have a valid shebang.
2.  **New Coverage:** Added specific test cases to `tests/test_shebang_detection.py` to verify the detection of these new interpreters.
3.  **Reliability Fix:** Added a local reset of `gptscan.current_cancel_event` and `gptscan._all_results_cache` in `tests/test_on_demand_ai.py` to prevent test failure due to state leakage from other tests.

These changes increase the tool's effectiveness in identifying malicious scripts and ensure a more stable CI/CD process.

---
*PR created automatically by Jules for task [2608206849115225174](https://jules.google.com/task/2608206849115225174) started by @RainRat*