### PR TITLE
Fix Markdown table breakage in report generation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2593,10 +2593,10 @@ def generate_markdown(results: List[Dict[str, Any]]) -> str:
         conf_str = gpt_conf or own_conf
         analysis_parts = []
         if admin:
-            admin_clean = admin.replace("|", "\\|")
+            admin_clean = admin.replace("|", "\\|").replace("\n", "<br>")
             analysis_parts.append(f"**Admin:** {admin_clean}")
         if user:
-            user_clean = user.replace("|", "\\|")
+            user_clean = user.replace("|", "\\|").replace("\n", "<br>")
             analysis_parts.append(f"**User:** {user_clean}")
         analysis = "<br>".join(analysis_parts)
 


### PR DESCRIPTION
This PR fixes a bug in the Markdown report generation where multi-line AI analysis notes would break the summary table structure. By replacing literal newlines with `<br>` tags, the table rows remain on a single physical line, which is required for valid Markdown tables, while still allowing the rendered output to show multiple lines within a cell.

Changes:
- Modified `generate_markdown` in `gptscan.py` to escape newlines in `admin_desc` and `end-user_desc`.
- Verified the fix with a reproduction test case.
- Ensured no regressions were introduced by running the full test suite.

---
*PR created automatically by Jules for task [7043113205178548272](https://jules.google.com/task/7043113205178548272) started by @RainRat*