### PR TITLE
Fix: Show non-percentage statuses when threat threshold is active

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1112,7 +1112,7 @@ def _matches_filter(values: Tuple[Any, ...]) -> bool:
     is_show_all = all_var.get() if all_var else False
     if not is_show_all:
         conf = get_effective_confidence(values[1], values[4])
-        if conf < Config.THRESHOLD:
+        if 0 <= conf < Config.THRESHOLD:
             return False
 
     if not filter_var:


### PR DESCRIPTION
I identified and resolved a logic bug in the `_matches_filter` function within `gptscan.py`. 

### Issue
When a threat level threshold was active (e.g., set to 50), the GUI incorrectly filtered out results that had non-percentage statuses, such as "Dry Run", "Error", or "Fetch Error". This happened because these statuses resulted in a sentinel confidence value of -1.0, which was always less than any positive threshold, causing the results to be hidden.

### Fix
I updated the threshold condition in `_matches_filter` from `if conf < Config.THRESHOLD:` to `if 0 <= conf < Config.THRESHOLD:`. This change ensures that only valid confidence scores (which are >= 0) are subjected to the threshold-based filtering, while status messages (which have a confidence of -1.0) remain visible to the user regardless of the threshold setting.

### Verification
- Created a reproduction test case `tests/reproduce_filter_bug.py` that failed before the fix and passed after.
- Ran the full test suite (497 tests) to ensure no regressions were introduced.
- Verified that local configuration files were not unintentionally modified.

---
*PR created automatically by Jules for task [7275993443665748610](https://jules.google.com/task/7275993443665748610) started by @RainRat*