### PR TITLE
[UI/UX] Relocate Threat Level settings to Scan Options

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4648,6 +4648,29 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
     bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")
 
+    threshold_frame = ttk.Frame(options_frame)
+    threshold_frame.grid(row=3, column=0, columnspan=2, sticky='w', padx=10, pady=2)
+
+    def on_threshold_change():
+        try:
+            val = int(threshold_spin.get())
+            Config.THRESHOLD = max(0, min(100, val))
+            _apply_filter()
+        except ValueError:
+            pass
+
+    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
+    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
+    threshold_spin.delete(0, tk.END)
+    threshold_spin.insert(0, str(Config.THRESHOLD))
+    threshold_spin.pack(side=tk.LEFT, padx=5)
+    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
+    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
+
+    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
+    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
+    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
+
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5)
@@ -4775,28 +4798,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
     clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
     bind_hover_message(clear_filter_btn, "Clear the filter.")
-
-    ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)
-
-    def on_threshold_change():
-        try:
-            val = int(threshold_spin.get())
-            Config.THRESHOLD = max(0, min(100, val))
-            _apply_filter()
-        except ValueError:
-            pass
-
-    ttk.Label(filter_frame, text="Min. Threat Level:").grid(row=0, column=4, sticky="w")
-    threshold_spin = ttk.Spinbox(filter_frame, from_=0, to=100, width=5, command=on_threshold_change)
-    threshold_spin.delete(0, tk.END)
-    threshold_spin.insert(0, str(Config.THRESHOLD))
-    threshold_spin.grid(row=0, column=5, sticky="w", padx=5)
-    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
-    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
-
-    all_checkbox = ttk.Checkbutton(filter_frame, text="Show all files", variable=all_var, command=_apply_filter)
-    all_checkbox.grid(row=0, column=6, sticky="w", padx=(5, 0))
-    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Treeview ---
     style.configure('Scanner.Treeview', rowheight=50)


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** The "Min. Threat Level" and "Show all files" controls were located in the "Filter" frame at the bottom of the window. This created visual clutter in the search area and separated scan-wide configuration from the "Scan Options" section.
* **Solution:** Relocated these controls to a new row within the "Scan Options" frame. This improves visual hierarchy by grouping all scan-wide parameters together and streamlines the "Filter" area to focus exclusively on text-based searching of results.

---
*PR created automatically by Jules for task [11255621843699495978](https://jules.google.com/task/11255621843699495978) started by @RainRat*