### PR TITLE
Fix cumulative text wrapping in Results Treeview

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -747,8 +747,12 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
         col_widths = [tree.column(cid)['width'] for cid in tree['columns']]
 
         for iid in tree.get_children():
-            values = tree.item(iid)['values']
-            new_vals = get_wrapped_values(tree, values, measure=measure, col_widths=col_widths)
+            raw_values = _get_item_raw_values(iid)
+            if not raw_values:
+                continue
+
+            new_vals = get_wrapped_values(tree, raw_values, measure=measure, col_widths=col_widths)
+            new_vals.append(json.dumps(raw_values[:7]))
             tree.item(iid, values=new_vals)
 
 

--- a/tests/test_motion_handler.py
+++ b/tests/test_motion_handler.py
@@ -32,11 +32,16 @@ def test_motion_handler_updates_children(monkeypatch):
     # Mock adjust_newlines to return a predictable value
     monkeypatch.setattr(gptscan, "adjust_newlines", lambda text, width, measure=None: f"wrapped_{text}")
 
+    # Mock _get_item_raw_values
+    monkeypatch.setattr(gptscan, "_get_item_raw_values", lambda iid: ["long text that should wrap", "short"])
+
     # Call motion_handler with event=None
     gptscan.motion_handler(mock_tree, None)
 
-    # Verify tree.item(iid, values=...) was called with wrapped values
-    mock_tree.item.assert_called_with("iid1", values=["wrapped_long text that should wrap", "wrapped_short"])
+    # Verify tree.item(iid, values=...) was called with wrapped values and the hidden json cache
+    import json
+    expected_values = ["wrapped_long text that should wrap", "wrapped_short", json.dumps(["long text that should wrap", "short"])]
+    mock_tree.item.assert_called_with("iid1", values=expected_values)
 
 def test_motion_handler_ignores_non_separator_events():
     mock_tree = MagicMock()


### PR DESCRIPTION
* **What:** Modified the `motion_handler` function in `gptscan.py` to use original, un-wrapped data from the hidden `orig_json` column when recalculating text wrapping during column resizing. Updated `tests/test_motion_handler.py` to match this behavior.
* **Why:** Previously, `motion_handler` used the already-wrapped text from the Treeview's display cells, causing text to wrap further upon every resize ("cumulative wrapping"). By referencing the original raw data, the text can now correctly "unwrap" when a column is expanded or re-wrap accurately when it is shrunk. This improves UI readability and prevents text distortion. No breaking changes were introduced as existing functionality and the internal data cache are preserved.

---
*PR created automatically by Jules for task [7533011712327469528](https://jules.google.com/task/7533011712327469528) started by @RainRat*