### PR TITLE
[DOCS] Correct Python version support and add troubleshooting for 3.12+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This project is a security tool that uses both local and cloud-based analysis. I
     * The API uses the prompt in `task.txt` to return a JSON assessment (Administrator description, End-user description, Threat Level).
 
 ## Environment Setup
-* **Python Version:** 3.9 through 3.12 required.
+* **Python Version:** 3.9, 3.10, or 3.11 required.
 * **Dependencies:**
     * `tensorflow` (Heavy dependency, ensure compatibility with your local CUDA/CPU setup).
     * `openai` (v1.0+ code style used, including `AsyncOpenAI`).

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ echo "print('hello')" | python gptscan.py --cli --stdin
 ## Installation
 
 ### Prerequisites
-*   **Python:** You need **Python 3.9 through 3.12**.
+*   **Python:** You need **Python 3.9, 3.10, or 3.11**.
 *   **Tkinter (Linux only):** If you are on Linux, you may need to install the Tkinter library (for example: `sudo apt-get install python3-tk`).
 
 ### Installation Steps
@@ -246,6 +246,7 @@ You can retrain the local scanner model to recognize new types of threats. For d
 
 ## Troubleshooting
 
+*   **Python 3.12+ incompatibility:** If you encounter errors installing TensorFlow or running the scanner on Python 3.12, please use Python 3.9, 3.10, or 3.11. The core scanner requires `tensorflow<2.16`, which is not available for Python 3.12.
 *   **Tkinter not found:** On Linux, run `sudo apt-get install python3-tk`.
 *   **Model file missing:** Ensure `scripts.h5` is in the same folder as `gptscan.py`. This file is required for the scanner to function.
 *   **Extensions list missing:** Ensure `extensions.txt` exists in the same folder. If this file is missing, the scanner will use built-in defaults (`.py`, `.js`, `.bat`, `.ps1`, `.ipynb`).


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated `readme.md` and `AGENTS.md` to reflect that Python 3.12 is not currently supported due to dependency constraints. Added a troubleshooting tip to `readme.md` for Python 3.12 users.
* **Why:** The documentation previously claimed support for Python 3.12, but the core scanner fails on that version because `tensorflow < 2.16` is not available. This change prevents user confusion and installation failures on newer Python environments.

---
*PR created automatically by Jules for task [8991737502488087570](https://jules.google.com/task/8991737502488087570) started by @RainRat*