### PR TITLE
[DOCS] Standardize supported format documentation for scans and imports

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4584,7 +4584,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Escape>', lambda event: cancel_scan())
     select_file_btn = ttk.Button(input_frame, text="File...", command=browse_file_click)
     select_file_btn.grid(row=0, column=2, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_file_btn, "Select one or more script or Markdown files to scan.")
+    bind_hover_message(select_file_btn, "Select one or more script, Notebook, HTML, or Markdown files to scan.")
 
     select_dir_btn = ttk.Button(input_frame, text="Folder...", command=browse_dir_click)
     select_dir_btn.grid(row=0, column=3, sticky="e", padx=(5, 0), ipady=5)
@@ -4592,7 +4592,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     select_url_btn = ttk.Button(input_frame, text="URL...", command=select_url_click)
     select_url_btn.grid(row=0, column=4, sticky="e", padx=(5, 0), ipady=5)
-    bind_hover_message(select_url_btn, "Scan a script, Markdown file, or archive from a remote URL. Multiple targets can be entered manually in the textbox.")
+    bind_hover_message(select_url_btn, "Scan a script, Notebook, HTML, Markdown file, or archive from a remote URL. Multiple targets can be entered manually in the textbox.")
 
     select_clipboard_btn = ttk.Button(input_frame, text="Clipboard", command=scan_clipboard_click)
     select_clipboard_btn.grid(row=0, column=5, sticky="e", padx=(5, 0), ipady=5)
@@ -4896,7 +4896,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     import_button = ttk.Button(footer_frame, text="Import", width=10, command=import_results)
     import_button.grid(row=0, column=11, padx=2, ipady=5)
-    bind_hover_message(import_button, "Load results from a JSON or CSV file.")
+    bind_hover_message(import_button, "Load results from a JSON, CSV, SARIF, Markdown, or HTML file.")
 
     export_button = ttk.Button(footer_frame, text="Export", width=10, command=export_results)
     export_button.grid(row=0, column=12, padx=2, ipady=5)

--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Path to scan:** Type one or more paths (separated by spaces) or choose from the dropdown. It remembers your last 10 locations.
 *   **File...:** Select one or more files to scan.
 *   **Folder...:** Select a whole directory to scan.
-*   **URL...:** Scan a script, Markdown file, or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **URL...:** Scan a script, Notebook, HTML, Markdown file, or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Clipboard:** Scan code currently in your clipboard.
 
 #### Scan Options
@@ -148,7 +148,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Open / Reveal:** Open the file or show its location in your file manager.
 *   **Rescan:** Re-scan the selected file(s).
 *   **Exclude:** Add the selected file(s) to your `.gptscanignore` file.
-*   **Import / Export:** Save results to many formats (CSV, JSON, SARIF, HTML, Markdown) or load them from a previous scan (supports JSON, CSV, SARIF, and Markdown).
+*   **Import / Export:** Save results to many formats (CSV, JSON, SARIF, HTML, Markdown) or load them from a previous scan (supports JSON, CSV, SARIF, Markdown, and HTML).
 *   **Clear:** Clear all results from the list.
 
 #### File Menu
@@ -229,7 +229,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--exclude [patterns], -e [patterns]`: Skip files that match these patterns.
 *   `--file-list [file]`: Scan a list of files from a text file.
 *   `--extensions [types]`: Only scan specific file types (for example: `py,js`).
-*   `--import [file]`: Load results from a previous scan (JSON, CSV, SARIF, or Markdown). Use `-` for terminal input.
+*   `--import [file]`: Load results from a previous scan (JSON, CSV, SARIF, Markdown, or HTML). Use `-` for terminal input.
 *   `--max-size [value]`: Set the maximum file size to scan (e.g., `10MB`, `500KB`). The default is 10MB.
 *   `--json, -j`: Save or show results in JSON format (one object per line).
 *   `--csv`: Save or show results in CSV format.


### PR DESCRIPTION
### Changes
This PR improves the project documentation and internal help strings to accurately reflect the tool's support for various file formats.

#### 1. Project Documentation (`readme.md`)
- Added **Notebook** and **HTML** to the list of formats supported via web links in the **Scan Input** section.
- Added **HTML** to the list of supported import formats in the **Footer Actions** (GUI) and **Common Options** (CLI) sections.

#### 2. Internal Help Strings (`gptscan.py`)
- Updated hover messages for the **File...**, **URL...**, and **Import** buttons to include Notebooks, HTML files, and all five supported import formats (JSON, CSV, SARIF, Markdown, and HTML).

### Verification
- Verified that `unpack_content` in `gptscan.py` supports Notebooks and HTML files.
- Verified that `parse_report_content` in `gptscan.py` supports HTML imports.
- Ran the test suite (`python3 -m pytest --ignore=tests/test_train.py`) and all 509 tests passed.
- Manually confirmed the hover text logic in `tests/test_hover_help.py`.
- Removed development junk (`dummy.py`) and restored session configuration (`.gptscan_settings.json`) as per code review feedback.

---
*PR created automatically by Jules for task [13945845860532858831](https://jules.google.com/task/13945845860532858831) started by @RainRat*