### PR TITLE
[UI/UX] Show scan progress percentage in window title

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -486,7 +486,7 @@ def update_status(message: str) -> None:
 
 
 def update_progress(value: int) -> None:
-    """Update the progress bar to reflect current progress.
+    """Update the progress bar and window title to reflect current progress.
 
     Parameters
     ----------
@@ -495,11 +495,21 @@ def update_progress(value: int) -> None:
     """
     if progress_bar and root:
         progress_bar['value'] = value
+
+        # Update window title with percentage
+        try:
+            max_val = float(progress_bar['maximum'])
+            if max_val > 0:
+                percent = int((value / max_val) * 100)
+                root.title(f"[{percent}%] GPT Virus Scanner")
+        except (ValueError, TypeError, ZeroDivisionError):
+            pass
+
         root.update_idletasks()
 
 
 def configure_progress(max_value: int) -> None:
-    """Initialize progress bar values for a new scan.
+    """Initialize progress bar and window title for a new scan.
 
     Parameters
     ----------
@@ -509,6 +519,7 @@ def configure_progress(max_value: int) -> None:
     if progress_bar and root:
         progress_bar["maximum"] = max_value
         progress_bar["value"] = 0
+        root.title("[0%] GPT Virus Scanner")
         root.update_idletasks()
 
 
@@ -1298,6 +1309,9 @@ def _auto_select_best_result() -> None:
 
 def set_scanning_state(is_scanning: bool) -> None:
     """Enable or disable controls based on scanning state."""
+
+    if root and not is_scanning:
+        root.title("GPT Virus Scanner")
 
     if scan_button:
         scan_button.config(

--- a/tests/test_window_title_progress.py
+++ b/tests/test_window_title_progress.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+
+def test_configure_progress_updates_title(monkeypatch):
+    mock_root = MagicMock()
+    mock_bar = MagicMock()
+    monkeypatch.setattr(gptscan, "root", mock_root)
+    monkeypatch.setattr(gptscan, "progress_bar", mock_bar)
+
+    gptscan.configure_progress(100)
+
+    mock_root.title.assert_called_with("[0%] GPT Virus Scanner")
+
+def test_update_progress_updates_title(monkeypatch):
+    mock_root = MagicMock()
+    mock_bar = MagicMock()
+    # Mocking progress_bar['maximum'] = 200
+    mock_bar.__getitem__.side_effect = lambda key: 200 if key == 'maximum' else None
+
+    monkeypatch.setattr(gptscan, "root", mock_root)
+    monkeypatch.setattr(gptscan, "progress_bar", mock_bar)
+
+    # 50 out of 200 is 25%
+    gptscan.update_progress(50)
+
+    mock_root.title.assert_called_with("[25%] GPT Virus Scanner")
+
+def test_set_scanning_state_resets_title(monkeypatch):
+    mock_root = MagicMock()
+    monkeypatch.setattr(gptscan, "root", mock_root)
+
+    # When scanning stops
+    gptscan.set_scanning_state(False)
+
+    mock_root.title.assert_called_with("GPT Virus Scanner")
+
+def test_update_progress_handles_zero_division(monkeypatch):
+    mock_root = MagicMock()
+    mock_bar = MagicMock()
+    # Mocking progress_bar['maximum'] = 0
+    mock_bar.__getitem__.side_effect = lambda key: 0 if key == 'maximum' else None
+
+    monkeypatch.setattr(gptscan, "root", mock_root)
+    monkeypatch.setattr(gptscan, "progress_bar", mock_bar)
+
+    mock_root.title.reset_mock()
+    gptscan.update_progress(50)
+
+    # Should not raise exception and should not call title if division by zero would occur or max is 0
+    # Actually my code does `if max_val > 0:`
+    mock_root.title.assert_not_called()


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** Users lose visibility of scan progress when the application is minimized or obscured by other windows, as the progress bar and status label are only visible within the main window.
* **Solution:** Integrate the scan progress percentage directly into the window title (e.g., "[45%] GPT Virus Scanner"). This "Feedback & Clarity" improvement ensures that progress is always monitorable via the taskbar or window decorations, adhering to professional UI/UX standards for long-running tasks.
* **Consistency:** The title is reset to the default "GPT Virus Scanner" whenever the scan stops or is canceled.
* **Safety:** Added error handling for percentage calculation to prevent division by zero or type errors.
* **Verification:** New unit tests in `tests/test_window_title_progress.py` confirm the title updates and resets correctly.

---
*PR created automatically by Jules for task [11111499730742163369](https://jules.google.com/task/11111499730742163369) started by @RainRat*