### PR TITLE
[DOCS] Remove unnecessary pyyaml dependency from readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
     ```
 2.  Install dependencies:
     ```bash
-    pip install "tensorflow<2.16" numpy openai pyyaml
+    pip install "tensorflow<2.16" numpy openai
     ```
 
 > **Important:** Always run the script from inside its own folder so it can find its required data files (like `scripts.h5`).


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the installation instructions in `readme.md`.
* **Why:** Simplified the installation steps by removing the `pyyaml` dependency, which is not required for the core scanner functionality. This reduces the number of packages users need to install and avoids confusion since `gptscan.py` handles YAML parsing via regex.

---
*PR created automatically by Jules for task [8439207564341527575](https://jules.google.com/task/8439207564341527575) started by @RainRat*