### PR TITLE
Fix silent content truncation in fetch_url_content

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -183,7 +183,11 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
         if content_length and int(content_length) > max_size:
             raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
 
-        return response.read(max_size)
+        data = response.read(max_size + 1)
+        if len(data) > max_size:
+            raise ValueError(f"Content too large (exceeds {format_bytes(max_size)})")
+
+        return data
 
 
 class Config:


### PR DESCRIPTION
### What
Updated `fetch_url_content` to robustly detect and reject content exceeding the `max_size` limit by attempting to read `max_size + 1` bytes and raising a `ValueError` if the data length exceeds the limit.

### Why
Previously, if a server did not provide a `Content-Length` header, the function would silently truncate the content to `max_size` bytes. This change ensures consistent error reporting for large files regardless of server headers, improving the reliability and safety of remote scanning. 

### Verification
- Created a reproduction script that mocked a 100-byte response with no `Content-Length` header and a 50-byte limit. Confirmed that the original code returned 50 bytes silently, while the updated code raises `ValueError`.
- Verified that `max_size=None` is safely handled (it is initialized to `Config.MAX_FILE_SIZE` at the start of the function).
- Ran the full test suite (530 tests), and all tests passed.

---
*PR created automatically by Jules for task [16179147991902846897](https://jules.google.com/task/16179147991902846897) started by @RainRat*