### PR TITLE
[TEST] Add coverage for URL fetch truncation and fix silent limit violation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -183,7 +183,11 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
         if content_length and int(content_length) > max_size:
             raise ValueError(f"Content too large ({format_bytes(int(content_length))})")
 
-        return response.read(max_size)
+        data = response.read(max_size + 1)
+        if len(data) > max_size:
+            raise ValueError(f"Content too large (exceeds {format_bytes(max_size)})")
+
+        return data
 
 
 class Config:

--- a/tests/test_url_fetch_robustness.py
+++ b/tests/test_url_fetch_robustness.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from gptscan import fetch_url_content, Config
+
+def test_fetch_url_content_detects_truncation():
+    max_size = 100
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None
+
+    def mock_read(size):
+        if size == max_size + 1:
+            return b"a" * (max_size + 1)
+        return b"a" * min(size, max_size + 1)
+
+    mock_response.read.side_effect = mock_read
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        # This is expected to FAIL (not raise ValueError) with current implementation
+        with pytest.raises(ValueError, match="Content too large"):
+            fetch_url_content("http://example.com/toolarge.py", max_size=max_size)
+
+def test_fetch_url_content_with_none_max_size():
+    original_max = Config.MAX_FILE_SIZE
+    Config.MAX_FILE_SIZE = 50
+    try:
+        mock_response = MagicMock()
+        mock_response.getheader.return_value = "100" # Larger than 50
+        mock_response.__enter__.return_value = mock_response
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            with pytest.raises(ValueError, match="Content too large"):
+                fetch_url_content("http://example.com/default_limit.py", max_size=None)
+    finally:
+        Config.MAX_FILE_SIZE = original_max
+
+def test_fetch_url_content_success_within_limit():
+    max_size = 100
+    content = b"a" * max_size
+
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = None
+    mock_response.read.return_value = content
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = fetch_url_content("http://example.com/ok.py", max_size=max_size)
+        assert len(result) == max_size
+        assert result == content


### PR DESCRIPTION
### Gap Analysis & Bug Fix

This Pull Request addresses a reliability and security gap in how the scanner fetches remote content.

#### Changes Made:
1.  **New Test Suite:** Created `tests/test_url_fetch_robustness.py` which specifically tests edge cases in URL fetching, such as:
    *   Detection of content exceeding `max_size` when `Content-Length` is missing or misleading.
    *   Ensuring `max_size=None` correctly defaults to `Config.MAX_FILE_SIZE`.
    *   Verifying success when content is exactly at the allowed limit.
2.  **Logic Fix:** Modified `fetch_url_content` in `gptscan.py` to use a more robust detection mechanism. Instead of calling `read(max_size)`, it now calls `read(max_size + 1)`. If the resulting data's length is greater than `max_size`, it explicitly raises a `ValueError`.

#### Justification:
Silent truncation of remote files could lead to incomplete scans or bypassed security checks if malicious payloads are located past the 10MB limit. Explicitly rejecting oversized files ensures the user is aware of the limitation and the scan's integrity is maintained.

All 533 tests passed successfully.

---
*PR created automatically by Jules for task [11183406384581284070](https://jules.google.com/task/11183406384581284070) started by @RainRat*