### PR TITLE
[FEAT] Multi-target scanning support in GUI

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "/some/path",
+    "last_path": "dir1 dir2",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,6 +12,8 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
+        "dir1 dir2",
+        "'/path one' '/path two'",
         "/some/path",
         "/some/repo",
         "1",

--- a/gptscan.py
+++ b/gptscan.py
@@ -497,13 +497,20 @@ def bind_hover_message(widget: tk.Widget, message: str, label: Optional[ttk.Labe
     widget.bind("<Leave>", on_leave)
 
 
-def _set_scan_target(path: str) -> None:
+def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
     """Update the scan target textbox and set focus to the scan button."""
-    if path and textbox:
-        textbox.delete(0, tk.END)
-        textbox.insert(0, path)
-        if scan_button:
-            scan_button.focus_set()
+    if not path or not textbox:
+        return
+
+    if isinstance(path, str):
+        target = shlex.quote(path)
+    else:
+        target = shlex.join(path)
+
+    textbox.delete(0, tk.END)
+    textbox.insert(0, target)
+    if scan_button:
+        scan_button.focus_set()
 
 
 def browse_dir_click() -> None:
@@ -544,11 +551,12 @@ def browse_file_click() -> None:
         ("Script files", ";".join([f"*{e}" for e in ext_list])),
         ("All files", "*.*")
     ]
-    file_selected = filedialog.askopenfilename(
-        title="Select File to Scan",
+    files_selected = filedialog.askopenfilenames(
+        title="Select File(s) to Scan",
         filetypes=file_types
     )
-    _set_scan_target(file_selected)
+    if files_selected:
+        _set_scan_target(files_selected)
 
 
 class AsyncRateLimiter:
@@ -1296,13 +1304,23 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
         messagebox.showerror("Missing Selection", "Please select a file or folder to scan.")
         return
 
-    scan_targets: Union[str, List[str]] = scan_path if scan_path else []
-    if scan_path and git_var.get():
-        git_files = get_git_changed_files(scan_path)
-        if not git_files:
-            messagebox.showinfo("Git Scan", "No git changes detected in the selected directory.")
+    try:
+        scan_targets = shlex.split(scan_path) if scan_path else []
+    except ValueError as e:
+        messagebox.showerror("Input Error", f"Invalid input format: {e}")
+        return
+
+    if scan_targets and git_var.get():
+        all_git_files = []
+        for target in scan_targets:
+            git_files = get_git_changed_files(target)
+            if git_files:
+                all_git_files.extend(git_files)
+
+        if not all_git_files:
+            messagebox.showinfo("Git Scan", "No git changes detected in the selected targets.")
             return
-        scan_targets = git_files
+        scan_targets = all_git_files
 
     if not dry_var.get() and not os.path.exists('scripts.h5'):
         messagebox.showerror("Model Not Found", "The scanner cannot find 'scripts.h5'. This file is required to run local scans.")
@@ -4169,9 +4187,18 @@ def copy_cli_command(event: Optional[tk.Event] = None) -> None:
     cmd_parts = ["python", "gptscan.py"]
 
     # Target path
-    target = textbox.get() if textbox else Config.last_path
-    if target:
-        cmd_parts.append(shlex.quote(target))
+    target_str = textbox.get() if textbox else Config.last_path
+    if target_str:
+        try:
+            targets = shlex.split(target_str)
+            if targets:
+                for t in targets:
+                    cmd_parts.append(shlex.quote(t))
+            else:
+                cmd_parts.append(shlex.quote(target_str))
+        except ValueError:
+            # Fallback to single quote if splitting fails
+            cmd_parts.append(shlex.quote(target_str))
 
     cmd_parts.append("--cli")
 
@@ -4335,7 +4362,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Escape>', lambda event: cancel_scan())
     select_file_btn = ttk.Button(input_frame, text="File...", command=browse_file_click)
     select_file_btn.grid(row=0, column=2, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_file_btn, "Select a single script or Markdown file to scan.")
+    bind_hover_message(select_file_btn, "Select one or more scripts or Markdown files to scan.")
 
     select_dir_btn = ttk.Button(input_frame, text="Folder...", command=browse_dir_click)
     select_dir_btn.grid(row=0, column=3, sticky="e", padx=(5, 0), ipady=5)
@@ -4343,7 +4370,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     select_url_btn = ttk.Button(input_frame, text="URL...", command=select_url_click)
     select_url_btn.grid(row=0, column=4, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_url_btn, "Scan a script, Markdown file, or archive from a remote URL.")
+    bind_hover_message(select_url_btn, "Scan a script, Markdown file, or archive from a remote URL. You can enter multiple targets separated by spaces.")
 
     select_clipboard_btn = ttk.Button(input_frame, text="Clipboard", command=scan_clipboard_click)
     select_clipboard_btn.grid(row=0, column=5, sticky="e", padx=(5, 0), ipady=5)

--- a/tests/test_copy_cli_command.py
+++ b/tests/test_copy_cli_command.py
@@ -53,8 +53,16 @@ def test_copy_cli_command_basic(mock_gui_vars):
         gptscan.copy_cli_command()
         mock_root.clipboard_append.assert_called_once_with("python gptscan.py /test/path --cli")
 
+def test_copy_cli_command_multi_target(mock_gui_vars):
+    mock_gui_vars['textbox'].get.return_value = "/path1 /path2"
+    with patch('gptscan.root', MagicMock()) as mock_root, \
+         patch('gptscan.update_status'):
+        gptscan.copy_cli_command()
+        command = mock_root.clipboard_append.call_args[0][0]
+        assert "python gptscan.py /path1 /path2 --cli" in command
+
 def test_copy_cli_command_with_spaces_in_path(mock_gui_vars):
-    mock_gui_vars['textbox'].get.return_value = "/path with spaces/script.py"
+    mock_gui_vars['textbox'].get.return_value = "'/path with spaces/script.py'"
     with patch('gptscan.root', MagicMock()) as mock_root, \
          patch('gptscan.update_status'):
         gptscan.copy_cli_command()

--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -80,5 +80,5 @@ def test_button_click_with_git_changes_no_changes(monkeypatch):
 
     # Assert
     mock_get_git.assert_called_once_with("/some/repo")
-    mock_msgbox.showinfo.assert_called_once_with("Git Scan", "No git changes detected in the selected directory.")
+    mock_msgbox.showinfo.assert_called_once_with("Git Scan", "No git changes detected in the selected targets.")
     mock_thread.assert_not_called()

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -44,7 +44,7 @@ def test_browse_file_click_cancels(monkeypatch):
     monkeypatch.setattr(gptscan, 'textbox', mock_textbox, raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: ())
 
     gptscan.browse_file_click()
 
@@ -56,7 +56,7 @@ def test_browse_file_click_selects_file(monkeypatch):
     mock_scan_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilename', lambda **kwargs: '/path/to/file.py')
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **kwargs: ('/path/to/file.py',))
 
     gptscan.browse_file_click()
 
@@ -220,7 +220,7 @@ def test_button_click_starts_scan(monkeypatch):
     assert kwargs['target'] == gptscan.run_scan
 
     args = kwargs['args']
-    assert args[0] == "/some/path"
+    assert args[0] == ["/some/path"]
     assert args[1] is True # deep
     assert args[2] is False # all
     assert args[3] is True # gpt

--- a/tests/test_multi_target_gui.py
+++ b/tests/test_multi_target_gui.py
@@ -1,0 +1,115 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import shlex
+
+def test_set_scan_target_multi():
+    with patch('gptscan.textbox') as mock_textbox, \
+         patch('gptscan.scan_button') as mock_button:
+        # Test single path
+        gptscan._set_scan_target("/path/to/file")
+        mock_textbox.delete.assert_called_with(0, gptscan.tk.END)
+        mock_textbox.insert.assert_called_with(0, shlex.quote("/path/to/file"))
+
+        # Test multiple paths
+        gptscan._set_scan_target(["/path one", "/path two"])
+        mock_textbox.insert.assert_called_with(0, shlex.join(["/path one", "/path two"]))
+
+def test_button_click_multi_target():
+    with patch('gptscan.textbox') as mock_textbox, \
+         patch('gptscan.git_var') as mock_git, \
+         patch('gptscan.dry_var') as mock_dry, \
+         patch('gptscan.deep_var') as mock_deep, \
+         patch('gptscan.all_var') as mock_all, \
+         patch('gptscan.gpt_var') as mock_gpt, \
+         patch('gptscan.threading.Thread') as mock_thread, \
+         patch('gptscan.os.path.exists', return_value=True), \
+         patch('gptscan.set_scanning_state'), \
+         patch('gptscan.update_status'), \
+         patch('gptscan.clear_results'):
+
+        mock_textbox.get.return_value = "'/path one' '/path two'"
+        mock_git.get.return_value = False
+        mock_dry.get.return_value = False
+        mock_deep.get.return_value = False
+        mock_all.get.return_value = False
+        mock_gpt.get.return_value = False
+        gptscan.current_cancel_event = None
+
+        gptscan.button_click()
+
+        # Check if run_scan was called with the split targets
+        args, kwargs = mock_thread.call_args
+        scan_args = kwargs.get('args') or args[0] # target, deep, show_all, use_gpt, cancel_event, ...
+        assert scan_args[0] == ["/path one", "/path two"]
+
+def test_button_click_invalid_format():
+    with patch('gptscan.textbox') as mock_textbox, \
+         patch('gptscan.messagebox.showerror') as mock_error, \
+         patch('gptscan.clear_results'):
+
+        mock_textbox.get.return_value = "'unclosed quote"
+        gptscan.current_cancel_event = None
+
+        gptscan.button_click()
+        mock_error.assert_called_once()
+        assert "Input Error" in mock_error.call_args[0][0]
+
+def test_copy_cli_command_multi():
+    with patch('gptscan.textbox') as mock_textbox, \
+         patch('gptscan.root') as mock_root, \
+         patch('gptscan.Config') as mock_config, \
+         patch('gptscan.deep_var') as mock_deep, \
+         patch('gptscan.git_var') as mock_git, \
+         patch('gptscan.dry_var') as mock_dry, \
+         patch('gptscan.all_var') as mock_all, \
+         patch('gptscan.scan_all_var') as mock_scan_all, \
+         patch('gptscan.gpt_var') as mock_gpt:
+
+        mock_textbox.get.return_value = "target1 \"target two\""
+        mock_config.THRESHOLD = 50
+        mock_config.provider = "openai"
+        mock_deep.get.return_value = False
+        mock_git.get.return_value = False
+        mock_dry.get.return_value = False
+        mock_all.get.return_value = False
+        mock_scan_all.get.return_value = False
+        mock_gpt.get.return_value = False
+
+        gptscan.copy_cli_command()
+
+        # Verify the command in clipboard
+        args, kwargs = mock_root.clipboard_append.call_args
+        command = args[0]
+        assert "target1" in command
+        assert "'target two'" in command
+        assert "--cli" in command
+
+def test_button_click_git_multi():
+    with patch('gptscan.textbox') as mock_textbox, \
+         patch('gptscan.git_var') as mock_git, \
+         patch('gptscan.dry_var') as mock_dry, \
+         patch('gptscan.deep_var') as mock_deep, \
+         patch('gptscan.all_var') as mock_all, \
+         patch('gptscan.gpt_var') as mock_gpt, \
+         patch('gptscan.get_git_changed_files') as mock_get_git, \
+         patch('gptscan.threading.Thread') as mock_thread, \
+         patch('gptscan.os.path.exists', return_value=True), \
+         patch('gptscan.set_scanning_state'), \
+         patch('gptscan.update_status'), \
+         patch('gptscan.clear_results'):
+
+        mock_textbox.get.return_value = "dir1 dir2"
+        mock_git.get.return_value = True
+        mock_dry.get.return_value = False
+        mock_deep.get.return_value = False
+        mock_all.get.return_value = False
+        mock_gpt.get.return_value = False
+        mock_get_git.side_effect = [["dir1/f1.py"], ["dir2/f2.js"]]
+        gptscan.current_cancel_event = None
+
+        gptscan.button_click()
+
+        args, kwargs = mock_thread.call_args
+        scan_args = kwargs.get('args') or args[0]
+        assert set(scan_args[0]) == {"dir1/f1.py", "dir2/f2.js"}


### PR DESCRIPTION
Implemented multi-target scanning support in the GPT Virus Scanner GUI. Users can now:
- Select multiple files using the "File..." button (updated to `askopenfilenames`).
- Enter multiple space-separated or quoted paths and URLs in the target textbox (parsed using `shlex.split`).
- Generate CLI commands that correctly include all selected targets with proper shell quoting.
- Aggregate Git changes across multiple target directories.

The implementation includes:
- Updates to `_set_scan_target`, `browse_file_click`, `button_click`, and `copy_cli_command` in `gptscan.py`.
- New unit tests in `tests/test_multi_target_gui.py`.
- Updates to several existing test files to maintain compatibility with the new list-based target handling.
- Improved hover messages to guide users on the new functionality.

---
*PR created automatically by Jules for task [7568095832196652925](https://jules.google.com/task/7568095832196652925) started by @RainRat*