### PR TITLE
Refactor redundant Dockerfile instruction finalization logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2041,6 +2041,10 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             instructions = []
             current_instr = []
 
+            def finalize_instr():
+                if current_instr:
+                    instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+
             for line in text.splitlines():
                 stripped = line.strip()
                 if not stripped or stripped.startswith('#'):
@@ -2049,19 +2053,17 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 # Check for new instruction
                 instr_match = re.match(r'^\s*(?:RUN|CMD|ENTRYPOINT)\s+(.*)', line, re.IGNORECASE)
                 if instr_match:
-                    if current_instr:
-                        instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+                    finalize_instr()
                     current_instr = [instr_match.group(1)]
                 elif current_instr:
                     current_instr.append(line.strip())
 
                 # If line doesn't end with \, we've finished this instruction (if we were in one)
                 if current_instr and not line.rstrip().endswith('\\'):
-                    instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+                    finalize_instr()
                     current_instr = []
 
-            if current_instr:
-                instructions.append(" ".join([c.rstrip('\\').strip() for c in current_instr]))
+            finalize_instr()
 
             if instructions:
                 for i, cmd in enumerate(instructions, 1):


### PR DESCRIPTION
* **What:** Extracted the redundant instruction finalization logic (`" ".join([c.rstrip('\\').strip() for c in current_instr])`) into a local helper function `finalize_instr()` within the Dockerfile parsing block of the `unpack_content` function.
* **Why:** Improves maintainability and readability by eliminating code duplication. The external behavior remains identical, and the change is verified by the existing `tests/test_devops_scanning.py` and the full test suite.

---
*PR created automatically by Jules for task [9158057385536120708](https://jules.google.com/task/9158057385536120708) started by @RainRat*