### PR TITLE
[TEST] Support multi-line Makefile recipes in unpack_content

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2295,8 +2295,27 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
     if 'makefile' in lowered_check and (os.path.basename(lowered_check) == 'makefile' or lowered_check.endswith('.makefile')):
         try:
             text = content.decode('utf-8', errors='ignore')
-            # Extract recipes (lines starting with a tab)
-            recipes = re.findall(r'^\t(.*)', text, re.MULTILINE)
+            # Extract recipes (lines starting with a tab) with multi-line support
+            recipes = []
+            current_recipe = []
+
+            def finalize_recipe():
+                if current_recipe:
+                    recipes.append(" ".join([c.rstrip('\\').strip() for c in current_recipe]))
+
+            for line in text.splitlines():
+                if line.startswith('\t'):
+                    current_recipe.append(line[1:])
+                    # If line doesn't end with \, we've finished this recipe
+                    if not line.rstrip().endswith('\\'):
+                        finalize_recipe()
+                        current_recipe = []
+                elif current_recipe:
+                    finalize_recipe()
+                    current_recipe = []
+
+            finalize_recipe()
+
             if recipes:
                 for i, recipe in enumerate(recipes, 1):
                     if recipe.strip():

--- a/tests/test_devops_scanning.py
+++ b/tests/test_devops_scanning.py
@@ -118,3 +118,15 @@ RUN echo part1 \\
     results = list(unpack_content("Dockerfile", content))
     assert len(results) == 1
     assert results[0][1] == b"echo part1 part2 part3"
+
+def test_makefile_multiline():
+    content = b"""
+target:
+\techo "part 1" \\
+\t"part 2"
+\techo "part 3"
+"""
+    results = list(unpack_content("Makefile", content))
+    assert len(results) == 2
+    assert results[0][1] == b'echo "part 1" "part 2"'
+    assert results[1][1] == b'echo "part 3"'


### PR DESCRIPTION
This PR improves the Makefile snippet extraction in `gptscan.py`. Previously, the scanner used a simple regex that treated every line starting with a tab as an independent command, failing to account for line continuations (`\`).

The improved implementation uses a stateful parser that:
1. Iterates through the Makefile line by line.
2. Identifies lines starting with tabs (recipes).
3. Correctly joins lines ending with `\` into a single snippet, removing the continuation character and normalizing whitespace.
4. Correctly handles recipe termination by non-tabbed lines.

A new test case `test_makefile_multiline` has been added to `tests/test_devops_scanning.py` to verify this behavior and ensure no regressions for standard single-line recipes.

---
*PR created automatically by Jules for task [4258172953934387278](https://jules.google.com/task/4258172953934387278) started by @RainRat*