### PR TITLE
Fix silent truncation in URL content fetching

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -183,7 +183,11 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
         if content_length and int(content_length) > max_size:
             raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
 
-        return response.read(max_size)
+        content = response.read(max_size + 1)
+        if len(content) > max_size:
+            raise ValueError(f"Content too large (exceeds {format_bytes(max_size)})")
+
+        return content
 
 
 class Config:


### PR DESCRIPTION
* **What:** Modified `fetch_url_content` to read `max_size + 1` bytes and raise a `ValueError` if the data length exceeds `max_size`.
* **Why:** Previously, if the `Content-Length` header was missing or incorrect, `urllib.request.urlopen(...).read(max_size)` would silently truncate the content to the limit without notification. This change ensures that files exceeding the size limit are explicitly rejected with a `ValueError`, improving scan reliability. The change is non-breaking and handles the `max_size=None` case by defaulting to `Config.MAX_FILE_SIZE`.

---
*PR created automatically by Jules for task [10854530654965339408](https://jules.google.com/task/10854530654965339408) started by @RainRat*