### PR TITLE
[FEAT] Add support for scanning Dockerfiles and Makefiles

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -388,8 +388,13 @@ class Config:
         # Normalize file_path to string for consistent extension checking,
         # but keep Path objects for file-system operations.
         path_str = str(file_path).lower()
-        # Check archive extensions
-        if not is_member and (path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json'))):
+        # Check archive and container extensions
+        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json'))
+        if not is_container:
+            basename = os.path.basename(path_str)
+            is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
+
+        if not is_member and is_container:
             return True
 
         extension = os.path.splitext(path_str)[1]
@@ -1988,7 +1993,63 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 7. Fallback: yield as a single snippet if it's a supported file type
+    # 7. Check for Dockerfile
+    lowered_check = check_name.lower()
+    if 'dockerfile' in lowered_check and (os.path.basename(lowered_check) == 'dockerfile' or lowered_check.endswith('.dockerfile')):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Extract RUN, CMD, and ENTRYPOINT instructions with multi-line support
+            instructions = []
+            current_instr = []
+
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+
+                # Check for new instruction
+                instr_match = re.match(r'^\s*(?:RUN|CMD|ENTRYPOINT)\s+(.*)', line, re.IGNORECASE)
+                if instr_match:
+                    if current_instr:
+                        instructions.append(" ".join(current_instr))
+                    current_instr = [instr_match.group(1)]
+                elif current_instr:
+                    # Continuation of previous instruction if it ended with \
+                    if instructions and not current_instr: # Should not happen with current logic
+                         pass
+                    current_instr.append(line.strip())
+
+                # If line doesn't end with \, we've finished this instruction (if we were in one)
+                if current_instr and not line.rstrip().endswith('\\'):
+                    instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+                    current_instr = []
+
+            if current_instr:
+                instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+
+            if instructions:
+                for i, cmd in enumerate(instructions, 1):
+                    if cmd.strip():
+                        yield (f"{name} [Instruction {i}]", cmd.encode('utf-8'))
+                return
+        except Exception:
+            pass
+
+    # 8. Check for Makefile
+    if 'makefile' in lowered_check and (os.path.basename(lowered_check) == 'makefile' or lowered_check.endswith('.makefile')):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Extract recipes (lines starting with a tab)
+            recipes = re.findall(r'^\t(.*)', text, re.MULTILINE)
+            if recipes:
+                for i, recipe in enumerate(recipes, 1):
+                    if recipe.strip():
+                        yield (f"{name} [Recipe {i}]", recipe.encode('utf-8'))
+                return
+        except Exception:
+            pass
+
+    # 9. Fallback: yield as a single snippet if it's a supported file type
     # If scan_all_files is True, we always yield. Otherwise check extension/shebang.
     if Config.is_supported_file(check_name, content=content, is_member=(depth > 0)):
         yield name, content
@@ -2134,8 +2195,13 @@ def scan_files(
     for f_path in file_list:
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
-        # Check if it's a known container by extension or by content
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json')):
+        # Check if it's a known container by extension, by content, or by filename
+        is_container = path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json'))
+        if not is_container:
+            basename = os.path.basename(path_s)
+            is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
+
+        if is_container:
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,8 @@ The scanner finds scripts in several ways:
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Jupyter Notebook cells:** It extracts and scans individual code cells from `.ipynb` files.
 *   **By package.json scripts:** It extracts and scans individual commands from the `scripts` object in `package.json` files.
+*   **By Dockerfile instructions:** It extracts and scans `RUN`, `CMD`, and `ENTRYPOINT` instructions from Dockerfiles.
+*   **By Makefile recipes:** It extracts and scans recipes from Makefiles.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.
 *   **By HTML script tags:** It extracts and scans inline code from `<script>` tags in HTML files (`.html`, `.htm`, `.xhtml`).
 *   **By the first line of the file:** If a file does not have an extension, the tool checks the first line for a "shebang" (like `#!/bin/bash`). It recognizes many interpreters, including Python, Node.js, Bash (including Ash, Dash, and Zsh), Perl, Ruby, PHP, PowerShell, Lua, osascript, and iPython.

--- a/tests/test_devops_scanning.py
+++ b/tests/test_devops_scanning.py
@@ -1,0 +1,98 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_dockerfile_extraction():
+    content = b"""
+FROM python:3.9
+RUN pip install malicious-pkg
+COPY . /app
+CMD ["python", "app.py"]
+ENTRYPOINT ["/entrypoint.sh"]
+"""
+    results = list(unpack_content("Dockerfile", content))
+
+    # Expected instructions: RUN, CMD, ENTRYPOINT
+    assert len(results) == 3
+    assert results[0] == ("Dockerfile [Instruction 1]", b"pip install malicious-pkg")
+    assert results[1] == ("Dockerfile [Instruction 2]", b'["python", "app.py"]')
+    assert results[2] == ("Dockerfile [Instruction 3]", b'["/entrypoint.sh"]')
+
+def test_dockerfile_multiline():
+    content = b"""
+RUN apt-get update && \\
+    apt-get install -y \\
+    curl \\
+    wget
+"""
+    results = list(unpack_content("Dockerfile", content))
+    assert len(results) == 1
+    assert results[0][1] == b"apt-get update && apt-get install -y curl wget"
+
+def test_makefile_extraction():
+    content = b"""
+all: build
+
+build:
+\t./build.sh
+\t@echo "Done"
+
+clean:
+\trm -rf dist
+"""
+    results = list(unpack_content("Makefile", content))
+
+    # Expected recipes
+    assert len(results) == 3
+    assert results[0] == ("Makefile [Recipe 1]", b"./build.sh")
+    assert results[1] == ("Makefile [Recipe 2]", b'@echo "Done"')
+    assert results[2] == ("Makefile [Recipe 3]", b"rm -rf dist")
+
+def test_dockerfile_case_insensitive():
+    content = b"RUN echo 'hello'"
+    results = list(unpack_content("dockerfile", content))
+    assert len(results) == 1
+    assert results[0] == ("dockerfile [Instruction 1]", b"echo 'hello'")
+
+def test_makefile_case_insensitive():
+    content = b"\techo 'world'"
+    results = list(unpack_content("makefile", content))
+    assert len(results) == 1
+    assert results[0] == ("makefile [Recipe 1]", b"echo 'world'")
+
+def test_stricter_matching():
+    # Files that should NOT be treated as containers
+    content = b"some content"
+
+    # test_makefile.py should NOT be a container, but it IS a supported script (if .py is in extensions)
+    # So it might still yield a result, but not as a [Recipe X] or [Instruction X]
+    results = list(unpack_content("test_makefile.py", content))
+    for name, _ in results:
+        assert "[Recipe" not in name
+        assert "[Instruction" not in name
+
+    results = list(unpack_content("my_dockerfile.txt", content))
+    for name, _ in results:
+        assert "[Instruction" not in name
+
+def test_dockerfile_extension():
+    content = b"RUN malicious"
+    results = list(unpack_content("prod.dockerfile", content))
+    assert len(results) == 1
+    assert results[0][0] == "prod.dockerfile [Instruction 1]"
+
+def test_makefile_extension():
+    content = b"\tmalicious"
+    results = list(unpack_content("module.makefile", content))
+    assert len(results) == 1
+    assert results[0][0] == "module.makefile [Recipe 1]"
+
+def test_fallback_still_works():
+    # If a Dockerfile has no RUN/CMD/ENTRYPOINT, it should still be yielded as a whole file if it matches shebang or something (though Dockerfiles usually don't)
+    # More importantly, if a .py file was incorrectly matched as a container, it should fallback to being a .py file.
+
+    content = b"#!/usr/bin/env python\nprint('hello')"
+    # "Dockerfile" named file with python content and no Docker instructions
+    results = list(unpack_content("Dockerfile", content))
+    # It should yield the whole file because of the shebang fallback in unpack_content (step 9)
+    assert len(results) == 1
+    assert results[0] == ("Dockerfile", content)


### PR DESCRIPTION
This Pull Request introduces support for scanning Dockerfiles and Makefiles. The scanner now extracts and analyzes commands from `RUN`, `CMD`, and `ENTRYPOINT` instructions in Dockerfiles, as well as recipes in Makefiles. Stricter filename matching ensures these features are only applied to actual DevOps configuration files, and multi-line support in Dockerfiles captures complex commands correctly.

**Key Changes:**
- **Dockerfile Support:** Extracts instructions while correctly handling multi-line continuations (lines ending with `\`).
- **Makefile Support:** Extracts all recipe lines (lines starting with a TAB).
- **Strict Matching:** Only targets files named `dockerfile` or `makefile` (case-insensitive) or those with `.dockerfile` or `.makefile` extensions.
- **Documentation:** Updated `readme.md` to include these new formats in the "Supported Files" section.
- **Testing:** Added `tests/test_devops_scanning.py` with 9 test cases covering extraction, multi-line support, and strict matching.

---
*PR created automatically by Jules for task [5435591234860877809](https://jules.google.com/task/5435591234860877809) started by @RainRat*