### PR TITLE
[DOCS] Fix script discovery count in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Once your provider is ready, you must enable the feature when you run a scan:
 
 ## Supported Files
 
-The scanner finds scripts in four ways:
+The scanner finds scripts in several ways:
 *   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** The "Supported Files" section in `readme.md`.
* **Why:** Corrected a factual error where the text claimed there were four script discovery methods, but the list actually contained six distinct methods. Using "several" ensures the documentation remains accurate even if more methods are added in the future.

---
*PR created automatically by Jules for task [7955503441679743013](https://jules.google.com/task/7955503441679743013) started by @RainRat*