### PR TITLE
[UI/UX] Add 'Copy JSON' feature and shortcuts to Result Details view

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4187,6 +4187,14 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         root.clipboard_append(code)
         set_local_status("Code copied to clipboard.", temporary=True)
 
+    def copy_as_json_details():
+        results = _get_tree_results_as_dicts([current_item_id])
+        if results:
+            js = json.dumps(results[0], indent=2)
+            root.clipboard_clear()
+            root.clipboard_append(js)
+            set_local_status("Result copied as JSON.", temporary=True)
+
     def on_exclude():
         """Exclude current file and move to next."""
         nonlocal current_item_id
@@ -4231,6 +4239,10 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     copy_btn = ttk.Button(btn_frame, text="Copy Analysis", width=15, command=copy_analysis)
     copy_btn.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(copy_btn, "Copy the full analysis and snippet to clipboard.", label=status_bar)
+
+    copy_json_btn = ttk.Button(btn_frame, text="Copy JSON", width=12, command=copy_as_json_details)
+    copy_json_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(copy_json_btn, "Copy the current result as a JSON object. (Ctrl+J)", label=status_bar)
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -4386,6 +4398,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     details_win.bind('<Shift-Return>', lambda e: open_file(path_entry.get()))
     details_win.bind('<Control-s>', lambda e: copy_code())
     details_win.bind('<Command-s>', lambda e: copy_code())
+    details_win.bind('<Control-j>', lambda e: copy_as_json_details())
+    details_win.bind('<Command-j>', lambda e: copy_as_json_details())
     details_win.bind('<F5>', lambda e: on_rescan())
     details_win.bind('r', lambda e: on_rescan())
     details_win.bind('R', lambda e: on_rescan())

--- a/tests/test_view_details_json.py
+++ b/tests/test_view_details_json.py
@@ -1,0 +1,67 @@
+import pytest
+import json
+import tkinter as tk
+from unittest.mock import MagicMock, patch
+import gptscan
+from tests.test_view_details import mock_view_details_env, setup_details
+
+def test_view_details_copy_json(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    # Setup a result
+    raw = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1]
+    mock_tree._item_values["item1"] = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1, json.dumps(raw)]
+    mock_tree.get_children.return_value = ["item1"]
+    mock_tree.selection.return_value = ["item1"]
+
+    # We need to mock _get_tree_results_as_dicts or ensure it works with our mock tree
+    # Actually _get_tree_results_as_dicts uses tree.item(iid, 'values') and other tree methods.
+    # Our mock_tree in mock_view_details_env is already somewhat set up.
+
+    # Let's mock _get_tree_results_as_dicts to be sure what it returns
+    mock_json_result = [{"path": "test.py", "threat_level": "90%"}]
+    with patch("gptscan._get_tree_results_as_dicts", return_value=mock_json_result):
+        gptscan.view_details(item_id="item1")
+
+        # Find the Copy JSON button and command
+        assert "btn_Copy JSON" in captured
+        btn_mock, copy_json_cmd = captured["btn_Copy JSON"]
+
+        # Execute the command
+        from gptscan import root as mock_root
+        copy_json_cmd()
+
+        # Verify clipboard and status bar feedback
+        mock_root.clipboard_clear.assert_called()
+        # It should call json.dumps on the first element of the list
+        expected_json = json.dumps(mock_json_result[0], indent=2)
+        mock_root.clipboard_append.assert_called_with(expected_json)
+
+        # Verify feedback via status bar (it's the first label created in view_details)
+        status_bar = captured['labels'][0]
+        assert status_bar.config_data.get('text') == "Result copied as JSON."
+
+def test_view_details_json_shortcuts(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    raw = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1]
+    mock_tree._item_values["item1"] = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1, json.dumps(raw)]
+    mock_tree.get_children.return_value = ["item1"]
+    mock_tree.selection.return_value = ["item1"]
+
+    captured_bindings = {}
+    mock_toplevel.bind.side_effect = lambda event, func: captured_bindings.update({event: func})
+
+    mock_json_result = [{"path": "test.py", "threat_level": "90%"}]
+    with patch("gptscan._get_tree_results_as_dicts", return_value=mock_json_result):
+        gptscan.view_details(item_id="item1")
+
+        assert '<Control-j>' in captured_bindings
+        assert '<Command-j>' in captured_bindings
+
+        from gptscan import root as mock_root
+        captured_bindings['<Control-j>'](None)
+
+        expected_json = json.dumps(mock_json_result[0], indent=2)
+        mock_root.clipboard_append.assert_called_with(expected_json)
+
+        status_bar = captured['labels'][0]
+        assert status_bar.config_data.get('text') == "Result copied as JSON."


### PR DESCRIPTION
This PR improves the usability of the 'Result Details' view by adding a 'Copy JSON' feature.

### Problem
Users viewing a specific scan result often need the raw JSON data for that finding (e.g., to share with colleagues or use in external tools). Previously, they had to close the details window, find the result in the main list, and use the global export/copy features.

### Solution
- **New Button:** A 'Copy JSON' button is now available in the details window footer, placed logically next to 'Copy Analysis'.
- **Keyboard Shortcuts:** The feature is bound to `Ctrl+J` (Windows/Linux) and `Cmd+J` (macOS), maintaining consistency with the main window's JSON export shortcut.
- **Feedback:** Success is communicated via the local status bar ("Result copied as JSON.").

### Verification
- **New Tests:** `tests/test_view_details_json.py` covers button interaction and keyboard shortcuts.
- **Regression Testing:** All 554 existing tests passed.
- **Manual Verification:** Code changes were reviewed and confirmed to follow the project's GUI patterns.

---
*PR created automatically by Jules for task [12040459021811153236](https://jules.google.com/task/12040459021811153236) started by @RainRat*