### PR TITLE
[FEAT] DevOps File Scanning (Dockerfile, Makefile)

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -388,8 +388,8 @@ class Config:
         # Normalize file_path to string for consistent extension checking,
         # but keep Path objects for file-system operations.
         path_str = str(file_path).lower()
-        # Check archive extensions
-        if not is_member and (path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json'))):
+        # Check archive and container extensions/filenames
+        if not is_member and (path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json', 'dockerfile', 'makefile'))):
             return True
 
         extension = os.path.splitext(path_str)[1]
@@ -1988,7 +1988,58 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 7. Fallback: yield as a single snippet if it's a supported file type
+    # 7. Check for Dockerfile
+    if check_name.lower().endswith('dockerfile'):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Handle line continuations first
+            text = text.replace('\\\n', '')
+            # Match RUN, CMD, ENTRYPOINT
+            # We use a simple regex to find the instructions and extract the rest of the line
+            pattern = r'^\s*(?:RUN|CMD|ENTRYPOINT)\s+(.*)$'
+            matches = re.findall(pattern, text, re.MULTILINE | re.IGNORECASE)
+            for i, cmd in enumerate(matches, 1):
+                clean_cmd = cmd.strip()
+                if clean_cmd:
+                    # Remove JSON array brackets if present (exec form)
+                    if clean_cmd.startswith('[') and clean_cmd.endswith(']'):
+                        try:
+                            parts = json.loads(clean_cmd)
+                            if isinstance(parts, list):
+                                clean_cmd = " ".join(parts)
+                        except json.JSONDecodeError:
+                            pass
+                    yield (f"{name} [Instruction {i}]", clean_cmd.encode('utf-8'))
+            return
+        except Exception:
+            pass
+
+    # 8. Check for Makefile
+    if check_name.lower().endswith('makefile'):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Extract recipes (lines starting with TAB)
+            lines = text.splitlines()
+            recipe_count = 0
+            current_recipe = []
+
+            for line in lines:
+                if line.startswith('\t'):
+                    current_recipe.append(line.strip())
+                else:
+                    if current_recipe:
+                        recipe_count += 1
+                        yield (f"{name} [Recipe {recipe_count}]", "\n".join(current_recipe).encode('utf-8'))
+                        current_recipe = []
+
+            if current_recipe:
+                recipe_count += 1
+                yield (f"{name} [Recipe {recipe_count}]", "\n".join(current_recipe).encode('utf-8'))
+            return
+        except Exception:
+            pass
+
+    # 9. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content
@@ -2135,7 +2186,7 @@ def scan_files(
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
         # Check if it's a known container by extension or by content
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json')):
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json', 'dockerfile', 'makefile')):
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()
@@ -5045,7 +5096,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json files, Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json, Dockerfile, Makefile, Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,8 @@ The scanner finds scripts in several ways:
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Jupyter Notebook cells:** It extracts and scans individual code cells from `.ipynb` files.
 *   **By package.json scripts:** It extracts and scans individual commands from the `scripts` object in `package.json` files.
+*   **By Dockerfile instructions:** It extracts and scans shell commands from `RUN`, `CMD`, and `ENTRYPOINT` instructions in `Dockerfile`.
+*   **By Makefile recipes:** It extracts and scans shell commands from recipes in `Makefile`.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.
 *   **By HTML script tags:** It extracts and scans inline code from `<script>` tags in HTML files (`.html`, `.htm`, `.xhtml`).
 *   **By the first line of the file:** If a file does not have an extension, the tool checks the first line for a "shebang" (like `#!/bin/bash`). It recognizes many interpreters, including Python, Node.js, Bash (including Ash, Dash, and Zsh), Perl, Ruby, PHP, PowerShell, Lua, osascript, and iPython.
@@ -115,7 +117,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Path to scan:** Type one or more paths (separated by spaces) or choose from the dropdown. It remembers your last 10 locations.
 *   **File...:** Select one or more files to scan.
 *   **Folder...:** Select a whole directory to scan.
-*   **URL...:** Scan a script, Notebook, HTML, Markdown file, or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **URL...:** Scan a script, Notebook, HTML, Markdown, Dockerfile, Makefile, or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Clipboard:** Scan code currently in your clipboard.
 
 #### Scan Options

--- a/tests/test_devops_scanning.py
+++ b/tests/test_devops_scanning.py
@@ -1,0 +1,82 @@
+import pytest
+from gptscan import unpack_content
+
+def test_unpack_dockerfile_instructions():
+    """Test that unpack_content correctly extracts instructions from a Dockerfile."""
+    docker_content = b"""
+FROM python:3.9
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y curl
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+CMD ["python", "app.py"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+"""
+    results = list(unpack_content("Dockerfile", docker_content))
+
+    # We expect 4 instructions: 2 RUN, 1 CMD, 1 ENTRYPOINT
+    assert len(results) == 4
+
+    # Check RUN with line continuation
+    assert results[0][0] == "Dockerfile [Instruction 1]"
+    assert b"apt-get update &&     apt-get install -y curl" in results[0][1]
+
+    # Check RUN simple
+    assert results[1][0] == "Dockerfile [Instruction 2]"
+    assert b"pip install -r requirements.txt" in results[1][1]
+
+    # Check CMD (JSON form should be joined)
+    assert results[2][0] == "Dockerfile [Instruction 3]"
+    assert b"python app.py" in results[2][1]
+
+    # Check ENTRYPOINT (JSON form should be joined)
+    assert results[3][0] == "Dockerfile [Instruction 4]"
+    assert b"/usr/bin/entrypoint.sh" in results[3][1]
+
+def test_unpack_makefile_recipes():
+    """Test that unpack_content correctly extracts recipes from a Makefile."""
+    makefile_content = b"""
+all: build test
+
+build:
+\t@echo "Building..."
+\tpython setup.py build
+
+test:
+\tpytest tests/
+
+clean:
+\trm -rf build/
+"""
+    results = list(unpack_content("Makefile", makefile_content))
+
+    # We expect 3 recipes: build, test, clean
+    assert len(results) == 3
+
+    # Check build recipe
+    assert results[0][0] == "Makefile [Recipe 1]"
+    assert b"@echo \"Building...\"\npython setup.py build" in results[0][1]
+
+    # Check test recipe
+    assert results[1][0] == "Makefile [Recipe 2]"
+    assert b"pytest tests/" in results[1][1]
+
+    # Check clean recipe
+    assert results[2][0] == "Makefile [Recipe 3]"
+    assert b"rm -rf build/" in results[2][1]
+
+def test_dockerfile_case_insensitivity():
+    """Test that Dockerfile detection is case-insensitive."""
+    docker_content = b"RUN echo 'hello'"
+    results = list(unpack_content("dockerfile", docker_content))
+    assert len(results) == 1
+    assert "dockerfile [Instruction 1]" in results[0][0]
+
+def test_makefile_case_insensitivity():
+    """Test that Makefile detection is case-insensitive."""
+    makefile_content = b"target:\n\techo 'hi'"
+    results = list(unpack_content("makefile", makefile_content))
+    assert len(results) == 1
+    assert "makefile [Recipe 1]" in results[0][0]


### PR DESCRIPTION
This PR adds the ability to scan Dockerfile and Makefile files for malicious shell commands. It extracts instructions like RUN, CMD, and ENTRYPOINT from Dockerfiles and recipes from Makefiles, treating them as individual snippets for analysis. This closes a gap in the scanning coverage by including build-time scripts.

---
*PR created automatically by Jules for task [15360282527103325050](https://jules.google.com/task/15360282527103325050) started by @RainRat*