### PR TITLE
[TEST] Fix and test for silent URL content truncation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -183,7 +183,11 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
         if content_length and int(content_length) > max_size:
             raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
 
-        return response.read(max_size)
+        content = response.read(max_size + 1)
+        if len(content) > max_size:
+            raise ValueError(f"Content too large ({format_bytes(len(content))})")
+
+        return content
 
 
 class Config:

--- a/tests/test_url_fetch_robustness.py
+++ b/tests/test_url_fetch_robustness.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+from gptscan import fetch_url_content
+
+def test_fetch_url_content_truncation_detection():
+    max_size = 100
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None
+    mock_response.read.side_effect = lambda size: b"A" * size
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        with pytest.raises(ValueError, match="Content too large"):
+            fetch_url_content("http://example.com/truncated.sh", max_size=max_size)
+
+def test_fetch_url_content_exact_size():
+    max_size = 100
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None
+    mock_response.read.return_value = b"A" * max_size
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        content = fetch_url_content("http://example.com/exact.sh", max_size=max_size)
+        assert len(content) == max_size


### PR DESCRIPTION
This PR addresses a reliability gap in the URL scanning logic. 

Previously, `fetch_url_content` would silently return truncated data if a remote script exceeded the `max_size` limit and the server omitted the `Content-Length` header. This could lead to incomplete scans and false negatives.

I have updated `fetch_url_content` to robustly detect this condition by attempting to read one byte beyond the limit. If more than `max_size` bytes are returned, a `ValueError` is now raised.

Additionally, I've added a new test file `tests/test_url_fetch_robustness.py` which covers:
- Detection of oversized content when `Content-Length` is missing.
- Verification that content exactly matching `max_size` is still accepted.

All 532 tests passed successfully.

---
*PR created automatically by Jules for task [115035640781815986](https://jules.google.com/task/115035640781815986) started by @RainRat*