### PR TITLE
[UI/UX] Enable multi-target selection in GUI and CLI

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "/some/path",
+    "last_path": ".",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,10 +12,6 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "/some/path",
-        "/some/repo",
-        "1",
-        "2",
-        "three"
+        "."
     ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -497,19 +497,34 @@ def bind_hover_message(widget: tk.Widget, message: str, label: Optional[ttk.Labe
     widget.bind("<Leave>", on_leave)
 
 
-def _set_scan_target(path: str) -> None:
-    """Update the scan target textbox and set focus to the scan button."""
-    if path and textbox:
-        textbox.delete(0, tk.END)
-        textbox.insert(0, path)
-        if scan_button:
-            scan_button.focus_set()
+def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
+    """Update the scan target textbox and set focus to the scan button.
+
+    Args:
+        path: A single path string, or an iterable of path strings.
+    """
+    if not path or not textbox:
+        return
+
+    # Handle multiple paths or a single path string
+    if isinstance(path, (list, tuple)):
+        # Join multiple targets with appropriate quoting
+        formatted_path = shlex.join(path)
+    else:
+        # For a single path, use quote if it's not a list, for safety
+        formatted_path = shlex.quote(str(path))
+
+    textbox.delete(0, tk.END)
+    textbox.insert(0, formatted_path)
+    if scan_button:
+        scan_button.focus_set()
 
 
 def browse_dir_click() -> None:
     """Handle the directory selection dialog and populate the textbox."""
     folder_selected = filedialog.askdirectory()
-    _set_scan_target(folder_selected)
+    if folder_selected:
+        _set_scan_target(folder_selected)
 
 
 def select_url_click() -> None:
@@ -544,11 +559,12 @@ def browse_file_click() -> None:
         ("Script files", ";".join([f"*{e}" for e in ext_list])),
         ("All files", "*.*")
     ]
-    file_selected = filedialog.askopenfilename(
-        title="Select File to Scan",
+    files_selected = filedialog.askopenfilenames(
+        title="Select File(s) to Scan",
         filetypes=file_types
     )
-    _set_scan_target(file_selected)
+    if files_selected:
+        _set_scan_target(files_selected)
 
 
 class AsyncRateLimiter:
@@ -1296,13 +1312,22 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
         messagebox.showerror("Missing Selection", "Please select a file or folder to scan.")
         return
 
-    scan_targets: Union[str, List[str]] = scan_path if scan_path else []
-    if scan_path and git_var.get():
-        git_files = get_git_changed_files(scan_path)
-        if not git_files:
+    try:
+        # Use shlex.split to support multi-target selection with quoting
+        scan_targets = shlex.split(scan_path) if scan_path else []
+    except ValueError as e:
+        messagebox.showerror("Selection Error", f"Malformed path selection: {e}")
+        return
+
+    if scan_targets and git_var.get():
+        all_git_files = []
+        for target in scan_targets:
+            all_git_files.extend(get_git_changed_files(target))
+
+        if not all_git_files:
             messagebox.showinfo("Git Scan", "No git changes detected in the selected directory.")
             return
-        scan_targets = git_files
+        scan_targets = all_git_files
 
     if not dry_var.get() and not os.path.exists('scripts.h5'):
         messagebox.showerror("Model Not Found", "The scanner cannot find 'scripts.h5'. This file is required to run local scans.")
@@ -4168,10 +4193,17 @@ def copy_cli_command(event: Optional[tk.Event] = None) -> None:
     """Copy the equivalent CLI command to the system clipboard."""
     cmd_parts = ["python", "gptscan.py"]
 
-    # Target path
-    target = textbox.get() if textbox else Config.last_path
-    if target:
-        cmd_parts.append(shlex.quote(target))
+    # Target path(s)
+    raw_target = textbox.get() if textbox else Config.last_path
+    if raw_target:
+        try:
+            # Parse possible multiple targets from the GUI textbox
+            targets = shlex.split(raw_target)
+            for t in targets:
+                cmd_parts.append(shlex.quote(t))
+        except ValueError:
+            # Fallback to quoting the raw string if parsing fails
+            cmd_parts.append(shlex.quote(raw_target))
 
     cmd_parts.append("--cli")
 
@@ -4335,7 +4367,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Escape>', lambda event: cancel_scan())
     select_file_btn = ttk.Button(input_frame, text="File...", command=browse_file_click)
     select_file_btn.grid(row=0, column=2, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_file_btn, "Select a single script or Markdown file to scan.")
+    bind_hover_message(select_file_btn, "Select one or more script or Markdown files to scan.")
 
     select_dir_btn = ttk.Button(input_frame, text="Folder...", command=browse_dir_click)
     select_dir_btn.grid(row=0, column=3, sticky="e", padx=(5, 0), ipady=5)
@@ -4343,7 +4375,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     select_url_btn = ttk.Button(input_frame, text="URL...", command=select_url_click)
     select_url_btn.grid(row=0, column=4, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_url_btn, "Scan a script, Markdown file, or archive from a remote URL.")
+    bind_hover_message(select_url_btn, "Scan a script, Markdown file, or archive from a remote URL. Multiple targets can be entered manually in the textbox.")
 
     select_clipboard_btn = ttk.Button(input_frame, text="Clipboard", command=scan_clipboard_click)
     select_clipboard_btn.grid(row=0, column=5, sticky="e", padx=(5, 0), ipady=5)
@@ -4914,12 +4946,16 @@ def main():
                     scan_targets.append(line)
 
         if args.git_changes:
-            # Use the specified target as the git root, or current directory if none.
-            git_root = scan_target or "."
-            git_files = get_git_changed_files(git_root)
+            # Use specified targets as git roots, or current directory if none.
+            git_roots = scan_targets if scan_targets else ["."]
+            git_files = []
+            for root_dir in git_roots:
+                git_files.extend(get_git_changed_files(root_dir))
+
             if not git_files:
-                print(f"No git changes detected or '{git_root}' is not a git repository.", file=sys.stderr)
-            scan_targets.extend(git_files)
+                print("No git changes detected in provided targets.", file=sys.stderr)
+            # Scan only changed files
+            scan_targets = git_files
 
         if not scan_targets and not args.git_changes:
             # Default to current directory if no targets provided and NOT using git-changes

--- a/tests/test_copy_cli_command.py
+++ b/tests/test_copy_cli_command.py
@@ -54,7 +54,8 @@ def test_copy_cli_command_basic(mock_gui_vars):
         mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
 
 def test_copy_cli_command_with_spaces_in_path(mock_gui_vars):
-    mock_gui_vars['textbox'].get.return_value = "/path with spaces/script.py"
+    # In multi-target mode, paths with spaces must be quoted in the textbox
+    mock_gui_vars['textbox'].get.return_value = "'/path with spaces/script.py'"
     with patch('gptscan.root', MagicMock()) as mock_root, \
          patch('gptscan.update_status'):
         gptscan.copy_cli_command()

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -44,7 +44,7 @@ def test_browse_file_click_cancels(monkeypatch):
     monkeypatch.setattr(gptscan, 'textbox', mock_textbox, raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: [])
 
     gptscan.browse_file_click()
 
@@ -56,7 +56,7 @@ def test_browse_file_click_selects_file(monkeypatch):
     mock_scan_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '/path/to/file.py')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: ['/path/to/file.py'])
 
     gptscan.browse_file_click()
 
@@ -220,7 +220,7 @@ def test_button_click_starts_scan(monkeypatch):
     assert kwargs['target'] == gptscan.run_scan
 
     args = kwargs['args']
-    assert args[0] == "/some/path"
+    assert args[0] == ["/some/path"]
     assert args[1] is True # deep
     assert args[2] is False # all
     assert args[3] is True # gpt

--- a/tests/test_multi_target_gui.py
+++ b/tests/test_multi_target_gui.py
@@ -1,0 +1,84 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+from gptscan import _set_scan_target, button_click, copy_cli_command
+import shlex
+
+@pytest.fixture
+def mock_gui_globals():
+    """Mock the global GUI variables in gptscan."""
+    with patch('gptscan.textbox', MagicMock()) as mock_textbox, \
+         patch('gptscan.scan_button', MagicMock()) as mock_scan_btn, \
+         patch('gptscan.git_var', MagicMock()) as mock_git_var, \
+         patch('gptscan.root', MagicMock()) as mock_root:
+
+        # Set default values for mocks
+        mock_git_var.get.return_value = False
+
+        yield {
+            'textbox': mock_textbox,
+            'scan_button': mock_scan_btn,
+            'git_var': mock_git_var,
+            'root': mock_root
+        }
+
+def test_set_scan_target_multi(mock_gui_globals):
+    """Verify that multiple paths are correctly joined in the textbox."""
+    paths = ["file1.py", "/path with spaces/file2.js"]
+    _set_scan_target(paths)
+
+    # Verify shlex.join was used to format the paths
+    expected = shlex.join(paths)
+    mock_gui_globals['textbox'].insert.assert_called_with(0, expected)
+
+def test_button_click_parsing(mock_gui_globals):
+    """Verify that button_click correctly parses multiple targets using shlex.split."""
+    targets = ["file1.py", "file2.js"]
+    raw_path = shlex.join(targets)
+    mock_gui_globals['textbox'].get.return_value = raw_path
+
+    with patch('gptscan.run_scan') as mock_run_scan, \
+         patch('gptscan.clear_results'), \
+         patch('gptscan.set_scanning_state'), \
+         patch('gptscan.update_status'), \
+         patch('gptscan.dry_var', MagicMock(get=lambda: True)), \
+         patch('gptscan.deep_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.all_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.gpt_var', MagicMock(get=lambda: False)):
+
+        button_click()
+
+        # The first argument to run_scan should be the list of parsed targets
+        args, _ = mock_run_scan.call_args
+        assert args[0] == targets
+
+def test_copy_cli_command_multi_target(mock_gui_globals):
+    """Verify that copy_cli_command handles multiple targets correctly."""
+    targets = ["file1.py", "/path with spaces/file2.js"]
+    raw_path = shlex.join(targets)
+    mock_gui_globals['textbox'].get.return_value = raw_path
+
+    # Mocking deep_var and other globals required for copy_cli_command
+    with patch('gptscan.deep_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.git_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.dry_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.all_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.scan_all_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.gpt_var', MagicMock(get=lambda: False)), \
+         patch('gptscan.update_status'):
+
+        copy_cli_command()
+
+        # Verify CLI command includes individually quoted targets
+        command = mock_gui_globals['root'].clipboard_append.call_args[0][0]
+        assert "python gptscan.py file1.py '/path with spaces/file2.js' --cli" in command
+
+def test_button_click_malformed_input(mock_gui_globals):
+    """Verify that malformed input is handled with an error message."""
+    mock_gui_globals['textbox'].get.return_value = 'file1.py "unclosed quote'
+
+    with patch('gptscan.messagebox.showerror') as mock_error, \
+         patch('gptscan.clear_results'):
+        button_click()
+        mock_error.assert_called_once()
+        assert "Malformed path selection" in mock_error.call_args[0][1]


### PR DESCRIPTION
This PR implements multi-target selection support in the GPT Virus Scanner, reducing friction for users who need to scan multiple disparate files or folders simultaneously.

Previously, the GUI only supported selecting a single file or directory at a time. This improvement upgrades the file picker, adds robust path parsing for the target textbox, and ensures that the Git scanning logic and CLI command generation correctly handle multiple inputs.

Changes include:
- `browse_file_click`: Switched to `filedialog.askopenfilenames`.
- `_set_scan_target`: Now joins multiple paths using `shlex.join`.
- `button_click`: Parses input via `shlex.split` and iterates through all targets for Git change detection.
- `copy_cli_command`: Correctly handles and quotes multiple targets in the generated command.
- Updated tooltips for the "File..." and "URL..." buttons.
- New unit tests in `tests/test_multi_target_gui.py` and updates to existing GUI and CLI tests.

---
*PR created automatically by Jules for task [9157172577481832745](https://jules.google.com/task/9157172577481832745) started by @RainRat*