### PR TITLE
[FEAT] CI/CD Workflow Script Extraction

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -393,7 +393,7 @@ class Config:
         # but keep Path objects for file-system operations.
         path_str = str(file_path).lower()
         # Check archive and container extensions
-        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json'))
+        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json', '.yml', '.yaml'))
         if not is_container:
             basename = os.path.basename(path_str)
             is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
@@ -2049,7 +2049,77 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 8. Check for Makefile
+    # 8. Check for CI/CD Workflows (YAML)
+    if lowered_check.endswith(('.yml', '.yaml')):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            snippets = []
+            script_keys = ['run', 'script', 'command', 'before_script', 'after_script']
+            # Match keys, optionally prefixed by a dash (common in YAML lists)
+            key_pattern = r'^\s*(?:-\s*)?(?:' + '|'.join(script_keys) + r'):\s*(.*)'
+            lines = text.splitlines()
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                match = re.match(key_pattern, line, re.IGNORECASE)
+                if match:
+                    first_line_val = match.group(1).strip()
+                    indent = len(line) - len(line.lstrip())
+
+                    if first_line_val in ('|', '>', '|-', '|+', '>-', '>+'):
+                        # Multi-line block
+                        block_lines = []
+                        i += 1
+                        while i < len(lines):
+                            if not lines[i].strip():
+                                block_lines.append("")
+                                i += 1
+                                continue
+                            current_indent = len(lines[i]) - len(lines[i].lstrip())
+                            if current_indent <= indent:
+                                break
+                            block_lines.append(lines[i])
+                            i += 1
+                        if block_lines:
+                            snippets.append("\n".join(block_lines))
+                        continue
+                    elif not first_line_val:
+                        # Potentially a list on the next lines
+                        list_items = []
+                        j = i + 1
+                        while j < len(lines):
+                            if not lines[j].strip():
+                                j += 1
+                                continue
+                            curr_indent = len(lines[j]) - len(lines[j].lstrip())
+                            if curr_indent <= indent:
+                                break
+                            list_match = re.match(r'^\s*-\s*(.*)', lines[j])
+                            if list_match:
+                                cmd = list_match.group(1).strip()
+                                if cmd:
+                                    list_items.append(cmd)
+                                j += 1
+                            else:
+                                break
+                        if list_items:
+                            snippets.append("\n".join(list_items))
+                            i = j
+                            continue
+                    elif first_line_val:
+                        # Single line command
+                        snippets.append(first_line_val)
+                i += 1
+
+            if snippets:
+                for idx, snippet in enumerate(snippets, 1):
+                    if snippet.strip():
+                        yield (f"{name} [Script {idx}]", snippet.encode('utf-8'))
+                return
+        except Exception:
+            pass
+
+    # 9. Check for Makefile
     if 'makefile' in lowered_check and (os.path.basename(lowered_check) == 'makefile' or lowered_check.endswith('.makefile')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -2210,7 +2280,7 @@ def scan_files(
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
         # Check if it's a known container by extension, by content, or by filename
-        is_container = path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json'))
+        is_container = path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json', '.yml', '.yaml'))
         if not is_container:
             basename = os.path.basename(path_s)
             is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
@@ -5126,7 +5196,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json files, Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json files, CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ GPT Virus Scanner uses AI to find malicious code in script files.
 *   **Local Scan:** A fast, built-in model checks files on your computer.
 *   **AI Analysis:** If a file looks suspicious, the tool can send it to an AI service (like OpenAI) for a detailed report.
 
-**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell), Jupyter Notebooks (.ipynb), Markdown files (.md), HTML files (.html, .htm), and archives (.zip, .tar), but does not analyze compiled programs.
+**Note:** This tool is a prototype, not a commercial antivirus product. It scans scripts (like Python, JavaScript, and PowerShell), CI/CD workflows (GitHub Actions, GitLab CI), Jupyter Notebooks (.ipynb), Markdown files (.md), HTML files (.html, .htm), and archives (.zip, .tar), but does not analyze compiled programs.
 
 ## Quick Start
 
@@ -87,6 +87,7 @@ The scanner finds scripts in several ways:
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Jupyter Notebook cells:** It extracts and scans individual code cells from `.ipynb` files.
 *   **By package.json scripts:** It extracts and scans individual commands from the `scripts` object in `package.json` files.
+*   **By CI/CD workflow scripts:** It extracts and scans `run`, `script`, and `command` blocks from YAML files (GitHub Actions, GitLab CI, etc.).
 *   **By Dockerfile instructions:** It extracts and scans `RUN`, `CMD`, and `ENTRYPOINT` instructions from Dockerfiles.
 *   **By Makefile recipes:** It extracts and scans recipes from Makefiles.
 *   **By Markdown blocks:** It extracts and scans code snippets from triple-backtick blocks in Markdown (`.md`) files.

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,84 @@
+import pytest
+from gptscan import unpack_content
+
+def test_extract_github_actions_run():
+    """Test extraction from a GitHub Actions workflow (multi-line run)."""
+    yaml_content = b"""
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        run: |
+          npm install
+          npm run build
+      - name: Test
+        run: npm test
+"""
+    results = list(unpack_content("workflow.yml", yaml_content))
+
+    assert len(results) == 2
+    assert results[0][0] == "workflow.yml [Script 1]"
+    assert b"npm install" in results[0][1]
+    assert b"npm run build" in results[0][1]
+    assert results[1][0] == "workflow.yml [Script 2]"
+    assert results[1][1] == b"npm test"
+
+def test_extract_gitlab_ci_script():
+    """Test extraction from a GitLab CI file (list-based script)."""
+    yaml_content = b"""
+build-job:
+  stage: build
+  script:
+    - echo "Compiling the code..."
+    - make
+  after_script:
+    - echo "Cleaning up..."
+"""
+    results = list(unpack_content(".gitlab-ci.yml", yaml_content))
+
+    assert len(results) == 2
+    assert results[0][0] == ".gitlab-ci.yml [Script 1]"
+    assert b"echo \"Compiling the code...\"" in results[0][1]
+    assert b"make" in results[0][1]
+    assert results[1][0] == ".gitlab-ci.yml [Script 2]"
+    assert results[1][1] == b"echo \"Cleaning up...\""
+
+def test_extract_generic_yaml_command():
+    """Test extraction from a generic YAML file (single line command)."""
+    yaml_content = b"""
+task:
+  name: deploy
+  command: ./deploy.sh --env production
+"""
+    results = list(unpack_content("task.yaml", yaml_content))
+
+    assert len(results) == 1
+    assert results[0][0] == "task.yaml [Script 1]"
+    assert results[0][1] == b"./deploy.sh --env production"
+
+def test_extract_dash_prefixed_key():
+    """Test extraction when the key is prefixed by a dash (e.g., - run: echo 1)."""
+    yaml_content = b"""
+steps:
+  - run: echo "dash prefixed"
+"""
+    results = list(unpack_content("dash.yml", yaml_content))
+    assert len(results) == 1
+    assert results[0][1] == b"echo \"dash prefixed\""
+
+def test_yaml_fallback_if_no_scripts():
+    """Test that it falls back to yielding the whole file if no script keys are found."""
+    yaml_content = b"""
+metadata:
+  name: my-app
+  version: 1.0.0
+"""
+    results = list(unpack_content("meta.yaml", yaml_content))
+
+    # Should yield the whole file as a single snippet
+    assert len(results) == 1
+    assert results[0][0] == "meta.yaml"
+    assert results[0][1] == yaml_content


### PR DESCRIPTION
### What
Added support for extracting and scanning script blocks from CI/CD workflow files (`.yml`, `.yaml`). This includes:
- Identifying script-related keys such as `run`, `script`, `command`, `before_script`, and `after_script`.
- Robust handling of YAML multi-line block scalars (using `|` or `>`) and dash-prefixed list items (common in GitLab CI and GitHub Actions steps).
- Automatic fallback to whole-file scanning if no specific script blocks are found in the YAML file.
- Integration into both GUI and CLI workflows.

### Why
I noticed that while `gptscan` successfully extracts scripts from Dockerfiles, Makefiles, and `package.json` files, it was missing support for CI/CD workflows. Given the rising frequency of supply chain attacks targeting CI/CD pipelines (e.g., malicious commands in GitHub Actions), this was a logical "missing piece" of functionality. By adding this feature, the tool can now pinpoint malicious code hidden inside infrastructure-as-code and automation scripts, rather than just scanning them as plain text.

### Implementation Details
- The extraction logic uses a combination of regex and indentation tracking to identify script blocks without requiring an external YAML parser dependency, maintaining the project's "Zero-Configuration" goal.
- The `is_supported_file` and `scan_files` functions were updated to classify `.yml` and `.yaml` as container formats, enabling the recursive unpacking logic.
- Documentation in `readme.md` and the CLI help string was updated to reflect this new capability.
- 5 new test cases were added to ensure high reliability across different YAML formatting styles.

---
*PR created automatically by Jules for task [1557142933248687275](https://jules.google.com/task/1557142933248687275) started by @RainRat*