### PR TITLE
[UI/UX] Consolidate Result Management Buttons

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -51,9 +51,7 @@ analyze_button: Optional[ttk.Button] = None
 exclude_button: Optional[ttk.Button] = None
 reveal_button: Optional[ttk.Button] = None
 vt_button: Optional[ttk.Button] = None
-import_button: Optional[ttk.Button] = None
-export_button: Optional[ttk.Button] = None
-clear_button: Optional[ttk.Button] = None
+results_button: Optional[ttk.Menubutton] = None
 select_file_btn: Optional[ttk.Button] = None
 select_dir_btn: Optional[ttk.Button] = None
 select_url_btn: Optional[ttk.Button] = None
@@ -1291,7 +1289,7 @@ def set_scanning_state(is_scanning: bool) -> None:
     # Disable all footer buttons during a scan
     footer_buttons = [
         view_button, rescan_button, open_button, analyze_button, exclude_button,
-        reveal_button, vt_button, import_button, export_button, clear_button
+        reveal_button, vt_button, results_button
     ]
     for btn in footer_buttons:
         if btn:
@@ -4531,7 +4529,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, vt_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, import_button, export_button, clear_button, default_font_measure, select_file_btn, select_dir_btn, select_url_btn, select_clipboard_btn, copy_cmd_button, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_entry, all_checkbox, threshold_spin
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, vt_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, default_font_measure, select_file_btn, select_dir_btn, select_url_btn, select_clipboard_btn, copy_cmd_button, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_entry, all_checkbox, threshold_spin
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -4892,21 +4890,16 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     exclude_button.grid(row=0, column=9, padx=2, ipady=5)
     bind_hover_message(exclude_button, "Exclude the selected items from future scans.")
 
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=10, sticky="ns", padx=5)
+    results_menu = tk.Menu(root, tearoff=0)
+    results_menu.add_command(label="Import Results...", command=import_results)
+    results_menu.add_command(label="Import from Clipboard", command=import_from_clipboard)
+    results_menu.add_command(label="Export Results...", command=export_results)
+    results_menu.add_separator()
+    results_menu.add_command(label="Clear Results", command=clear_results)
 
-    import_button = ttk.Button(footer_frame, text="Import", width=10, command=import_results)
-    import_button.grid(row=0, column=11, padx=2, ipady=5)
-    bind_hover_message(import_button, "Load results from a JSON or CSV file.")
-
-    export_button = ttk.Button(footer_frame, text="Export", width=10, command=export_results)
-    export_button.grid(row=0, column=12, padx=2, ipady=5)
-    bind_hover_message(export_button, "Save results to CSV, HTML, JSON, or SARIF.")
-
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=13, sticky="ns", padx=5)
-
-    clear_button = ttk.Button(footer_frame, text="Clear", width=10, command=clear_results)
-    clear_button.grid(row=0, column=14, padx=(2, 0), ipady=5)
-    bind_hover_message(clear_button, "Clear all results from the list.")
+    results_button = ttk.Menubutton(footer_frame, text="Results", menu=results_menu, direction="above")
+    results_button.grid(row=0, column=11, padx=(5, 0), ipady=5)
+    bind_hover_message(results_button, "Import, export, or clear scan results.")
 
     # --- Context Menu ---
     global context_menu

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -16,9 +16,7 @@ def test_open_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'analyze_button', MagicMock())
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
     monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'import_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'export_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'clear_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
     monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -15,9 +15,7 @@ def test_reveal_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'rescan_button', MagicMock())
     monkeypatch.setattr(gptscan, 'analyze_button', MagicMock())
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'import_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'export_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'clear_button', MagicMock())
+    monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
     monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 


### PR DESCRIPTION
### **[UI/UX] Consolidate Result Management Buttons**

**Context:** GUI
**Problem:** The main window's footer was cluttered with 10 buttons, mixing selection-dependent actions (View, Analyze, VT, Open, Reveal, Rescan, Exclude) with general result management (Import, Export, Clear). This lacked visual hierarchy and made the interface feel cramped.
**Solution:** Consolidated "Import", "Export", and "Clear" into a single "Results" `ttk.Menubutton`. This groups related utility actions under a single logical header, reducing the button count in the footer while maintaining full functionality. Added "Import from Clipboard" to this menu for improved discoverability.

**Changes:**
- Modified `gptscan.py`:
    - Updated global variables to replace `import_button`, `export_button`, and `clear_button` with `results_button`.
    - Updated `set_scanning_state` to manage the state of `results_button`.
    - Refactored `create_gui` to implement the new `Menubutton` and its associated menu.
- Modified `tests/test_reveal_button.py` and `tests/test_open_button.py`:
    - Updated monkeypatching logic to use `results_button`.
- Cleaned up `.gptscan_settings.json` to remove transient test paths.

---
*PR created automatically by Jules for task [8672480126814804114](https://jules.google.com/task/8672480126814804114) started by @RainRat*