### PR TITLE
Fix inconsistent Dockerfile backslash stripping

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2025,21 +2025,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 instr_match = re.match(r'^\s*(?:RUN|CMD|ENTRYPOINT)\s+(.*)', line, re.IGNORECASE)
                 if instr_match:
                     if current_instr:
-                        instructions.append(" ".join(current_instr))
+                        # Close previous instruction and ensure trailing backslashes (and following whitespace) are stripped
+                        instructions.append(" ".join([re.sub(r'\\\s*$', '', c).strip() for c in current_instr]))
                     current_instr = [instr_match.group(1)]
                 elif current_instr:
-                    # Continuation of previous instruction if it ended with \
-                    if instructions and not current_instr: # Should not happen with current logic
-                         pass
+                    # Continuation of previous instruction
                     current_instr.append(line.strip())
 
                 # If line doesn't end with \, we've finished this instruction (if we were in one)
-                if current_instr and not line.rstrip().endswith('\\'):
-                    instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+                if current_instr and not re.search(r'\\\s*$', line):
+                    instructions.append(" ".join([re.sub(r'\\\s*$', '', c).strip() for c in current_instr]))
                     current_instr = []
 
             if current_instr:
-                instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+                instructions.append(" ".join([re.sub(r'\\\s*$', '', c).strip() for c in current_instr]))
 
             if instructions:
                 for i, cmd in enumerate(instructions, 1):

--- a/tests/test_dockerfile_bug.py
+++ b/tests/test_dockerfile_bug.py
@@ -1,0 +1,15 @@
+from gptscan import unpack_content
+
+def test_dockerfile_instruction_switch_bug():
+    content = b"""
+RUN echo 1 \\
+CMD echo 2
+"""
+    results = list(unpack_content("Dockerfile", content))
+    # results[0] should be Instruction 1, results[1] should be Instruction 2
+    assert len(results) == 2
+    assert results[0][1] == b"echo 1"
+    assert results[1][1] == b"echo 2"
+
+if __name__ == "__main__":
+    test_dockerfile_instruction_switch_bug()


### PR DESCRIPTION
**PR Title:** [Fix inconsistent Dockerfile backslash stripping] 
**Description:** 
* **What:** Refactored the Dockerfile instruction extraction logic in `gptscan.py` to consistently handle multi-line instructions. The parser now uses a robust regular expression to identify and strip trailing backslashes (and any accidental trailing whitespace) at all three finalization points: when a new instruction keyword is encountered, when a block naturally ends, and at the end of the file.
* **Why:** The previous implementation had a logic bug where instructions terminated by a keyword switch would retain their trailing backslashes, leading to malformed code snippets. Consolidating the cleaning logic ensures consistent and accurate extraction of Dockerfile instructions for scanning. No breaking changes were introduced, and all 545 tests passed.

---
*PR created automatically by Jules for task [3480666793290739263](https://jules.google.com/task/3480666793290739263) started by @RainRat*