### PR TITLE
[FEAT] HTML Script Extraction

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1841,7 +1841,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 5. Fallback: yield as a single snippet if it's a supported file type
+    # 5. Check for HTML script tags
+    if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Match <script> blocks
+            scripts = re.findall(r'<script\b[^>]*>(.*?)</script>', text, re.DOTALL | re.IGNORECASE)
+            for i, script in enumerate(scripts, 1):
+                if script.strip():
+                    yield (f"{name} [Script {i}]", script.encode('utf-8'))
+            return
+        except Exception:
+            pass
+
+    # 6. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content
@@ -1985,7 +1998,7 @@ def scan_files(
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
         # Check if it's a known container by extension or by content
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md')):
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml')):
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()
@@ -4741,7 +4754,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, Markdown files, and web links for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, Markdown files, HTML files, and web links for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ GPT Virus Scanner uses AI to find malicious code in script files.
 *   **Local Scan:** A fast, built-in model checks files on your computer.
 *   **AI Analysis:** If a file looks suspicious, the tool can send it to an AI service (like OpenAI) for a detailed report.
 
-**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell), Jupyter Notebooks (.ipynb), Markdown files (.md), and archives (.zip, .tar), but does not analyze compiled programs.
+**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell), Jupyter Notebooks (.ipynb), Markdown files (.md), HTML files (.html, .htm), and archives (.zip, .tar), but does not analyze compiled programs.
 
 ## Quick Start
 
@@ -73,6 +73,7 @@ The scanner finds scripts in four ways:
 *   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.
+*   **By HTML script tags:** It extracts and scans inline code from `<script>` tags in HTML files (`.html`, `.htm`, `.xhtml`).
 *   **By the first line of the file:** If a file does not have an extension, the tool checks the very first line to identify the script type (for example, a line starting with `#!/bin/bash`).
 *   **Remote scripts (via URL):** It can download and scan scripts directly from the web using HTTP or HTTPS links.
 

--- a/tests/test_html_extraction.py
+++ b/tests/test_html_extraction.py
@@ -1,0 +1,69 @@
+import pytest
+import gptscan
+from gptscan import unpack_content
+
+def test_unpack_content_html_extraction():
+    """Verify that <script> blocks are correctly extracted from HTML files."""
+    html_content = """
+    <html>
+        <head>
+            <script>
+                console.log('Script 1');
+            </script>
+        </head>
+        <body>
+            <h1>Test</h1>
+            <script type="text/javascript">
+                const x = 10;
+                alert(x);
+            </script>
+            <script>
+                // Empty script should be ignored if strip() is empty
+            </script>
+            <script>    </script>
+            <p>More text</p>
+            <SCRIPT>
+                console.log('Case insensitive');
+            </SCRIPT>
+        </body>
+    </html>
+    """
+    content_bytes = html_content.encode('utf-8')
+
+    # Test with .html extension
+    snippets = list(unpack_content("test.html", content_bytes))
+
+    assert len(snippets) == 4
+
+    assert snippets[0][0] == "test.html [Script 1]"
+    assert "console.log('Script 1');" in snippets[0][1].decode('utf-8')
+
+    assert snippets[1][0] == "test.html [Script 2]"
+    assert "const x = 10;" in snippets[1][1].decode('utf-8')
+    assert "alert(x);" in snippets[1][1].decode('utf-8')
+
+    assert snippets[2][0] == "test.html [Script 3]"
+    assert "// Empty script" in snippets[2][1].decode('utf-8')
+
+    assert snippets[3][0] == "test.html [Script 5]"
+    assert "console.log('Case insensitive');" in snippets[3][1].decode('utf-8')
+
+def test_unpack_content_html_no_scripts():
+    """Verify that HTML files with no scripts yield no snippets."""
+    html_content = "<html><body><h1>No Scripts</h1></body></html>"
+    content_bytes = html_content.encode('utf-8')
+
+    snippets = list(unpack_content("noscripts.html", content_bytes))
+    assert len(snippets) == 0
+
+def test_unpack_content_xhtml_extraction():
+    """Verify that <script> blocks are correctly extracted from XHTML files."""
+    xhtml_content = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <script>alert('XHTML');</script>
+    </html>
+    """
+    snippets = list(unpack_content("test.xhtml", xhtml_content.encode('utf-8')))
+    assert len(snippets) == 1
+    assert snippets[0][0] == "test.xhtml [Script 1]"
+    assert b"alert('XHTML');" in snippets[0][1]


### PR DESCRIPTION
This PR introduces automatic extraction of inline `<script>` blocks from HTML, HTM, and XHTML files. Previously, HTML files were treated as single text blocks, which was inconsistent with how the scanner handles Markdown and Jupyter Notebooks.

By treating HTML files as containers, the scanner can now isolate and analyze each script tag individually. This improves detection accuracy for web-based threats and provides clearer analysis results by focusing on the actual code snippets rather than the surrounding markup.

Key changes:
- Logic in `unpack_content` to identify and extract scripts using a case-insensitive regex.
- Configuration in `scan_files` to trigger unpacking for common HTML extensions.
- Documentation updates to inform users of the new capability.
- Unit tests covering various HTML/XHTML scenarios, including case sensitivity and empty script tags.

---
*PR created automatically by Jules for task [1873989035992208338](https://jules.google.com/task/1873989035992208338) started by @RainRat*