### PR TITLE
[TEST] Improve configuration loading type safety and add validation tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -229,6 +229,23 @@ class Config:
         except (ValueError, TypeError):
             return default
 
+    @staticmethod
+    def _get_setting_bool(settings: Dict[str, Any], key: str, default: bool) -> bool:
+        """Extract a boolean setting with fallback to default on error."""
+        val = settings.get(key, default)
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            val_lower = val.lower().strip()
+            if val_lower in ('true', '1', 'yes', 'on'):
+                return True
+            if val_lower in ('false', '0', 'no', 'off'):
+                return False
+        try:
+            return bool(int(val))
+        except (ValueError, TypeError):
+            return default
+
     apikey_missing_message = (
         "No API key found. You cannot use OpenAI or OpenRouter, but local scans and Ollama still work."
     )
@@ -291,11 +308,11 @@ class Config:
             with open(cls.SETTINGS_FILE, 'r', encoding='utf-8') as f:
                 settings = json.load(f)
                 cls.last_path = settings.get("last_path", cls.last_path)
-                cls.deep_scan = settings.get("deep_scan", cls.deep_scan)
-                cls.git_changes_only = settings.get("git_changes_only", cls.git_changes_only)
-                cls.show_all_files = settings.get("show_all_files", cls.show_all_files)
-                cls.scan_all_files = settings.get("scan_all_files", cls.scan_all_files)
-                cls.use_ai_analysis = settings.get("use_ai_analysis", cls.use_ai_analysis)
+                cls.deep_scan = cls._get_setting_bool(settings, "deep_scan", cls.deep_scan)
+                cls.git_changes_only = cls._get_setting_bool(settings, "git_changes_only", cls.git_changes_only)
+                cls.show_all_files = cls._get_setting_bool(settings, "show_all_files", cls.show_all_files)
+                cls.scan_all_files = cls._get_setting_bool(settings, "scan_all_files", cls.scan_all_files)
+                cls.use_ai_analysis = cls._get_setting_bool(settings, "use_ai_analysis", cls.use_ai_analysis)
                 cls.provider = settings.get("provider", cls.provider)
                 cls.model_name = settings.get("model_name", cls.model_name)
                 cls.api_base = settings.get("api_base", cls.api_base)

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -1,0 +1,86 @@
+import json
+import pytest
+from gptscan import Config
+
+@pytest.fixture
+def temp_settings_file(tmp_path, monkeypatch):
+    """Use a temporary settings file path for testing."""
+    f = tmp_path / ".gptscan_settings_types.json"
+    monkeypatch.setattr(Config, "SETTINGS_FILE", str(f))
+    return f
+
+@pytest.fixture(autouse=True)
+def reset_config_settings():
+    """Reset configuration settings before and after each test."""
+    orig = {
+        "deep_scan": Config.deep_scan,
+        "git_changes_only": Config.git_changes_only,
+        "show_all_files": Config.show_all_files,
+        "scan_all_files": Config.scan_all_files,
+        "use_ai_analysis": Config.use_ai_analysis,
+        "threshold": Config.THRESHOLD
+    }
+    yield
+    Config.deep_scan = orig["deep_scan"]
+    Config.git_changes_only = orig["git_changes_only"]
+    Config.show_all_files = orig["show_all_files"]
+    Config.scan_all_files = orig["scan_all_files"]
+    Config.use_ai_analysis = orig["use_ai_analysis"]
+    Config.THRESHOLD = orig["threshold"]
+
+def test_load_settings_bool_strings(temp_settings_file):
+    settings = {
+        "deep_scan": "true",
+        "git_changes_only": "1",
+        "show_all_files": "False",
+        "scan_all_files": "0",
+        "use_ai_analysis": "yes"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.load_settings()
+
+    assert Config.deep_scan is True
+    assert Config.git_changes_only is True
+    assert Config.show_all_files is False
+    assert Config.scan_all_files is False
+    assert Config.use_ai_analysis is True
+
+def test_load_settings_bool_garbage_fallback(temp_settings_file):
+    settings = {
+        "deep_scan": "not-a-bool"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.deep_scan = True
+    Config.load_settings()
+    assert Config.deep_scan is True # Should remain unchanged
+
+    Config.deep_scan = False
+    Config.load_settings()
+    assert Config.deep_scan is False # Should remain unchanged
+
+def test_load_settings_int_strings(temp_settings_file):
+    settings = {
+        "threshold": "85"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.THRESHOLD = 50
+    Config.load_settings()
+    assert Config.THRESHOLD == 85
+    assert isinstance(Config.THRESHOLD, int)
+
+def test_load_settings_int_garbage_fallback(temp_settings_file):
+    settings = {
+        "threshold": "invalid"
+    }
+    with open(temp_settings_file, "w") as f:
+        json.dump(settings, f)
+
+    Config.THRESHOLD = 42
+    Config.load_settings()
+    assert Config.THRESHOLD == 42


### PR DESCRIPTION
### Type: Bug Fix / New Coverage

### What:
Implemented a new `_get_setting_bool` helper method in the `Config` class to safely handle boolean settings during configuration loading. This method correctly interprets boolean values even when they are represented as strings (e.g., "true", "false", "1", "0", "yes", "no") in the `.gptscan_settings.json` file. I also updated `Config.load_settings` to utilize this helper for all boolean flags (`deep_scan`, `git_changes_only`, `show_all_files`, `scan_all_files`, and `use_ai_analysis`). Additionally, I added a new test file `tests/test_config_types.py` to provide coverage for these type-conversion scenarios and existing integer parsing logic.

### Why:
This change addresses a subtle but important logic bug where manual edits to the JSON configuration file could lead to unexpected behavior. In Python, any non-empty string is evaluated as `True`. If a user manually changed a setting to `"False"` (as a string), the application would previously treat it as `True`. By implementing explicit type conversion and validation, we ensure the scanner's settings are robust and behave as intended by the user.

---
*PR created automatically by Jules for task [13189282556934454937](https://jules.google.com/task/13189282556934454937) started by @RainRat*