### PR TITLE
[FEAT] Configurable maximum file size limits for scanning and viewing

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -9,6 +9,8 @@
     "model_name": "gpt-4o",
     "api_base": null,
     "threshold": 50,
+    "max_file_size": 10485760,
+    "max_source_view_size": 2097152,
     "recent_paths": [
         "/some/path",
         "/some/repo",

--- a/gptscan.py
+++ b/gptscan.py
@@ -95,13 +95,13 @@ def load_file(filename: str, mode: str = 'single_line') -> Union[str, List[str]]
         return [] if mode == 'multi_line' else ''
 
 
-def fetch_url_content(url: str, timeout: int = 10, max_size: int = 5 * 1024 * 1024) -> bytes:
+def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = None) -> bytes:
     """Fetches content from a URL with safety limits.
 
     Args:
         url: The URL to fetch.
         timeout: Connection timeout in seconds.
-        max_size: Maximum download size in bytes.
+        max_size: Maximum download size in bytes. Defaults to Config.MAX_FILE_SIZE.
 
     Returns:
         The content as bytes.
@@ -110,6 +110,9 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: int = 5 * 1024 * 10
         ValueError: If the response is too large or invalid.
         urllib.error.URLError: If the fetch fails.
     """
+    if max_size is None:
+        max_size = Config.MAX_FILE_SIZE
+
     with urllib.request.urlopen(url, timeout=timeout) as response:
         content_length = response.getheader('Content-Length')
         if content_length and int(content_length) > max_size:
@@ -128,6 +131,8 @@ class Config:
     MAX_RETRIES = 3
     RATE_LIMIT_PER_MINUTE = 60
     MAX_CONCURRENT_REQUESTS = 5
+    MAX_FILE_SIZE = 10 * 1024 * 1024
+    MAX_SOURCE_VIEW_SIZE = 2 * 1024 * 1024
     gpt_cache: Dict[str, Dict[str, Any]] = {}
     apikey: str = load_file('apikey.txt')
     taskdesc: str = load_file('task.txt')
@@ -182,6 +187,8 @@ class Config:
             "model_name": cls.model_name,
             "api_base": cls.api_base,
             "threshold": cls.THRESHOLD,
+            "max_file_size": cls.MAX_FILE_SIZE,
+            "max_source_view_size": cls.MAX_SOURCE_VIEW_SIZE,
             "recent_paths": cls.recent_paths,
         }
         try:
@@ -210,6 +217,18 @@ class Config:
                 threshold = settings.get("threshold", cls.THRESHOLD)
                 try:
                     cls.THRESHOLD = int(threshold)
+                except (ValueError, TypeError):
+                    pass
+
+                max_file_size = settings.get("max_file_size", cls.MAX_FILE_SIZE)
+                try:
+                    cls.MAX_FILE_SIZE = int(max_file_size)
+                except (ValueError, TypeError):
+                    pass
+
+                max_source_view_size = settings.get("max_source_view_size", cls.MAX_SOURCE_VIEW_SIZE)
+                try:
+                    cls.MAX_SOURCE_VIEW_SIZE = int(max_source_view_size)
                 except (ValueError, TypeError):
                     pass
 
@@ -816,6 +835,52 @@ def parse_percent(val: str, default: float = -1.0) -> float:
         return float(text.strip('%'))
     except ValueError:
         return default
+
+
+def parse_size_string(size_str: str) -> int:
+    """Convert a human-readable size string (e.g., "10MB", "500KB") to bytes.
+
+    Args:
+        size_str: The size string to parse.
+
+    Returns:
+        The size in bytes as an integer.
+
+    Raises:
+        ValueError: If the string format is invalid.
+    """
+    if not size_str:
+        raise ValueError("Size string is empty")
+
+    match = re.match(r'^(\d+(?:\.\d+)?)\s*([a-zA-Z]*)$', size_str.strip())
+    if not match:
+        raise ValueError(f"Invalid size format: {size_str}")
+
+    value_str, unit = match.groups()
+    value = float(value_str)
+    unit = unit.upper()
+
+    units = {
+        '': 1,
+        'B': 1,
+        'K': 1024,
+        'KB': 1024,
+        'KIB': 1024,
+        'M': 1024 * 1024,
+        'MB': 1024 * 1024,
+        'MIB': 1024 * 1024,
+        'G': 1024 * 1024 * 1024,
+        'GB': 1024 * 1024 * 1024,
+        'GIB': 1024 * 1024 * 1024,
+        'T': 1024 * 1024 * 1024 * 1024,
+        'TB': 1024 * 1024 * 1024 * 1024,
+        'TIB': 1024 * 1024 * 1024 * 1024,
+    }
+
+    if unit not in units:
+        raise ValueError(f"Unknown unit: {unit}")
+
+    return int(value * units[unit])
 
 
 def format_bytes(num: float) -> str:
@@ -1597,7 +1662,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             buffer = io.BytesIO(content)
             with zipfile.ZipFile(buffer) as z:
                 for info in z.infolist():
-                    if info.is_dir() or info.file_size > 10 * 1024 * 1024:
+                    if info.is_dir() or info.file_size > Config.MAX_FILE_SIZE:
                         continue
                     with z.open(info) as f:
                         member_content = f.read()
@@ -1619,7 +1684,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             buffer = io.BytesIO(content)
             with tarfile.open(fileobj=buffer) as t:
                 for member in t.getmembers():
-                    if not member.isfile() or member.size > 10 * 1024 * 1024:
+                    if not member.isfile() or member.size > Config.MAX_FILE_SIZE:
                         continue
                     f = t.extractfile(member)
                     if f:
@@ -1936,6 +2001,22 @@ def scan_files(
 
             if file_size is not None:
                 total_bytes_scanned += file_size
+
+            # Check file size limit (skip if not explicitly requested)
+            if not is_explicit and file_size is not None and file_size > Config.MAX_FILE_SIZE:
+                yield (
+                    'result',
+                    (
+                        str(file_path),
+                        'Large File',
+                        '',
+                        '',
+                        '',
+                        f"Skipped: File exceeds maximum size ({format_bytes(Config.MAX_FILE_SIZE)})",
+                        '-',
+                    )
+                )
+                continue
 
             if dry_run:
                 yield (
@@ -3321,7 +3402,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
             else:
                 try:
                     file_size = os.path.getsize(path)
-                    if file_size > 2 * 1024 * 1024: # 2MB limit
+                    if file_size > Config.MAX_SOURCE_VIEW_SIZE:
                         if not messagebox.askyesno("Large File", f"The file is {format_bytes(file_size)}. Loading it might be slow. Continue?"):
                             raise ValueError("Cancelled")
 
@@ -4172,6 +4253,24 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     dry_checkbox.pack(side=tk.TOP, anchor='w', padx=10, pady=2)
     bind_hover_message(dry_checkbox, "Simulate the scan process without running checks.")
 
+    size_frame = ttk.Frame(options_frame)
+    size_frame.pack(side=tk.TOP, fill=tk.X, padx=10, pady=2)
+    ttk.Label(size_frame, text="Max File Size (MB):").pack(side=tk.LEFT)
+
+    def on_max_size_change():
+        try:
+            val = float(max_size_spin.get())
+            Config.MAX_FILE_SIZE = int(val * 1024 * 1024)
+        except ValueError:
+            pass
+
+    max_size_spin = ttk.Spinbox(size_frame, from_=1, to=1024, width=5, command=on_max_size_change)
+    max_size_spin.delete(0, tk.END)
+    max_size_spin.insert(0, str(int(Config.MAX_FILE_SIZE / (1024 * 1024))))
+    max_size_spin.pack(side=tk.LEFT, padx=5)
+    max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
+    bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")
+
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5)
@@ -4583,6 +4682,11 @@ def main():
         type=str,
         help='Import and process results from a previous scan (JSON, CSV, or SARIF). Use "-" to read from terminal input (piped).'
     )
+    scan_group.add_argument(
+        '--max-size',
+        type=str,
+        help='The maximum file size to scan (e.g., "10MB", "500KB").'
+    )
 
     ai_group = parser.add_argument_group("AI Analysis")
     ai_group.add_argument('-g', '--use-gpt', action='store_true', help='Use AI to create detailed reports for suspicious files. Note: This requires an API key for OpenAI and OpenRouter, but not for Ollama.')
@@ -4650,6 +4754,12 @@ def main():
 
     if args.all_files:
         Config.scan_all_files = True
+
+    if args.max_size:
+        try:
+            Config.MAX_FILE_SIZE = parse_size_string(args.max_size)
+        except ValueError as e:
+            parser.error(f"Invalid --max-size: {e}")
 
     Config.THRESHOLD = args.threshold
 

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Deep scan:** Scan the whole file. Normally, the scanner only checks the start and end to save time.
 *   **Scan all files:** Scan every file, even those without common script extensions.
 *   **Dry Run:** Simulate the scan without actually analyzing any files.
+*   **Max File Size (MB):** Skip files larger than this size.
 
 #### AI Analysis
 *   **Use AI Analysis:** Enable detailed reports for suspicious findings.
@@ -203,6 +204,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--file-list [file]`: Scan a list of files from a text file.
 *   `--extensions [types]`: Only scan specific file types (for example: `py,js`).
 *   `--import [file]`: Load results from a previous scan (JSON, CSV, or SARIF). Use `-` for terminal input.
+*   `--max-size [value]`: Set the maximum file size to scan (e.g., `10MB`, `500KB`).
 *   `--json`: Save or show results in JSON format (one object per line).
 *   `--csv`: Save or show results in CSV format.
 *   `--sarif`: Save results in SARIF format for security tools.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,20 @@ def reset_globals():
     gptscan._all_results_cache = []
     gptscan._model_cache = None
     gptscan._async_openai_client = None
+
+    # Save original Config state
+    orig_exts = gptscan.Config.extensions_set.copy()
+    orig_threshold = gptscan.Config.THRESHOLD
+    orig_max_file_size = gptscan.Config.MAX_FILE_SIZE
+    orig_max_source_view_size = gptscan.Config.MAX_SOURCE_VIEW_SIZE
+
     yield
+
+    # Restore original Config state
+    gptscan.Config.extensions_set = orig_exts
+    gptscan.Config.THRESHOLD = orig_threshold
+    gptscan.Config.MAX_FILE_SIZE = orig_max_file_size
+    gptscan.Config.MAX_SOURCE_VIEW_SIZE = orig_max_source_view_size
 
 @pytest.fixture
 def mock_tf_env(monkeypatch):

--- a/tests/test_file_size_limit.py
+++ b/tests/test_file_size_limit.py
@@ -1,0 +1,69 @@
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import gptscan
+
+def test_parse_size_string():
+    assert gptscan.parse_size_string("10MB") == 10 * 1024 * 1024
+    assert gptscan.parse_size_string("500KB") == 500 * 1024
+    assert gptscan.parse_size_string("1G") == 1024 * 1024 * 1024
+    assert gptscan.parse_size_string("100") == 100
+    with pytest.raises(ValueError):
+        gptscan.parse_size_string("invalid")
+
+def test_fetch_url_content_size_limit():
+    with patch("urllib.request.urlopen") as mock_url:
+        mock_response = MagicMock()
+        mock_response.getheader.return_value = "20000000" # 20MB
+        mock_url.return_value.__enter__.return_value = mock_response
+
+        gptscan.Config.MAX_FILE_SIZE = 10 * 1024 * 1024 # 10MB
+
+        with pytest.raises(ValueError, match="Content too large"):
+            gptscan.fetch_url_content("http://example.com/large.py")
+
+def test_scan_files_skips_large_local_file(tmp_path, monkeypatch):
+    large_file = tmp_path / "large.py"
+    large_file.write_text("print('hello')" * 1000)
+
+    # Set limit very low
+    monkeypatch.setattr(gptscan.Config, 'MAX_FILE_SIZE', 100)
+
+    # Mock model to return something
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.9]]
+    monkeypatch.setattr(gptscan, 'get_model', lambda: mock_model)
+    monkeypatch.setattr(gptscan, '_tf_module', MagicMock())
+
+    # Scan the directory, so the file is not "explicitly" requested
+    gen = gptscan.scan_files([str(tmp_path)], deep_scan=False, show_all=True, use_gpt=False)
+
+    results = []
+    for event_type, data in gen:
+        if event_type == 'result':
+            results.append(data)
+
+    assert len(results) == 1
+    assert results[0][1] == 'Large File'
+    assert "exceeds maximum size" in results[0][5]
+
+def test_unpack_content_respects_size_limit(monkeypatch):
+    # Mock Config.MAX_FILE_SIZE
+    monkeypatch.setattr(gptscan.Config, 'MAX_FILE_SIZE', 100)
+
+    # Create a small "archive" content that would yield a member
+    # Instead of real zip, I'll mock zipfile.ZipFile
+    with patch("zipfile.ZipFile") as mock_zip:
+        mock_info = MagicMock()
+        mock_info.is_dir.return_value = False
+        mock_info.file_size = 200 # Larger than limit
+        mock_info.filename = "large_member.py"
+
+        mock_zip.return_value.__enter__.return_value.infolist.return_value = [mock_info]
+
+        content = b"PK\x03\x04 fake zip content"
+        gen = gptscan.unpack_content("test.zip", content)
+
+        # Should yield nothing because member is too large
+        results = list(gen)
+        assert len(results) == 0

--- a/tests/test_url_scan.py
+++ b/tests/test_url_scan.py
@@ -18,7 +18,8 @@ def test_fetch_url_content_success():
 def test_fetch_url_content_too_large():
     """Test that fetch_url_content raises ValueError for large content."""
     mock_response = MagicMock()
-    mock_response.getheader.return_value = str(10 * 1024 * 1024) # 10MB
+    # Use a value larger than the default Config.MAX_FILE_SIZE (10MB)
+    mock_response.getheader.return_value = str(11 * 1024 * 1024)
     mock_response.__enter__.return_value = mock_response
 
     with patch("urllib.request.urlopen", return_value=mock_response):


### PR DESCRIPTION
This feature introduces a centralized and configurable system for managing file size limits across the application. It replaces several hardcoded values with unified settings.

Key improvements:
1. **Configurability:** Users can now set the maximum file size for scanning via CLI (`--max-size`) or GUI (Scan Options frame).
2. **Unified Enforcement:** The limit is consistently applied to local files, archive members (ZIP/TAR), and remote URLs.
3. **Safety:** Large files are skipped with a clear "Large File" status, preventing performance issues or OOM errors.
4. **UX:** The GUI source viewer now uses the configurable `MAX_SOURCE_VIEW_SIZE` to warn before loading potentially slow files.
5. **Robustness:** Added a `parse_size_string` utility that handles units like KB, MB, and GB.
6. **Test Reliability:** Updated `conftest.py` to ensure global configuration state is reset between tests.

---
*PR created automatically by Jules for task [3911311959123933662](https://jules.google.com/task/3911311959123933662) started by @RainRat*