### PR TITLE
Inline get_cli_command into copy_cli_command

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4152,14 +4152,8 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
         analyze_button.config(state="normal" if has_selection and ai_available else "disabled")
 
 
-def get_cli_command() -> str:
-    """Generate a CLI command equivalent to the current GUI settings.
-
-    Returns
-    -------
-    str
-        A string representing the `python gptscan.py ...` command.
-    """
+def copy_cli_command(event: Optional[tk.Event] = None) -> None:
+    """Copy the equivalent CLI command to the system clipboard."""
     cmd_parts = ["python", "gptscan.py"]
 
     # Target path
@@ -4195,12 +4189,7 @@ def get_cli_command() -> str:
         if Config.api_base:
             cmd_parts.extend(["--api-base", Config.api_base])
 
-    return " ".join(cmd_parts)
-
-
-def copy_cli_command(event: Optional[tk.Event] = None) -> None:
-    """Copy the equivalent CLI command to the system clipboard."""
-    cmd = get_cli_command()
+    cmd = " ".join(cmd_parts)
     if root:
         root.clipboard_clear()
         root.clipboard_append(cmd)

--- a/tests/test_copy_cli_command.py
+++ b/tests/test_copy_cli_command.py
@@ -1,10 +1,11 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from gptscan import get_cli_command, Config, deep_var, git_var, dry_var, all_var, gpt_var, textbox
+import gptscan
+from gptscan import Config, deep_var, git_var, dry_var, all_var, gpt_var, textbox
 
 @pytest.fixture
 def mock_gui_vars():
-    """Mock the Tkinter variables used by get_cli_command."""
+    """Mock the Tkinter variables used by copy_cli_command."""
     with patch('gptscan.deep_var', MagicMock()) as mock_deep, \
          patch('gptscan.git_var', MagicMock()) as mock_git, \
          patch('gptscan.dry_var', MagicMock()) as mock_dry, \
@@ -46,56 +47,65 @@ def reset_config():
     Config.api_base = orig_api_base
     Config.last_path = orig_last_path
 
-def test_get_cli_command_basic(mock_gui_vars):
-    command = get_cli_command()
-    assert command == "python gptscan.py /test/path --cli"
+def test_copy_cli_command_basic(mock_gui_vars):
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
 
-def test_get_cli_command_with_spaces_in_path(mock_gui_vars):
+def test_copy_cli_command_with_spaces_in_path(mock_gui_vars):
     mock_gui_vars['textbox'].get.return_value = "/path with spaces/script.py"
-    command = get_cli_command()
-    assert "python gptscan.py '/path with spaces/script.py' --cli" in command
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        assert "python gptscan.py '/path with spaces/script.py' --cli" in mock_root.clipboard_append.call_args[0][0]
 
-def test_get_cli_command_all_options(mock_gui_vars):
+def test_copy_cli_command_all_options(mock_gui_vars):
     mock_gui_vars['deep'].get.return_value = True
     mock_gui_vars['git'].get.return_value = True
     mock_gui_vars['dry'].get.return_value = True
     mock_gui_vars['all'].get.return_value = True
     Config.THRESHOLD = 75
 
-    command = get_cli_command()
-    assert "--deep" in command
-    assert "--git-changes" in command
-    assert "--dry-run" in command
-    assert "--show-all" in command
-    assert "--threshold 75" in command
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        command = mock_root.clipboard_append.call_args[0][0]
+        assert "--deep" in command
+        assert "--git-changes" in command
+        assert "--dry-run" in command
+        assert "--show-all" in command
+        assert "--threshold 75" in command
 
-def test_get_cli_command_ai_options(mock_gui_vars):
+def test_copy_cli_command_ai_options(mock_gui_vars):
     mock_gui_vars['gpt'].get.return_value = True
     Config.provider = "ollama"
     Config.model_name = "llama3.2"
     Config.api_base = "http://localhost:11434/v1"
 
-    command = get_cli_command()
-    assert "--use-gpt" in command
-    assert "--provider ollama" in command
-    assert "--model llama3.2" in command
-    assert "--api-base http://localhost:11434/v1" in command
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        command = mock_root.clipboard_append.call_args[0][0]
+        assert "--use-gpt" in command
+        assert "--provider ollama" in command
+        assert "--model llama3.2" in command
+        assert "--api-base http://localhost:11434/v1" in command
 
-def test_get_cli_command_default_provider_omitted(mock_gui_vars):
+def test_copy_cli_command_default_provider_omitted(mock_gui_vars):
     mock_gui_vars['gpt'].get.return_value = True
     Config.provider = "openai"
 
-    command = get_cli_command()
-    assert "--use-gpt" in command
-    assert "--provider" not in command
-
-def test_copy_cli_command(mock_gui_vars):
     with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        command = mock_root.clipboard_append.call_args[0][0]
+        assert "--use-gpt" in command
+        assert "--provider" not in command
+
+def test_copy_cli_command_ui_update(mock_gui_vars):
+    with patch('gptscan.root', MagicMock()), \
          patch('gptscan.update_status') as mock_update_status:
 
-        from gptscan import copy_cli_command
-        copy_cli_command()
-
-        mock_root.clipboard_clear.assert_called_once()
-        mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
+        gptscan.copy_cli_command()
         mock_update_status.assert_called_once_with("CLI command copied to clipboard.")


### PR DESCRIPTION
This PR addresses a case of premature abstraction by inlining the `get_cli_command` function into its only call site, `copy_cli_command`.

### What:
- Removed the separate `get_cli_command` function definition in `gptscan.py`.
- Moved the logic for generating the CLI command string directly into `copy_cli_command`.
- Updated `tests/test_copy_cli_command.py` to test `copy_cli_command` directly instead of the now-deleted helper.

### Why:
- **Reduces Complexity:** Eliminates a single-use private function, making the code more direct.
- **Maintainability:** Simplifies the script's internal API.
- **Non-breaking:** The external behavior of copying the CLI command to the clipboard remains identical. All existing tests pass.

---
*PR created automatically by Jules for task [1778704005703451760](https://jules.google.com/task/1778704005703451760) started by @RainRat*