### PR TITLE
[DOCS] Correct script discovery method count in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Once your provider is ready, you must enable the feature when you run a scan:
 
 ## Supported Files
 
-The scanner finds scripts in four ways:
+The scanner finds scripts in several ways:
 *   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the "Supported Files" section in `readme.md`.
* **Why:** The previous text stated there were "four ways" to find scripts, but the list actually contains six methods (file type, archive content, Markdown blocks, HTML script tags, first line/shebang, and remote scripts via URL). Changing it to "several ways" ensures accuracy and simplifies future updates.

---
*PR created automatically by Jules for task [6471321700425381437](https://jules.google.com/task/6471321700425381437) started by @RainRat*