### PR TITLE
Inline redundant helper `_get_selected_row_values` into `_resolve_file_path`

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3414,22 +3414,17 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
     return [str(v).replace('\n', ' ') for v in values[:7]]
 
 
-def _get_selected_row_values() -> Optional[List[Any]]:
-    """Retrieve raw values from the currently selected Treeview row."""
-    if not tree:
-        return None
-    selection = tree.selection()
-    if not selection:
-        return None
-    return _get_item_raw_values(selection[0])
-
-
 def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True) -> Optional[str]:
     """Retrieve and optionally verify a file path from an event or direct argument."""
     if isinstance(event_or_path, str):
         file_path = event_or_path
     else:
-        values = _get_selected_row_values()
+        if not tree:
+            return None
+        selection = tree.selection()
+        if not selection:
+            return None
+        values = _get_item_raw_values(selection[0])
         if not values:
             return None
         file_path = str(values[0])

--- a/tests/test_markdown_coverage.py
+++ b/tests/test_markdown_coverage.py
@@ -140,10 +140,6 @@ def test_copy_as_markdown_no_selection(monkeypatch):
     # Should just return
     gptscan.copy_as_markdown()
 
-def test_get_selected_row_values_no_tree(monkeypatch):
-    """Test _get_selected_row_values when tree is None (covers line 1829)."""
-    monkeypatch.setattr(gptscan, 'tree', None, raising=False)
-    assert gptscan._get_selected_row_values() is None
 
 def test_export_results_sarif(monkeypatch, tmp_path):
     """Test export_results with .sarif extension (covers lines 1720-1722)."""

--- a/tests/test_raw_values_logic.py
+++ b/tests/test_raw_values_logic.py
@@ -64,19 +64,3 @@ def test_get_item_raw_values_empty_values(mock_tree):
     result = gptscan._get_item_raw_values("item1")
     assert result == []
 
-def test_get_selected_row_values(mock_tree, monkeypatch):
-    raw_data = ["path", "conf"]
-    # Mock _get_item_raw_values to return our data
-    monkeypatch.setattr(gptscan, "_get_item_raw_values", lambda iid: raw_data if iid == "sel1" else None)
-
-    mock_tree.selection.return_value = ("sel1",)
-
-    assert gptscan._get_selected_row_values() == raw_data
-
-    # Test no selection
-    mock_tree.selection.return_value = ()
-    assert gptscan._get_selected_row_values() is None
-
-def test_get_selected_row_values_no_tree(monkeypatch):
-    monkeypatch.setattr(gptscan, 'tree', None)
-    assert gptscan._get_selected_row_values() is None


### PR DESCRIPTION
This PR inlines the private helper function `_get_selected_row_values` into its single call site within `_resolve_file_path`. 

**What:** 
- Removed the definition of `_get_selected_row_values`.
- Inlined the logic for retrieving the raw values of the currently selected Treeview row directly into `_resolve_file_path`.
- Updated unit tests to remove direct testing of the deleted internal helper.

**Why:** 
- **Code Quality:** The helper function was a premature abstraction that added indirection without significant reuse or complexity management.
- **Maintainability:** Simplifies the code by placing selection logic directly in the function that uses it.
- **Safety:** Verified that `_get_selected_row_values` was only used in this one location and that the change is non-breaking via a full test suite run.

---
*PR created automatically by Jules for task [8156494417632391231](https://jules.google.com/task/8156494417632391231) started by @RainRat*