### PR TITLE
Fix logic bug in GitLab repository URL resolution

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -138,7 +138,7 @@ def resolve_remote_url(url: str) -> str:
     # 8. GitLab Repo -> ZIP Archive
     # Example: https://gitlab.com/user/repo -> https://gitlab.com/user/repo/-/archive/main/repo-main.zip
     # Note: GitLab is trickier as the default branch varies. We'll try common patterns.
-    gl_repo_match = re.match(r'https?://(?:www\.)?gitlab\.com/(.+)/([^/]+)$', url, re.IGNORECASE)
+    gl_repo_match = re.match(r'https?://(?:www\.)?gitlab\.com/(?!.*/-/)(.+)/([^/]+)$', url, re.IGNORECASE)
     if gl_repo_match:
         group_path, repo = gl_repo_match.groups()
         # GitLab doesn't have a universal HEAD.zip, but we can try to guess or just return the URL

--- a/tests/test_url_resolution.py
+++ b/tests/test_url_resolution.py
@@ -115,3 +115,8 @@ def test_resolve_github_www_prefix():
     url = "https://www.github.com/user/repo/blob/main/script.py"
     expected = "https://raw.githubusercontent.com/user/repo/main/script.py"
     assert resolve_remote_url(url) == expected
+
+def test_resolve_gitlab_issues_not_repo():
+    url = "https://gitlab.com/user/repo/-/issues"
+    # Should not be resolved to an archive
+    assert resolve_remote_url(url) == url


### PR DESCRIPTION
* **What:** Updated the GitLab repository root regular expression in `resolve_remote_url` to include a negative lookahead `(?!.*/-/)`.
* **Why:** This prevents GitLab feature pages (like `/issues`, `/merge_requests`, or `/settings`) from being incorrectly identified as repository roots and resolved to archive links. This is a non-breaking fix that improves the accuracy of remote URL scanning. Added a new test case `test_resolve_gitlab_issues_not_repo` to `tests/test_url_resolution.py` to ensure continued correctness.

---
*PR created automatically by Jules for task [6893263104277405010](https://jules.google.com/task/6893263104277405010) started by @RainRat*