### PR TITLE
[FEAT] Scan code blocks in Markdown files

### DIFF
--- a/extensions.txt
+++ b/extensions.txt
@@ -71,3 +71,4 @@
 .yaml
 .yml
 .ipynb
+.md

--- a/gptscan.py
+++ b/gptscan.py
@@ -1645,7 +1645,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Fallback: yield as a single snippet if it's a supported file type
+    # 4. Check for Markdown code blocks
+    if check_name.lower().endswith('.md'):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Match fenced code blocks (triple backticks)
+            blocks = re.findall(r'```(?:\w+)?\s*\n?(.*?)\s*```', text, re.DOTALL)
+            for i, block in enumerate(blocks, 1):
+                if block.strip():
+                    yield (f"{name} [Block {i}]", block.encode('utf-8'))
+            return
+        except Exception:
+            pass
+
+    # 5. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content
@@ -1789,7 +1802,7 @@ def scan_files(
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
         # Check if it's a known container by extension or by content
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb')):
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md')):
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()

--- a/tests/test_markdown_scan.py
+++ b/tests/test_markdown_scan.py
@@ -1,0 +1,99 @@
+import pytest
+import io
+from unittest.mock import MagicMock
+import gptscan
+from gptscan import scan_files, Config
+
+@pytest.fixture
+def mock_tf_env(monkeypatch):
+    """Setup mock TensorFlow and Model to avoid actual loading."""
+    mock_model = MagicMock()
+    # Return 0.9 (90%) for anything containing 'malicious', 0.1 otherwise
+    def mock_predict(tf_data, **kwargs):
+        return [[0.9]]
+
+    mock_model.predict.side_effect = mock_predict
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    mock_tf = MagicMock()
+    mock_tf.constant = lambda x: x
+    mock_tf.expand_dims = lambda x, axis: x
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+
+    return mock_model
+
+def test_markdown_code_block_extraction(mock_tf_env, tmp_path):
+    """Test that scripts inside Markdown code blocks are detected and scanned."""
+    md_path = tmp_path / "README.md"
+    md_content = b"""
+# Project README
+
+Here is a python block:
+```python
+print('malicious block 1')
+```
+
+And a bash block:
+```bash
+echo 'malicious block 2'
+```
+
+Plain text here.
+"""
+    md_path.write_bytes(md_content)
+
+    events = list(scan_files(
+        scan_targets=[str(md_path)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    results = [data for event, data in events if event == 'result']
+
+    # Both code blocks should be found and scanned
+    assert len(results) == 2
+
+    # Check first block
+    path1, own_conf1, _, _, _, snippet1, line1 = results[0]
+    assert "README.md [Block 1]" in path1
+    assert own_conf1 == "90%"
+    assert "print('malicious block 1')" in snippet1
+
+    # Check second block
+    path2, own_conf2, _, _, _, snippet2, line2 = results[1]
+    assert "README.md [Block 2]" in path2
+    assert own_conf2 == "90%"
+    assert "echo 'malicious block 2'" in snippet2
+
+def test_markdown_no_blocks(mock_tf_env, tmp_path):
+    """Test that Markdown files with no code blocks yield no results."""
+    md_path = tmp_path / "safe.md"
+    md_content = b"# Safe Markdown\nNo code here."
+    md_path.write_bytes(md_content)
+
+    events = list(scan_files(
+        scan_targets=[str(md_path)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 0
+
+def test_markdown_empty_blocks(mock_tf_env, tmp_path):
+    """Test that empty code blocks are ignored."""
+    md_path = tmp_path / "empty.md"
+    md_content = b"```python\n\n```"
+    md_path.write_bytes(md_content)
+
+    events = list(scan_files(
+        scan_targets=[str(md_path)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 0

--- a/tests/test_on_demand_ai.py
+++ b/tests/test_on_demand_ai.py
@@ -43,6 +43,9 @@ def test_request_single_gpt_analysis_error(monkeypatch):
 
 def test_on_analyze_now_ui_flow(monkeypatch):
     """Test the 'Analyze with AI' button flow in the details window."""
+    # 0. Reset global state
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+
     # 1. Setup Config and basic UI mocks
     monkeypatch.setattr(gptscan.Config, "GPT_ENABLED", True)
     monkeypatch.setattr(gptscan, "root", MagicMock())


### PR DESCRIPTION
This PR adds support for scanning code snippets embedded within Markdown files. 

By treating Markdown as a container format (similar to Jupyter Notebooks or Archives), the scanner now extracts fenced code blocks (triple backticks) and analyzes them individually. This allows the tool to identify malicious "install commands" or snippets frequently found in README files while avoiding false positives from surrounding natural language prose.

Key changes:
1.  **Markdown Parsing:** Added regex-based logic to `unpack_content` to isolate code blocks.
2.  **Universal Discovery:** Added `.md` to `extensions.txt` so documentation files are automatically included in folder scans.
3.  **Test Coverage:** Created a new test suite for Markdown scenarios and resolved a state-related failure in an existing AI test.

---
*PR created automatically by Jules for task [2124533965753199638](https://jules.google.com/task/2124533965753199638) started by @RainRat*