### PR TITLE
[TEST] Add package.json script extraction and coverage

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "",
+    "last_path": "file1.py file2.js",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -11,5 +11,12 @@
     "threshold": 50,
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
-    "recent_paths": []
+    "recent_paths": [
+        "file1.py file2.js",
+        "/some/path",
+        "/some/repo",
+        "1",
+        "2",
+        "three"
+    ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -1929,7 +1929,21 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 5. Check for HTML script tags
+    # 5. Check for package.json scripts
+    if check_name.lower().endswith('package.json') or 'package.json]' in check_name.lower():
+        try:
+            pkg_data = json.loads(content.decode('utf-8', errors='ignore'))
+            if isinstance(pkg_data, dict) and 'scripts' in pkg_data:
+                scripts = pkg_data['scripts']
+                if isinstance(scripts, dict):
+                    for script_name, script_cmd in scripts.items():
+                        if isinstance(script_cmd, str) and script_cmd.strip():
+                            yield (f"{name} [Script: {script_name}]", script_cmd.encode('utf-8'))
+                return
+        except Exception:
+            pass
+
+    # 6. Check for HTML script tags
     if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -1942,7 +1956,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Fallback: yield as a single snippet if it's a supported file type
+    # 7. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content

--- a/tests/test_package_json_scan.py
+++ b/tests/test_package_json_scan.py
@@ -1,0 +1,69 @@
+import json
+import pytest
+from gptscan import unpack_content
+
+def test_unpack_package_json_scripts():
+    """Verify that scripts are correctly extracted from package.json files."""
+    pkg_data = {
+        "name": "test-app",
+        "version": "1.0.0",
+        "scripts": {
+            "start": "node index.js",
+            "test": "jest",
+            "build": "webpack --mode production",
+            "empty": "  ",
+            "non-string": 123
+        }
+    }
+    content_bytes = json.dumps(pkg_data).encode('utf-8')
+
+    # Test with package.json filename
+    snippets = list(unpack_content("package.json", content_bytes))
+
+    assert len(snippets) == 3
+
+    # Check each extracted script
+    script_names = [s[0] for s in snippets]
+    assert "package.json [Script: start]" in script_names
+    assert "package.json [Script: test]" in script_names
+    assert "package.json [Script: build]" in script_names
+
+    # Verify content
+    scripts_dict = {name: cmd for name, cmd in snippets}
+    assert scripts_dict["package.json [Script: start]"] == b"node index.js"
+    assert scripts_dict["package.json [Script: test]"] == b"jest"
+    assert scripts_dict["package.json [Script: build]"] == b"webpack --mode production"
+
+def test_unpack_package_json_no_scripts():
+    """Verify that package.json files with no scripts yield no snippets."""
+    pkg_data = {"name": "no-scripts"}
+    content_bytes = json.dumps(pkg_data).encode('utf-8')
+
+    snippets = list(unpack_content("package.json", content_bytes))
+    assert len(snippets) == 0
+
+def test_unpack_package_json_invalid_scripts():
+    """Verify that package.json with non-dictionary scripts yields no snippets."""
+    pkg_data = {"scripts": "not-a-dict"}
+    content_bytes = json.dumps(pkg_data).encode('utf-8')
+
+    snippets = list(unpack_content("package.json", content_bytes))
+    assert len(snippets) == 0
+
+def test_unpack_package_json_empty():
+    """Verify that an empty or malformed package.json is handled gracefully."""
+    snippets = list(unpack_content("package.json", b""))
+    assert len(snippets) == 0
+
+    snippets = list(unpack_content("package.json", b"{invalid json}"))
+    assert len(snippets) == 0
+
+def test_unpack_nested_package_json():
+    """Verify that package.json scripts are extracted even when nested in an archive name."""
+    pkg_data = {"scripts": {"dev": "nodemon server.js"}}
+    content_bytes = json.dumps(pkg_data).encode('utf-8')
+
+    snippets = list(unpack_content("my-project[package.json]", content_bytes))
+    assert len(snippets) == 1
+    assert snippets[0][0] == "my-project[package.json] [Script: dev]"
+    assert snippets[0][1] == b"nodemon server.js"


### PR DESCRIPTION
This PR adds support for scanning npm scripts within `package.json` files. The `unpack_content` function now parses `package.json` to extract and scan individual commands from the `scripts` object, yielding them with the format `package.json [Script: <script_name>]`. 

A new test file `tests/test_package_json_scan.py` is included to verify this functionality across various scenarios, including valid scripts, empty scripts, and malformed JSON. The implementation maintains consistency with existing specialized extractors by returning after processing to avoid redundant scanning of the container file itself.

---
*PR created automatically by Jules for task [13323530614396395441](https://jules.google.com/task/13323530614396395441) started by @RainRat*