### PR TITLE
[TEST] Add recursion depth coverage for archive unpacking

### DIFF
--- a/tests/test_unpack_recursion_limit.py
+++ b/tests/test_unpack_recursion_limit.py
@@ -1,0 +1,34 @@
+import io
+import zipfile
+import pytest
+from gptscan import unpack_content
+
+def test_unpack_content_recursion_limit_stops_at_depth_six():
+    current_content = b"print('depth 6')"
+    current_name = "leaf.py"
+
+    for i in range(1, 8):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as z:
+            z.writestr(current_name, current_content)
+        current_content = buffer.getvalue()
+        current_name = f"nest{i}.zip"
+
+    results = list(unpack_content("outer.zip", current_content))
+    assert len(results) == 0
+
+def test_unpack_content_works_at_depth_five():
+    current_content = b"print('at depth 5')"
+    current_name = "leaf.py"
+
+    for i in range(1, 5):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as z:
+            z.writestr(current_name, current_content)
+        current_content = buffer.getvalue()
+        current_name = f"nest{i}.zip"
+
+    results = list(unpack_content("nest4.zip", current_content))
+    assert len(results) == 1
+    assert "leaf.py" in results[0][0]
+    assert results[0][1] == b"print('at depth 5')"


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added unit tests to verify the recursion depth limit (depth > 5) in the `unpack_content` function for nested ZIP archives.
* **Why:** This edge case was previously untested, leaving a gap in the validation of the scanner's safety mechanisms against infinite recursion or decompression bombs.

---
*PR created automatically by Jules for task [18373608851910867773](https://jules.google.com/task/18373608851910867773) started by @RainRat*