### PR TITLE
Remove redundant tree widget validation in check_virustotal

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4155,9 +4155,6 @@ def copy_sha256(event: Optional[tk.Event] = None) -> None:
 
 def check_virustotal(event_or_path: Union[tk.Event, str, None] = None) -> None:
     """Check selected files on VirusTotal (opens multiple tabs if needed)."""
-    if not tree:
-        return
-
     # List of (path, snippet_if_available)
     targets: List[Tuple[str, Optional[str]]] = []
 


### PR DESCRIPTION
* **What:** Removed the redundant `if not tree: return` check from the `check_virustotal` function.
* **Why:** The `tree` widget is a global `ttk.Treeview` instance that is guaranteed to be initialized when UI actions trigger this function. Removing this check simplifies the code without altering its behavior or safety.

---
*PR created automatically by Jules for task [3293874675845797881](https://jules.google.com/task/3293874675845797881) started by @RainRat*