### PR TITLE
[TEST] Consolidate container detection and add manifest coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -246,6 +246,20 @@ class Config:
         except (ValueError, TypeError):
             return default
 
+    @staticmethod
+    def is_container(file_path: Union[Path, str]) -> bool:
+        """Check if a file is a container that should be unpacked (archives, notebooks, manifests, etc.)."""
+        path_s = str(file_path).lower()
+        # Extensions and manifest files
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.yml', '.yaml',
+                            'package.json', 'composer.json', 'deno.json', 'deno.jsonc')):
+            return True
+        # Dockerfile and Makefile variants
+        basename = os.path.basename(path_s)
+        if basename in ('dockerfile', 'makefile') or basename.endswith(('.dockerfile', '.makefile')):
+            return True
+        return False
+
     apikey_missing_message = (
         "No API key found. You cannot use OpenAI or OpenRouter, but local scans and Ollama still work."
     )
@@ -386,16 +400,10 @@ class Config:
         if is_explicit or cls.scan_all_files:
             return True
 
-        # Normalize file_path to string for consistent extension checking,
-        # but keep Path objects for file-system operations.
+        # Normalize file_path to string for consistent extension checking
         path_str = str(file_path).lower()
-        # Check archive and container extensions
-        is_container = path_str.endswith(('.zip', '.tar', '.tar.gz', 'package.json', 'composer.json', 'deno.json', 'deno.jsonc', '.yml', '.yaml'))
-        if not is_container:
-            basename = os.path.basename(path_str)
-            is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
 
-        if not is_member and is_container:
+        if not is_member and cls.is_container(path_str):
             return True
 
         extension = os.path.splitext(path_str)[1]
@@ -2336,13 +2344,8 @@ def scan_files(
     for f_path in file_list:
         is_explicit = f_path in explicit_files
         path_s = str(f_path).lower()
-        # Check if it's a known container by extension, by content, or by filename
-        is_container = path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', 'package.json', '.yml', '.yaml'))
-        if not is_container:
-            basename = os.path.basename(path_s)
-            is_container = basename == 'dockerfile' or basename == 'makefile' or basename.endswith(('.dockerfile', '.makefile'))
 
-        if is_container:
+        if Config.is_container(path_s):
             try:
                 with open(f_path, 'rb') as f:
                     full_content = f.read()

--- a/tests/test_container_consistency.py
+++ b/tests/test_container_consistency.py
@@ -1,0 +1,67 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import gptscan
+from gptscan import scan_files, Config
+
+def test_local_composer_json_unpacking(monkeypatch, tmp_path):
+    """Test that a local composer.json is unpacked."""
+    composer_data = {
+        "scripts": {
+            "test": "phpunit"
+        }
+    }
+    composer_file = tmp_path / "composer.json"
+    composer_file.write_text(json.dumps(composer_data))
+
+    # Mock model to avoid TF
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.5]]
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+    monkeypatch.setattr(gptscan, "_tf_module", MagicMock())
+
+    Config.set_extensions(Config.DEFAULT_EXTENSIONS)
+
+    events = list(scan_files(
+        scan_targets=[str(composer_file)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    names = [r[0] for r in results]
+
+    # If it's not unpacked, name will be just the path to composer.json
+    # If it is unpacked, it should contain "[Script: test]"
+    assert any("[Script: test]" in n for n in names), f"Expected unpacked script for local composer.json, but got names: {names}"
+
+def test_local_deno_json_unpacking(monkeypatch, tmp_path):
+    """Test that a local deno.json is unpacked."""
+    deno_data = {
+        "tasks": {
+            "start": "deno run main.ts"
+        }
+    }
+    deno_file = tmp_path / "deno.json"
+    deno_file.write_text(json.dumps(deno_data))
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [[0.5]]
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+    monkeypatch.setattr(gptscan, "_tf_module", MagicMock())
+
+    Config.set_extensions(Config.DEFAULT_EXTENSIONS)
+
+    events = list(scan_files(
+        scan_targets=[str(deno_file)],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    names = [r[0] for r in results]
+
+    assert any("[Task: start]" in n for n in names), f"Expected unpacked task for local deno.json, but got names: {names}"


### PR DESCRIPTION
### Description
- **Type:** New Coverage / Refactor
- **What:** Unified container detection logic into `Config.is_container` and added integration tests for `composer.json` and `deno.json` manifest scanning.
- **Why:** Previously, container detection was duplicated across `Config.is_supported_file` and `scan_files`, leading to inconsistencies where local manifest files were ignored during scanning while URL-based or clipboard-based versions were processed. This change ensures all scannable "containers" (archives, notebooks, manifests, etc.) are handled uniformly regardless of their source.

### Changes
- Added `Config.is_container` in `gptscan.py`.
- Updated `Config.is_supported_file` and `scan_files` to call `Config.is_container`.
- Added `tests/test_container_consistency.py` with 2 new test cases.
- Verified fix with `pytest` (all 564 tests passing).

---
*PR created automatically by Jules for task [6095280581586133985](https://jules.google.com/task/6095280581586133985) started by @RainRat*