### PR TITLE
[FEAT] Add multi-target (batch) scanning support to the GUI

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "/some/path",
+    "last_path": "/some/repo",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,8 +12,10 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "/some/path",
         "/some/repo",
+        "/some/path",
+        "/repo1 /repo2",
+        "/path/1 '/path/2 with spaces'",
         "1",
         "2",
         "three"

--- a/gptscan.py
+++ b/gptscan.py
@@ -497,13 +497,20 @@ def bind_hover_message(widget: tk.Widget, message: str, label: Optional[ttk.Labe
     widget.bind("<Leave>", on_leave)
 
 
-def _set_scan_target(path: str) -> None:
+def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
     """Update the scan target textbox and set focus to the scan button."""
-    if path and textbox:
-        textbox.delete(0, tk.END)
-        textbox.insert(0, path)
-        if scan_button:
-            scan_button.focus_set()
+    if not path or not textbox:
+        return
+
+    if isinstance(path, str):
+        display_path = shlex.quote(path)
+    else:
+        display_path = shlex.join(list(path))
+
+    textbox.delete(0, tk.END)
+    textbox.insert(0, display_path)
+    if scan_button:
+        scan_button.focus_set()
 
 
 def browse_dir_click() -> None:
@@ -544,11 +551,12 @@ def browse_file_click() -> None:
         ("Script files", ";".join([f"*{e}" for e in ext_list])),
         ("All files", "*.*")
     ]
-    file_selected = filedialog.askopenfilename(
-        title="Select File to Scan",
+    files_selected = filedialog.askopenfilenames(
+        title="Select File(s) to Scan",
         filetypes=file_types
     )
-    _set_scan_target(file_selected)
+    if files_selected:
+        _set_scan_target(files_selected)
 
 
 class AsyncRateLimiter:
@@ -1296,13 +1304,23 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
         messagebox.showerror("Missing Selection", "Please select a file or folder to scan.")
         return
 
-    scan_targets: Union[str, List[str]] = scan_path if scan_path else []
-    if scan_path and git_var.get():
-        git_files = get_git_changed_files(scan_path)
-        if not git_files:
-            messagebox.showinfo("Git Scan", "No git changes detected in the selected directory.")
+    try:
+        scan_targets: List[str] = shlex.split(scan_path) if scan_path else []
+    except ValueError as e:
+        messagebox.showerror("Invalid Input", f"Could not parse scan paths: {e}\nCheck for unclosed quotes.")
+        return
+
+    if scan_targets and git_var.get():
+        all_git_files = []
+        for target in scan_targets:
+            git_files = get_git_changed_files(target)
+            if git_files:
+                all_git_files.extend(git_files)
+
+        if not all_git_files:
+            messagebox.showinfo("Git Scan", "No git changes detected in the selected locations.")
             return
-        scan_targets = git_files
+        scan_targets = all_git_files
 
     if not dry_var.get() and not os.path.exists('scripts.h5'):
         messagebox.showerror("Model Not Found", "The scanner cannot find 'scripts.h5'. This file is required to run local scans.")
@@ -4168,10 +4186,12 @@ def copy_cli_command(event: Optional[tk.Event] = None) -> None:
     """Copy the equivalent CLI command to the system clipboard."""
     cmd_parts = ["python", "gptscan.py"]
 
-    # Target path
-    target = textbox.get() if textbox else Config.last_path
-    if target:
-        cmd_parts.append(shlex.quote(target))
+    # Target paths
+    target_str = textbox.get() if textbox else Config.last_path
+    if target_str:
+        targets = shlex.split(target_str)
+        for t in targets:
+            cmd_parts.append(shlex.quote(t))
 
     cmd_parts.append("--cli")
 
@@ -4331,11 +4351,12 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     textbox.grid(row=0, column=1, sticky="ew", padx=5)
     textbox.bind('<Return>', lambda event: button_click())
     textbox.focus_set()
+    bind_hover_message(textbox, "Enter one or more file or folder paths to scan. Use spaces to separate multiple paths.")
 
     root.bind('<Escape>', lambda event: cancel_scan())
     select_file_btn = ttk.Button(input_frame, text="File...", command=browse_file_click)
     select_file_btn.grid(row=0, column=2, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_file_btn, "Select a single script or Markdown file to scan.")
+    bind_hover_message(select_file_btn, "Select one or more script or Markdown files to scan.")
 
     select_dir_btn = ttk.Button(input_frame, text="Folder...", command=browse_dir_click)
     select_dir_btn.grid(row=0, column=3, sticky="e", padx=(5, 0), ipady=5)

--- a/readme.md
+++ b/readme.md
@@ -97,8 +97,8 @@ You can customize the scanner using these files in the same folder:
 Run `python gptscan.py` to open the GUI.
 
 #### Scan Input
-*   **Path to scan:** Type a path or choose from the dropdown. It remembers your last 10 locations.
-*   **File...:** Select a single file to scan.
+*   **Path to scan:** Type one or more paths (files or folders) separated by spaces or choose from the dropdown. It remembers your last 10 locations.
+*   **File...:** Select one or more files to scan.
 *   **Folder...:** Select a whole directory to scan.
 *   **URL...:** Scan a script, Markdown file, or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Clipboard:** Scan code currently in your clipboard.

--- a/tests/test_copy_cli_command.py
+++ b/tests/test_copy_cli_command.py
@@ -54,7 +54,8 @@ def test_copy_cli_command_basic(mock_gui_vars):
         mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
 
 def test_copy_cli_command_with_spaces_in_path(mock_gui_vars):
-    mock_gui_vars['textbox'].get.return_value = "/path with spaces/script.py"
+    # In the new multi-target version, paths with spaces must be quoted in the textbox
+    mock_gui_vars['textbox'].get.return_value = "'/path with spaces/script.py'"
     with patch('gptscan.root', MagicMock()) as mock_root, \
          patch('gptscan.update_status'):
         gptscan.copy_cli_command()

--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -80,5 +80,5 @@ def test_button_click_with_git_changes_no_changes(monkeypatch):
 
     # Assert
     mock_get_git.assert_called_once_with("/some/repo")
-    mock_msgbox.showinfo.assert_called_once_with("Git Scan", "No git changes detected in the selected directory.")
+    mock_msgbox.showinfo.assert_called_once_with("Git Scan", "No git changes detected in the selected locations.")
     mock_thread.assert_not_called()

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -44,7 +44,7 @@ def test_browse_file_click_cancels(monkeypatch):
     monkeypatch.setattr(gptscan, 'textbox', mock_textbox, raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: ())
 
     gptscan.browse_file_click()
 
@@ -56,7 +56,7 @@ def test_browse_file_click_selects_file(monkeypatch):
     mock_scan_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '/path/to/file.py')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: ('/path/to/file.py',))
 
     gptscan.browse_file_click()
 
@@ -220,7 +220,7 @@ def test_button_click_starts_scan(monkeypatch):
     assert kwargs['target'] == gptscan.run_scan
 
     args = kwargs['args']
-    assert args[0] == "/some/path"
+    assert args[0] == ["/some/path"]
     assert args[1] is True # deep
     assert args[2] is False # all
     assert args[3] is True # gpt

--- a/tests/test_multi_target_gui.py
+++ b/tests/test_multi_target_gui.py
@@ -1,0 +1,107 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import shlex
+import os
+
+@pytest.fixture
+def mock_gui_vars():
+    with patch('gptscan.textbox', MagicMock()) as mock_textbox, \
+         patch('gptscan.git_var', MagicMock()) as mock_git, \
+         patch('gptscan.dry_var', MagicMock()) as mock_dry, \
+         patch('gptscan.deep_var', MagicMock()) as mock_deep, \
+         patch('gptscan.all_var', MagicMock()) as mock_all, \
+         patch('gptscan.gpt_var', MagicMock()) as mock_gpt:
+
+        mock_textbox.get.return_value = ""
+        mock_git.get.return_value = False
+        mock_dry.get.return_value = False
+        mock_deep.get.return_value = False
+        mock_all.get.return_value = False
+        mock_gpt.get.return_value = False
+
+        yield {
+            'textbox': mock_textbox,
+            'git': mock_git,
+            'dry': mock_dry,
+            'deep': mock_deep,
+            'all': mock_all,
+            'gpt': mock_gpt
+        }
+
+def test_set_scan_target_multi():
+    mock_textbox = MagicMock()
+    with patch('gptscan.textbox', mock_textbox), \
+         patch('gptscan.scan_button', MagicMock()):
+
+        # Test single path
+        gptscan._set_scan_target("/path/to/file")
+        mock_textbox.insert.assert_called_with(0, "/path/to/file")
+
+        mock_textbox.reset_mock()
+
+        # Test single path with spaces
+        gptscan._set_scan_target("/path with spaces/folder")
+        mock_textbox.insert.assert_called_with(0, "'/path with spaces/folder'")
+
+        mock_textbox.reset_mock()
+
+        # Test multiple paths
+        paths = ["/path/one", "/path/two with spaces"]
+        gptscan._set_scan_target(paths)
+        expected = shlex.join(paths)
+        mock_textbox.insert.assert_called_with(0, expected)
+
+def test_button_click_multi_target_parsing(mock_gui_vars):
+    paths = ["/path/1", "/path/2 with spaces"]
+    mock_gui_vars['textbox'].get.return_value = shlex.join(paths)
+
+    with patch('gptscan.run_scan'), \
+         patch('gptscan.clear_results'), \
+         patch('gptscan.set_scanning_state'), \
+         patch('gptscan.update_status'), \
+         patch('gptscan.threading.Thread') as mock_thread:
+
+        gptscan.button_click()
+
+        # Verify scan_targets passed to run_scan (via thread args)
+        args, kwargs = mock_thread.call_args
+        # kwargs is empty, args is (run_scan, scan_args)
+        # scan_args is a tuple, scan_args[0] is scan_targets
+        scan_args = kwargs.get('args') or args[1]
+        assert scan_args[0] == paths
+
+def test_copy_cli_command_multi_target(mock_gui_vars):
+    paths = ["/path/1", "/path/2"]
+    mock_gui_vars['textbox'].get.return_value = shlex.join(paths)
+
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        command = mock_root.clipboard_append.call_args[0][0]
+        assert "/path/1" in command
+        assert "/path/2" in command
+        # Ensure they are separate arguments
+        parts = shlex.split(command)
+        assert "/path/1" in parts
+        assert "/path/2" in parts
+
+def test_button_click_git_multi_target(mock_gui_vars):
+    paths = ["/repo1", "/repo2"]
+    mock_gui_vars['textbox'].get.return_value = shlex.join(paths)
+    mock_gui_vars['git'].get.return_value = True
+
+    with patch('gptscan.get_git_changed_files') as mock_get_git, \
+         patch('gptscan.threading.Thread') as mock_thread, \
+         patch('gptscan.clear_results'), \
+         patch('gptscan.set_scanning_state'), \
+         patch('gptscan.update_status'):
+
+        mock_get_git.side_effect = [["/repo1/a.py"], ["/repo2/b.py"]]
+
+        gptscan.button_click()
+
+        assert mock_get_git.call_count == 2
+        args, kwargs = mock_thread.call_args
+        scan_args = kwargs.get('args') or args[1]
+        assert set(scan_args[0]) == {"/repo1/a.py", "/repo2/b.py"}


### PR DESCRIPTION
### [FEAT] Add multi-target (batch) scanning support to the GUI

#### What:
Transitioned the GUI from a single-target scanner to a multi-target (batch) scanner. Users can now select multiple files via the "File..." button, manually enter multiple space-separated paths in the input field, and scan changed files across multiple Git repositories simultaneously. The "Copy CLI Command" feature has been updated to generate multi-argument commands.

#### Why:
The underlying scanning logic already supported multiple targets (via the `scan_targets` list), but the GUI was restricted to a single path string. Implementing batching support follows the logical evolution of the tool, allowing users to efficiently scan multiple folders or specific files across different locations in one pass. This creates immediate utility for developers managing multiple script repositories or analyzing a set of suspicious downloads.

#### Key Changes:
- **GUI Input:** Updated `_set_scan_target` to robustly handle multiple paths using `shlex.join` and `shlex.quote`. The "File..." browser now allows multiple selection.
- **Scan Logic:** Updated `button_click` to parse the input textbox using `shlex.split`, enabling support for multiple space-separated, quoted targets.
- **Git Integration:** Modified the Git change detection to iterate through all parsed targets, aggregating changed and untracked files from each location.
- **CLI Compatibility:** Updated `copy_cli_command` to correctly parse and quote multiple targets from the UI when generating the command-line equivalent.
- **UX & Documentation:** Improved hover messages for the path entry and file browser to explain multi-target support. Updated `readme.md` to reflect the new functionality.
- **Testing:** Introduced `tests/test_multi_target_gui.py` to verify the new path parsing and aggregation logic, and updated existing GUI tests (`tests/test_gui_logic.py`, `tests/test_copy_cli_command.py`) to handle the new batch behavior.

---
*PR created automatically by Jules for task [10190930290970296057](https://jules.google.com/task/10190930290970296057) started by @RainRat*