### PR TITLE
[DOCS] Simplify technical jargon in Result Details window

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3312,7 +3312,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         if showing_full_source:
             if path.startswith("["):
                 if not silent_fallback:
-                    messagebox.showinfo("Full Source", "Full source is not available for virtual files or clipboard content.")
+                    messagebox.showinfo("Full Source", "Full source is not available for files inside archives, web links, or clipboard content.")
             elif not os.path.exists(path):
                 if not silent_fallback:
                     messagebox.showerror("Error", f"File not found: {path}")

--- a/tests/test_on_demand_ai.py
+++ b/tests/test_on_demand_ai.py
@@ -44,6 +44,7 @@ def test_request_single_gpt_analysis_error(monkeypatch):
 def test_on_analyze_now_ui_flow(monkeypatch):
     """Test the 'Analyze with AI' button flow in the details window."""
     # 1. Setup Config and basic UI mocks
+    monkeypatch.setattr(gptscan, "current_cancel_event", None)
     monkeypatch.setattr(gptscan.Config, "GPT_ENABLED", True)
     monkeypatch.setattr(gptscan, "root", MagicMock())
 

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -228,7 +228,7 @@ def test_toggle_source_virtual_file(mock_view_details_env):
     setup_details(mock_view_details_env, "item1", "[Clipboard]", snippet="snippet")
     toggle_cmd = captured["btn_Show Full Source"][1]
     toggle_cmd()
-    mock_msgbox.showinfo.assert_called_with("Full Source", "Full source is not available for virtual files or clipboard content.")
+    mock_msgbox.showinfo.assert_called_with("Full Source", "Full source is not available for files inside archives, web links, or clipboard content.")
 
 def test_toggle_source_missing_file(mock_view_details_env, monkeypatch):
     captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env


### PR DESCRIPTION
This documentation improvement simplifies a user-facing error message in the Result Details window. 

Specifically, the message displayed when a user tries to view the full source for a non-local file (like one from a ZIP archive or a URL) was changed from:
"Full source is not available for virtual files or clipboard content."
to:
"Full source is not available for files inside archives, web links, or clipboard content."

This change follows the Lead Technical Writer's guidelines by removing technical jargon ("virtual files") and using Plain English to explain *why* the source isn't available.

Related changes:
- Updated `tests/test_view_details.py` to expect the new string.
- Fixed a flaky test in `tests/test_on_demand_ai.py` by ensuring `current_cancel_event` is reset before the test runs, preventing state leakage from previous tests.

---
*PR created automatically by Jules for task [17012986985939404556](https://jules.google.com/task/17012986985939404556) started by @RainRat*