### PR TITLE
[UI/UX] Relocate result filtering controls to the filter bar

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4923,28 +4923,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
     bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")
 
-    def on_threshold_change():
-        try:
-            val = int(threshold_spin.get())
-            Config.THRESHOLD = max(0, min(100, val))
-            _apply_filter()
-        except ValueError:
-            pass
-
-    threshold_frame = ttk.Frame(options_frame)
-    threshold_frame.grid(row=3, column=0, columnspan=2, sticky='w', padx=10, pady=2)
-
-    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
-    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
-    threshold_spin.delete(0, tk.END)
-    threshold_spin.insert(0, str(Config.THRESHOLD))
-    threshold_spin.pack(side=tk.LEFT, padx=5)
-    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
-    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
-
-    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
-    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
-    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
@@ -5071,8 +5049,33 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         _apply_filter()
 
     clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
-    clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
+    clear_filter_btn.grid(row=0, column=2, padx=(5, 5), ipady=5)
     bind_hover_message(clear_filter_btn, "Clear the filter.")
+
+    ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)
+
+    def on_threshold_change():
+        try:
+            val = int(threshold_spin.get())
+            Config.THRESHOLD = max(0, min(100, val))
+            _apply_filter()
+        except ValueError:
+            pass
+
+    threshold_frame = ttk.Frame(filter_frame)
+    threshold_frame.grid(row=0, column=4, sticky='w')
+
+    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
+    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
+    threshold_spin.delete(0, tk.END)
+    threshold_spin.insert(0, str(Config.THRESHOLD))
+    threshold_spin.pack(side=tk.LEFT, padx=5)
+    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
+    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
+
+    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
+    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
+    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Treeview ---
     style.configure('Scanner.Treeview', rowheight=50)

--- a/readme.md
+++ b/readme.md
@@ -130,8 +130,6 @@ Run `python gptscan.py` to open the GUI.
 *   **Scan all files:** Scan every file, even those without common script extensions.
 *   **Dry Run:** Simulate the scan without actually analyzing any files.
 *   **Max File Size (MB):** Skip files larger than this size.
-*   **Min. Threat Level:** Set the sensitivity. Higher values show only the most dangerous files.
-*   **Show all files:** See every scanned file, even safe ones.
 
 #### AI Analysis
 *   **Use AI Analysis:** Enable detailed reports for suspicious findings.
@@ -142,6 +140,8 @@ Run `python gptscan.py` to open the GUI.
 #### Results and Filtering
 *   **Filter:** Search the results list by path, threat level, notes, or code snippet.
 *   **Clear:** Clear the current filter text.
+*   **Min. Threat Level:** Set the sensitivity. Higher values show only the most dangerous files.
+*   **Show all files:** See every scanned file, even safe ones.
 
 #### Actions
 *   **Scan Now:** Start the scanning process.


### PR DESCRIPTION
### [UI/UX] Relocate result filtering controls to the filter bar

**Context:** GUI

**Problem:** The "Min. Threat Level" and "Show all files" controls were located in the "Scan Options" section, which is primarily for scan-time configuration. These controls actually filter the *results* currently shown in the list, creating a disconnect between the control location and the data they affect.

**Solution:** Relocated these filtering controls to the results filter bar. This groups all visibility-related tools (text search, threat threshold, and 'show all' toggle) in a single, cohesive toolbar just above the results tree. This improves visual hierarchy and reduces the friction of managing result visibility.

**Changes:**
1.  Modified `gptscan.py`:
    *   Moved `threshold_frame` (containing the threat level spinbox and "Show all files" checkbox) from the `options_frame` to the `filter_frame`.
    *   Updated the `filter_frame` layout to include a vertical separator between the text filter and the threshold controls.
    *   Adjusted the grid layout of `filter_frame` to accommodate the new controls while keeping the text filter expandable.
2.  Updated `readme.md`:
    *   Moved documentation for "Min. Threat Level" and "Show all files" from the "Scan Options" section to the "Results and Filtering" section to match the new UI layout.

---
*PR created automatically by Jules for task [15344585458916460730](https://jules.google.com/task/15344585458916460730) started by @RainRat*