### PR TITLE
[TEST] Fix Dockerfile multi-line instruction parsing and add coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2025,12 +2025,9 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 instr_match = re.match(r'^\s*(?:RUN|CMD|ENTRYPOINT)\s+(.*)', line, re.IGNORECASE)
                 if instr_match:
                     if current_instr:
-                        instructions.append(" ".join(current_instr))
+                        instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
                     current_instr = [instr_match.group(1)]
                 elif current_instr:
-                    # Continuation of previous instruction if it ended with \
-                    if instructions and not current_instr: # Should not happen with current logic
-                         pass
                     current_instr.append(line.strip())
 
                 # If line doesn't end with \, we've finished this instruction (if we were in one)

--- a/tests/test_devops_scanning.py
+++ b/tests/test_devops_scanning.py
@@ -96,3 +96,25 @@ def test_fallback_still_works():
     # It should yield the whole file because of the shebang fallback in unpack_content (step 9)
     assert len(results) == 1
     assert results[0] == ("Dockerfile", content)
+
+def test_dockerfile_interrupted_instruction():
+    content = b"""
+RUN echo first \\
+RUN echo second
+"""
+    results = list(unpack_content("Dockerfile", content))
+    assert len(results) == 2
+    assert results[0][1] == b"echo first"
+    assert results[1][1] == b"echo second"
+
+def test_dockerfile_with_comments_and_newlines():
+    content = b"""
+RUN echo part1 \\
+    # some comment
+    part2 \\
+
+    part3
+"""
+    results = list(unpack_content("Dockerfile", content))
+    assert len(results) == 1
+    assert results[0][1] == b"echo part1 part2 part3"


### PR DESCRIPTION
This PR fixes a bug in the Dockerfile snippet extraction logic and increases test coverage for edge cases.

### Changes:
- **Bug Fix:** In `gptscan.py`, the Dockerfile parser now correctly strips trailing backslashes (`\`) when an instruction is terminated. Previously, backslashes were only stripped if the instruction ended "naturally" without being interrupted by a new `RUN`, `CMD`, or `ENTRYPOINT` keyword.
- **Robustness:** The fix applies `rstrip('\\').strip()` to all parts of a multi-line instruction at every exit point (new keyword, line without continuation, and end of file).
- **New Coverage:** Added tests to `tests/test_devops_scanning.py` to verify:
    - Instructions interrupted by a new keyword are correctly cleaned.
    - Instructions spanning across comments and empty lines are correctly joined.
- **Cleanup:** Removed a redundant/dead code block in the Dockerfile parsing loop.

Verified by running the specific new tests and the full test suite (546 tests).

---
*PR created automatically by Jules for task [3318977456408877874](https://jules.google.com/task/3318977456408877874) started by @RainRat*