### PR TITLE
[FEAT] Import scan results from URL

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3696,12 +3696,16 @@ def import_results_from_content_generator(content: str, filename_hint: Optional[
 
 
 def import_results_generator(file_path: str) -> Generator[Tuple[str, Any], None, None]:
-    """Generator that yields events from an imported report file."""
+    """Generator that yields events from an imported report file or URL."""
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        if file_path.lower().startswith(('http://', 'https://')):
+            content_bytes = fetch_url_content(file_path)
+            content = content_bytes.decode('utf-8', errors='ignore')
+        else:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
         if not content.strip():
-            raise ValueError("File is empty.")
+            raise ValueError("File or URL content is empty.")
     except Exception as e:
         yield ('progress', (0, 1, f"Error: {e}"))
         return
@@ -3809,6 +3813,33 @@ def import_from_clipboard(event: Optional[tk.Event] = None) -> Optional[str]:
         messagebox.showerror("Import Failed", f"Could not parse clipboard content:\n{err}")
 
     return "break"
+
+
+def import_from_url() -> None:
+    """Import scan results from a web link (JSON, CSV, SARIF, Markdown, or HTML)."""
+    if not tree:
+        return
+
+    url = simpledialog.askstring("Import from URL", "Enter the URL of the scan results to import:")
+    if not url:
+        return
+
+    url = url.strip()
+    try:
+        update_status(f"Fetching results from {url}...")
+        content_bytes = fetch_url_content(url)
+        content = content_bytes.decode('utf-8', errors='ignore')
+
+        data_to_import = parse_report_content(content, filename_hint=url)
+
+        if not data_to_import:
+            messagebox.showwarning("Import Warning", "No valid scan results found at the provided URL.")
+            return
+
+        _finalize_import(data_to_import, url)
+
+    except Exception as err:
+        messagebox.showerror("Import Failed", f"Could not import results from URL:\n{err}")
 
 
 def clear_ai_cache() -> None:
@@ -4825,6 +4856,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     file_menu = tk.Menu(menubar, tearoff=0)
     file_menu.add_command(label="Import Results...", command=import_results)
     file_menu.add_command(label="Import from Clipboard", command=import_from_clipboard)
+    file_menu.add_command(label="Import from URL...", command=import_from_url)
     file_menu.add_command(label="Export Results...", command=export_results)
     file_menu.add_command(label="Manage Exclusions...", command=manage_exclusions)
     file_menu.add_command(label="Manage Extensions...", command=manage_extensions)
@@ -5177,6 +5209,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     results_menu = tk.Menu(results_button, tearoff=0)
     results_menu.add_command(label="Import Results...", command=import_results)
     results_menu.add_command(label="Import from Clipboard", command=import_from_clipboard)
+    results_menu.add_command(label="Import from URL...", command=import_from_url)
     results_menu.add_command(label="Export Results...", command=export_results)
     results_menu.add_separator()
     results_menu.add_command(label="Clear Results", command=clear_results)

--- a/tests/test_import_results_url.py
+++ b/tests/test_import_results_url.py
@@ -1,0 +1,107 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+
+def test_import_from_url_success(monkeypatch):
+    """Test importing scan results from a URL successfully."""
+    mock_url = "https://example.com/results.json"
+    data = [
+        {
+            "path": "test.py",
+            "own_conf": "85%",
+            "admin_desc": "Suspicious",
+            "end-user_desc": "Don't run",
+            "gpt_conf": "90%",
+            "snippet": "print('hello')",
+            "line": "10"
+        }
+    ]
+    content = json.dumps(data).encode('utf-8')
+
+    # Mock GUI components
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree)
+    monkeypatch.setattr(gptscan.tkinter.simpledialog, "askstring", lambda *args, **kwargs: mock_url)
+
+    # Mock network call
+    mock_fetch = MagicMock(return_value=content)
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    # Mock internal helpers
+    mock_finalize = MagicMock()
+    monkeypatch.setattr(gptscan, "_finalize_import", mock_finalize)
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+
+    gptscan.import_from_url()
+
+    mock_fetch.assert_called_once_with(mock_url)
+    mock_finalize.assert_called_once()
+    args, _ = mock_finalize.call_args
+    assert args[0][0]["path"] == "test.py"
+    assert args[1] == mock_url
+
+def test_import_from_url_cancelled(monkeypatch):
+    """Test that cancelling the URL dialog does nothing."""
+    monkeypatch.setattr(gptscan, "tree", MagicMock())
+    monkeypatch.setattr(gptscan.tkinter.simpledialog, "askstring", lambda *args, **kwargs: None)
+
+    mock_fetch = MagicMock()
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    gptscan.import_from_url()
+    mock_fetch.assert_not_called()
+
+def test_import_from_url_error(monkeypatch):
+    """Test error handling when fetching from URL fails."""
+    mock_url = "https://example.com/results.json"
+    monkeypatch.setattr(gptscan, "tree", MagicMock())
+    monkeypatch.setattr(gptscan.tkinter.simpledialog, "askstring", lambda *args, **kwargs: mock_url)
+
+    def mock_fetch_error(url):
+        raise ValueError("Network error")
+
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch_error)
+
+    mock_messagebox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_messagebox)
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+
+    gptscan.import_from_url()
+
+    mock_messagebox.showerror.assert_called()
+    assert "Network error" in mock_messagebox.showerror.call_args[0][1]
+
+def test_import_results_generator_url(monkeypatch):
+    """Test the generator used by CLI for URL imports."""
+    mock_url = "http://example.com/results.json"
+    data = [{"path": "remote.py", "own_conf": "50%"}]
+    content = json.dumps(data).encode('utf-8')
+
+    mock_fetch = MagicMock(return_value=content)
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    events = list(gptscan.import_results_generator(mock_url))
+
+    # Check if we got the result event
+    result_events = [e for e in events if e[0] == 'result']
+    assert len(result_events) == 1
+    assert result_events[0][1][0] == "remote.py"
+    mock_fetch.assert_called_once_with(mock_url)
+
+def test_import_results_generator_file(monkeypatch, tmp_path):
+    """Verify that file imports still work with the updated generator."""
+    local_file = tmp_path / "local.json"
+    data = [{"path": "local.py", "own_conf": "10%"}]
+    local_file.write_text(json.dumps(data))
+
+    # Mock fetch to ensure it's NOT called for local files
+    mock_fetch = MagicMock()
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    events = list(gptscan.import_results_generator(str(local_file)))
+
+    result_events = [e for e in events if e[0] == 'result']
+    assert len(result_events) == 1
+    assert result_events[0][1][0] == "local.py"
+    mock_fetch.assert_not_called()


### PR DESCRIPTION
This PR introduces the ability to import scan results directly from a web link (URL). This follows the codebase's existing "Import from File" and "Import from Clipboard" patterns, providing a seamless way to review results hosted on remote servers or generated by CI/CD pipelines.

Key changes:
1.  **GUI Support:** A new `import_from_url` function has been added, accessible via the "Import from URL..." menu option in both the main 'File' menu and the 'Results' dropdown in the footer.
2.  **CLI Support:** The `--import-results` (or `--import`) flag now automatically detects if the provided path is a URL (starting with `http://` or `https://`) and fetches the content accordingly.
3.  **Robustness:** Uses the existing `fetch_url_content` utility to handle network requests and `parse_report_content` for universal format detection (JSON, CSV, SARIF, Markdown, HTML).
4.  **Testing:** A new test file `tests/test_import_results_url.py` ensures both GUI and CLI paths are correctly handled, including error scenarios.

---
*PR created automatically by Jules for task [3088751652076445165](https://jules.google.com/task/3088751652076445165) started by @RainRat*