### PR TITLE
Fix silent truncation in URL content fetching

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -183,7 +183,10 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
         if content_length and int(content_length) > max_size:
             raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
 
-        return response.read(max_size)
+        data = response.read(max_size + 1)
+        if len(data) > max_size:
+            raise ValueError(f"Content too large (exceeds {format_bytes(max_size)})")
+        return data
 
 
 class Config:

--- a/tests/test_url_fetch_robustness.py
+++ b/tests/test_url_fetch_robustness.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from gptscan import fetch_url_content, Config
+
+def test_fetch_url_content_truncation_detection():
+    """Test that fetch_url_content detects truncation when Content-Length is missing."""
+    max_size = 100
+    # Simulate content larger than max_size
+    mock_content = b"a" * (max_size + 1)
+
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None # No content-length
+    # Mock read to return max_size + 1 bytes when asked
+    mock_response.read.side_effect = lambda size: mock_content[:size]
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        with pytest.raises(ValueError, match="Content too large"):
+            fetch_url_content("http://example.com/oversized", max_size=max_size)
+
+def test_fetch_url_content_within_limit_no_header():
+    """Test that fetch_url_content works correctly within limit even if Content-Length is missing."""
+    max_size = 100
+    mock_content = b"a" * 50
+
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None # No content-length
+    mock_response.read.side_effect = lambda size: mock_content[:size]
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        content = fetch_url_content("http://example.com/valid", max_size=max_size)
+        assert content == mock_content
+        assert len(content) == 50


### PR DESCRIPTION
The `fetch_url_content` function in `gptscan.py` had a logic bug where it would silently truncate remote content if the `Content-Length` header was missing or inaccurate. This occurred because it used `response.read(max_size)` without verifying if more data was available.

This PR fixes the issue by:
1. Attempting to read `max_size + 1` bytes from the response.
2. Raising a `ValueError` if the length of the retrieved data exceeds `max_size`.
3. Adding a new unit test file `tests/test_url_fetch_robustness.py` to cover these scenarios.

This ensures that the safety limits are strictly enforced, preventing incomplete scans of large files that omit size headers.


---
*PR created automatically by Jules for task [10825714068638000204](https://jules.google.com/task/10825714068638000204) started by @RainRat*