### PR TITLE
[FEAT] Glob pattern support for file collection

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "",
+    "last_path": "file1.py file2.js",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -11,5 +11,12 @@
     "threshold": 50,
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
-    "recent_paths": []
+    "recent_paths": [
+        "file1.py file2.js",
+        "/some/path",
+        "/some/repo",
+        "1",
+        "2",
+        "three"
+    ]
 }

--- a/gptscan.py
+++ b/gptscan.py
@@ -1,5 +1,6 @@
 import asyncio
 import csv
+import glob
 import hashlib
 import html
 import io
@@ -903,28 +904,42 @@ def get_git_changed_files(path: str = ".") -> List[str]:
 
 
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:
-    """Collect files from a single path or a list of paths (files or directories).
+    """Collect files from a single path or a list of paths (files, directories, or globs).
 
     Parameters
     ----------
     targets : Union[str, List[str]]
-        A single directory path or a list of file/directory paths.
+        A single directory path or a list of file/directory paths or glob patterns.
+        Multiple targets can be provided in a single space-separated string.
 
     Returns
     -------
     List[Path]
         A deduplicated list of files to scan.
     """
-    if isinstance(targets, str):
-        targets = [targets]
+    if isinstance(targets, (str, Path)):
+        try:
+            targets = shlex.split(str(targets))
+        except ValueError:
+            targets = [str(targets)]
 
     results: List[Path] = []
     for t in targets:
         p = Path(t)
-        if p.is_file():
-            results.append(p)
-        elif p.is_dir():
-            results.extend([f for f in p.rglob('*') if f.is_file()])
+        if p.exists():
+            if p.is_file():
+                results.append(p)
+            elif p.is_dir():
+                results.extend([f for f in p.rglob('*') if f.is_file()])
+        elif any(char in str(t) for char in ['*', '?', '[']):
+            # Try to expand as a glob pattern
+            expanded = glob.glob(str(t), recursive=True)
+            for path_str in expanded:
+                ep = Path(path_str)
+                if ep.is_file():
+                    results.append(ep)
+                elif ep.is_dir():
+                    results.extend([f for f in ep.rglob('*') if f.is_file()])
 
     # Use dict keys to remove duplicates while preserving insertion order.
     return list(dict.fromkeys(results))
@@ -2053,7 +2068,10 @@ def scan_files(
 
     # Identify which files were explicitly passed as targets and deduplicate them
     if isinstance(scan_targets, (str, Path)):
-        scan_targets = [scan_targets]
+        try:
+            scan_targets = shlex.split(str(scan_targets))
+        except ValueError:
+            scan_targets = [str(scan_targets)]
 
     scan_targets = list(dict.fromkeys(scan_targets))
 
@@ -4580,6 +4598,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     textbox.grid(row=0, column=1, sticky="ew", padx=5)
     textbox.bind('<Return>', lambda event: button_click())
     textbox.focus_set()
+    bind_hover_message(textbox, "Enter one or more files, folders, or glob patterns (e.g., src/**/*.py) to scan. Separate multiple targets with spaces.")
 
     root.bind('<Escape>', lambda event: cancel_scan())
     select_file_btn = ttk.Button(input_frame, text="File...", command=browse_file_click)
@@ -5004,11 +5023,11 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {Config.VERSION}')
-    parser.add_argument('target', nargs='?', help='The folder or file to scan.')
+    parser.add_argument('target', nargs='?', help='The folder, file, or glob pattern to scan (e.g., src/**/*.py).')
     parser.add_argument(
         'files',
         nargs='*',
-        help='More folders or files to scan.'
+        help='More folders, files, or glob patterns to scan.'
     )
 
     scan_group = parser.add_argument_group("Scan Options")

--- a/tests/test_glob_expansion.py
+++ b/tests/test_glob_expansion.py
@@ -1,0 +1,106 @@
+import os
+from pathlib import Path
+import pytest
+from gptscan import collect_files
+
+def test_collect_files_basic_glob(tmp_path, monkeypatch):
+    """Test basic glob expansion like *.py."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.py").touch()
+    (tmp_path / "b.js").touch()
+    (tmp_path / "c.py").touch()
+
+    targets = ["*.py"]
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"a.py", "c.py"}
+
+def test_collect_files_recursive_glob(tmp_path, monkeypatch):
+    """Test recursive glob expansion like **/*.js."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.js").touch()
+    (src / "b.py").touch()
+
+    nested = src / "nested"
+    nested.mkdir()
+    (nested / "c.js").touch()
+
+    targets = ["**/*.js"]
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"a.js", "c.js"}
+
+def test_collect_files_mixed_targets(tmp_path, monkeypatch):
+    """Test a mix of literal paths and glob patterns."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.py").touch()
+    (tmp_path / "b.js").touch()
+
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.py").touch()
+
+    # Literal file, Literal dir, and Glob
+    targets = ["a.py", "sub", "*.js"]
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"a.py", "c.py", "b.js"}
+
+def test_collect_files_glob_matching_dir(tmp_path, monkeypatch):
+    """Test glob patterns that match directories."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").touch()
+
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "b.js").touch()
+
+    # Glob matching directories
+    targets = ["sr*"]
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"a.py"}
+
+def test_collect_files_no_match(tmp_path, monkeypatch):
+    """Test glob patterns that match nothing."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.py").touch()
+
+    targets = ["*.js", "non_existent.py"]
+    results = collect_files(targets)
+
+    assert results == []
+
+def test_collect_files_literal_with_glob_chars(tmp_path, monkeypatch):
+    """Test that literal paths containing glob chars are handled if they exist."""
+    monkeypatch.chdir(tmp_path)
+    # File named literally "file[1].py"
+    special = tmp_path / "file[1].py"
+    special.touch()
+
+    # If it exists literally, it should be picked up
+    targets = ["file[1].py"]
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"file[1].py"}
+
+def test_collect_files_space_separated_string(tmp_path, monkeypatch):
+    """Test that collect_files handles a single space-separated string of targets."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.py").touch()
+    (tmp_path / "b.js").touch()
+
+    targets = "a.py b.js"
+    results = collect_files(targets)
+
+    paths = {p.name for p in results}
+    assert paths == {"a.py", "b.js"}


### PR DESCRIPTION
This PR adds support for glob patterns (e.g., `src/**/*.py`) and multiple space-separated targets in the scan path input for both the CLI and GUI.

### What:
- Modified `collect_files` to expand targets using `glob.glob` if they contain wildcard characters (`*`, `?`, `[`).
- Integrated `shlex.split` into `collect_files` and `scan_files` to correctly parse multiple targets from a single string (primarily for GUI compatibility).
- Updated CLI argument help and added a GUI tooltip (hover message) to inform users of the new capability.
- Added a new test file `tests/test_glob_expansion.py` covering various globbing scenarios.

### Why:
Expanding the file collection logic to support globs provides a powerful "Batching" capability, allowing users to scan specific subsets of files (e.g., all `.js` files in a nested directory structure) without needing to manually list them or scan entire directories. This aligns with the project's goal of making script analysis more efficient and flexible.

---
*PR created automatically by Jules for task [2472913958685686383](https://jules.google.com/task/2472913958685686383) started by @RainRat*