### PR TITLE
[DOCS] Clarify Python version prerequisites in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 ## Installation
 
 ### Prerequisites
-*   Python 3.8 or higher.
+*   Python 3.9, 3.10, or 3.11. (Python 3.12 is not supported yet due to model compatibility).
 *   (Optional) An API key for [OpenAI](https://platform.openai.com/) or [OpenRouter](https://openrouter.ai/).
 *   (Optional) [Ollama](https://ollama.com/) for local AI analysis.
 


### PR DESCRIPTION
Updated the `readme.md` file to accurately reflect the supported Python versions. The documentation now specifies that Python 3.9, 3.10, or 3.11 is required and explicitly states that Python 3.12 is not currently supported due to machine learning model compatibility issues. This change helps prevent installation and runtime errors for users on newer Python environments.

---
*PR created automatically by Jules for task [12394664050821822723](https://jules.google.com/task/12394664050821822723) started by @RainRat*