### PR TITLE
[UI/UX] Reorganize scan configuration and streamline filter bar

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4707,6 +4707,29 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
     bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")
 
+    def on_threshold_change():
+        try:
+            val = int(threshold_spin.get())
+            Config.THRESHOLD = max(0, min(100, val))
+            _apply_filter()
+        except ValueError:
+            pass
+
+    threshold_frame = ttk.Frame(options_frame)
+    threshold_frame.grid(row=3, column=0, columnspan=2, sticky='w', padx=10, pady=2)
+
+    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
+    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
+    threshold_spin.delete(0, tk.END)
+    threshold_spin.insert(0, str(Config.THRESHOLD))
+    threshold_spin.pack(side=tk.LEFT, padx=5)
+    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
+    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
+
+    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
+    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
+    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
+
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5)
@@ -4834,28 +4857,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
     clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
     bind_hover_message(clear_filter_btn, "Clear the filter.")
-
-    ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)
-
-    def on_threshold_change():
-        try:
-            val = int(threshold_spin.get())
-            Config.THRESHOLD = max(0, min(100, val))
-            _apply_filter()
-        except ValueError:
-            pass
-
-    ttk.Label(filter_frame, text="Min. Threat Level:").grid(row=0, column=4, sticky="w")
-    threshold_spin = ttk.Spinbox(filter_frame, from_=0, to=100, width=5, command=on_threshold_change)
-    threshold_spin.delete(0, tk.END)
-    threshold_spin.insert(0, str(Config.THRESHOLD))
-    threshold_spin.grid(row=0, column=5, sticky="w", padx=5)
-    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
-    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
-
-    all_checkbox = ttk.Checkbutton(filter_frame, text="Show all files", variable=all_var, command=_apply_filter)
-    all_checkbox.grid(row=0, column=6, sticky="w", padx=(5, 0))
-    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Treeview ---
     style.configure('Scanner.Treeview', rowheight=50)


### PR DESCRIPTION
### [UI/UX] Reorganize scan configuration and streamline filter bar

**Context:** GUI

**Problem:** 
The "Min. Threat Level" threshold and "Show all files" controls were previously located in the results filter bar. This mixed scan-time configuration (how files are processed) with post-scan exploration (searching through found results). This created horizontal clutter in the filter bar and a confusing visual hierarchy where related scanner settings were split across different parts of the interface.

**Solution:**
Reorganized the main GUI by moving the threshold spinbox and "Show all files" checkbox to the "Scan Options" section. 
- Created a new `threshold_frame` at row 3 of the `options_frame` grid to house these controls.
- Used `pack(side=tk.LEFT)` for these controls to match the existing "Max File Size" layout.
- Streamlined the `filter_frame` by removing the moved controls and the redundant vertical separator.
- Ensured the `filter_entry` correctly expands to fill the newly available space.

This change improves visual hierarchy by grouping all scan-time configuration together, making the interface more intuitive and the filter bar more focused on its primary task.

**Changes:**
```python
<<<<<<< SEARCH
    max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
    bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")

    # --- Provider Frame ---
=======
    max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
    bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")

    def on_threshold_change():
        try:
            val = int(threshold_spin.get())
            Config.THRESHOLD = max(0, min(100, val))
            _apply_filter()
        except ValueError:
            pass

    threshold_frame = ttk.Frame(options_frame)
    threshold_frame.grid(row=3, column=0, columnspan=2, sticky='w', padx=10, pady=2)

    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
    threshold_spin.delete(0, tk.END)
    threshold_spin.insert(0, str(Config.THRESHOLD))
    threshold_spin.pack(side=tk.LEFT, padx=5)
    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")

    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")

    # --- Provider Frame ---
>>>>>>> REPLACE
<<<<<<< SEARCH
    clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
    clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
    bind_hover_message(clear_filter_btn, "Clear the filter.")

    ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)

    def on_threshold_change():
        try:
            val = int(threshold_spin.get())
            Config.THRESHOLD = max(0, min(100, val))
            _apply_filter()
        except ValueError:
            pass

    ttk.Label(filter_frame, text="Min. Threat Level:").grid(row=0, column=4, sticky="w")
    threshold_spin = ttk.Spinbox(filter_frame, from_=0, to=100, width=5, command=on_threshold_change)
    threshold_spin.delete(0, tk.END)
    threshold_spin.insert(0, str(Config.THRESHOLD))
    threshold_spin.grid(row=0, column=5, sticky="w", padx=5)
    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")

    all_checkbox = ttk.Checkbutton(filter_frame, text="Show all files", variable=all_var, command=_apply_filter)
    all_checkbox.grid(row=0, column=6, sticky="w", padx=(5, 0))
    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")

    # --- Treeview ---
=======
    clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
    clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
    bind_hover_message(clear_filter_btn, "Clear the filter.")

    # --- Treeview ---
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [2951961888372783859](https://jules.google.com/task/2951961888372783859) started by @RainRat*