### PR TITLE
Allow clipboard scanning without a selected path

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1196,12 +1196,12 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
     clear_results()
 
     scan_path = textbox.get()
-    if not scan_path:
+    if not scan_path and not extra_snippets:
         messagebox.showerror("Missing Selection", "Please select a file or folder to scan.")
         return
 
-    scan_targets: Union[str, List[str]] = scan_path
-    if git_var.get():
+    scan_targets: Union[str, List[str]] = scan_path if scan_path else []
+    if scan_path and git_var.get():
         git_files = get_git_changed_files(scan_path)
         if not git_files:
             messagebox.showinfo("Git Scan", "No git changes detected in the selected directory.")
@@ -1212,15 +1212,16 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
         messagebox.showerror("Model Not Found", "The scanner cannot find 'scripts.h5'. This file is required to run local scans.")
         return
 
-    Config.last_path = scan_path
-    if scan_path and (not Config.recent_paths or Config.recent_paths[0] != scan_path):
-        if scan_path in Config.recent_paths:
-            Config.recent_paths.remove(scan_path)
-        Config.recent_paths.insert(0, scan_path)
-        Config.recent_paths = Config.recent_paths[:10]
-        if textbox:
-            textbox['values'] = Config.recent_paths
-    Config.save_settings()
+    if scan_path:
+        Config.last_path = scan_path
+        if not Config.recent_paths or Config.recent_paths[0] != scan_path:
+            if scan_path in Config.recent_paths:
+                Config.recent_paths.remove(scan_path)
+            Config.recent_paths.insert(0, scan_path)
+            Config.recent_paths = Config.recent_paths[:10]
+            if textbox:
+                textbox['values'] = Config.recent_paths
+        Config.save_settings()
 
     current_cancel_event = threading.Event()
     set_scanning_state(True)

--- a/tests/test_clipboard_fix.py
+++ b/tests/test_clipboard_fix.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import threading
+
+@pytest.fixture
+def mock_gui(monkeypatch):
+    mock_root = MagicMock()
+    mock_textbox = MagicMock()
+    mock_messagebox = MagicMock()
+    mock_git_var = MagicMock()
+    mock_dry_var = MagicMock()
+    mock_deep_var = MagicMock()
+    mock_all_var = MagicMock()
+    mock_gpt_var = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'root', mock_root)
+    monkeypatch.setattr(gptscan, 'textbox', mock_textbox)
+    monkeypatch.setattr(gptscan, 'messagebox', mock_messagebox)
+    monkeypatch.setattr(gptscan, 'git_var', mock_git_var)
+    monkeypatch.setattr(gptscan, 'dry_var', mock_dry_var)
+    monkeypatch.setattr(gptscan, 'deep_var', mock_deep_var)
+    monkeypatch.setattr(gptscan, 'all_var', mock_all_var)
+    monkeypatch.setattr(gptscan, 'gpt_var', mock_gpt_var)
+
+    # Mocking finish_scan_state and update_status to avoid errors
+    monkeypatch.setattr(gptscan, 'set_scanning_state', MagicMock())
+    monkeypatch.setattr(gptscan, 'update_status', MagicMock())
+    monkeypatch.setattr(gptscan, 'clear_results', MagicMock())
+
+    return {
+        'root': mock_root,
+        'textbox': mock_textbox,
+        'messagebox': mock_messagebox,
+        'git_var': mock_git_var,
+        'dry_var': mock_dry_var
+    }
+
+def test_button_click_with_empty_path_and_snippets(mock_gui, monkeypatch):
+    """Verify that button_click proceeds if snippets are provided, even if scan_path is empty."""
+    mock_gui['textbox'].get.return_value = ""
+    mock_gui['git_var'].get.return_value = False
+    mock_gui['dry_var'].get.return_value = True # Avoid model check for simplicity
+
+    # Mock Thread to avoid actual execution
+    mock_thread = MagicMock()
+    monkeypatch.setattr(threading, 'Thread', mock_thread)
+
+    extra_snippets = [("[Clipboard]", b"print('hello')")]
+    gptscan.button_click(extra_snippets=extra_snippets)
+
+    # Should NOT have shown an error
+    mock_gui['messagebox'].showerror.assert_not_called()
+
+    # Should HAVE started a scan thread
+    mock_thread.assert_called_once()
+    args, kwargs = mock_thread.call_args
+    scan_args = kwargs.get('args') or args[1]
+
+    # scan_targets (first arg of scan_args) should be an empty list, not an empty string or current dir
+    assert scan_args[0] == []
+    # extra_snippets (9th arg) should be present
+    assert scan_args[8] == extra_snippets
+
+def test_button_click_with_empty_path_and_no_snippets(mock_gui, monkeypatch):
+    """Verify that button_click still shows error if both path and snippets are missing."""
+    mock_gui['textbox'].get.return_value = ""
+
+    gptscan.button_click(extra_snippets=None)
+
+    # Should HAVE shown an error
+    mock_gui['messagebox'].showerror.assert_called_with("Missing Selection", "Please select a file or folder to scan.")


### PR DESCRIPTION
* **What:** Modified `button_click` in `gptscan.py` to allow the scan to proceed when `extra_snippets` (e.g., from clipboard or stdin) are provided, even if the `scan_path` from the GUI textbox is empty. The `scan_targets` is correctly initialized as an empty list in this case, and path-dependent logic (Git checks, configuration/history updates) is guarded by `if scan_path:` checks.
* **Why:** Previously, the application would show a "Missing Selection" error if no file or folder was selected, even if the user clicked "Scan Clipboard". This forced users to select a placeholder path before they could scan snippets. This change improves the user experience by allowing snippet-only scans. The change is non-breaking as it only relaxes a validation check and safely handles the empty path case.

---
*PR created automatically by Jules for task [17997729519568370831](https://jules.google.com/task/17997729519568370831) started by @RainRat*