### PR TITLE
[TEST] Add comprehensive tests for resolve_remote_url and fix protocol case-sensitivity

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -84,7 +84,7 @@ def resolve_remote_url(url: str) -> str:
         A resolved URL pointing to raw content or a downloadable archive.
     """
     url = url.strip()
-    if not url.startswith(('http://', 'https://')):
+    if not url.lower().startswith(('http://', 'https://')):
         return url
 
     # Remove trailing slashes and common fragments

--- a/tests/test_url_resolution.py
+++ b/tests/test_url_resolution.py
@@ -1,0 +1,71 @@
+import pytest
+from gptscan import resolve_remote_url
+
+def test_resolve_github_blob():
+    url = "https://github.com/user/repo/blob/main/script.py"
+    expected = "https://raw.githubusercontent.com/user/repo/main/script.py"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_github_gist():
+    url = "https://gist.github.com/user/1234567890abcdef"
+    expected = "https://gist.github.com/user/1234567890abcdef/raw"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_github_repo():
+    url = "https://github.com/user/repo"
+    expected = "https://github.com/user/repo/archive/HEAD.zip"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_github_repo_with_trailing_slash():
+    url = "https://github.com/user/repo/"
+    expected = "https://github.com/user/repo/archive/HEAD.zip"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_github_special_pages_not_repo():
+    special_pages = [
+        "https://github.com/user/repo/issues",
+        "https://github.com/user/repo/pulls",
+        "https://github.com/user/repo/actions",
+        "https://github.com/user/repo/projects",
+        "https://github.com/user/repo/wiki",
+        "https://github.com/user/repo/security",
+        "https://github.com/user/repo/insights",
+        "https://github.com/user/repo/settings"
+    ]
+    for url in special_pages:
+        assert resolve_remote_url(url) == url
+
+def test_resolve_gitlab_blob():
+    url = "https://gitlab.com/user/repo/-/blob/main/script.py"
+    expected = "https://gitlab.com/user/repo/-/raw/main/script.py"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_standard_url():
+    url = "https://example.com/script.sh"
+    assert resolve_remote_url(url) == url
+
+def test_resolve_non_url():
+    path = "/home/user/script.py"
+    assert resolve_remote_url(path) == path
+
+    path_relative = "./script.py"
+    assert resolve_remote_url(path_relative) == path_relative
+
+def test_resolve_url_with_fragment():
+    url = "https://github.com/user/repo/blob/main/script.py#L10"
+    expected = "https://raw.githubusercontent.com/user/repo/main/script.py"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_github_case_insensitivity():
+    url = "HTTPS://GITHUB.COM/user/repo/BLOB/main/script.py"
+    expected = "https://raw.githubusercontent.com/user/repo/main/script.py"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_gitlab_repo_returns_original():
+    url = "https://gitlab.com/user/repo"
+    assert resolve_remote_url(url) == url
+
+def test_resolve_github_www_prefix():
+    url = "https://www.github.com/user/repo/blob/main/script.py"
+    expected = "https://raw.githubusercontent.com/user/repo/main/script.py"
+    assert resolve_remote_url(url) == expected


### PR DESCRIPTION
This PR addresses a gap in test coverage for the `resolve_remote_url` function in `gptscan.py`. It adds a new test file `tests/test_url_resolution.py` that covers GitHub blob, gist, and repository URLs, as well as GitLab blob URLs and various edge cases like fragments and trailing slashes. 

During testing, a minor bug was discovered where the function was case-sensitive when checking for the `http://` or `https://` protocol. This has been fixed by using a lower-case comparison.

All 494 tests in the suite are passing.

---
*PR created automatically by Jules for task [4167917039140876816](https://jules.google.com/task/4167917039140876816) started by @RainRat*