### PR TITLE
Fix path splitting bug for Path objects with spaces

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1012,11 +1012,13 @@ def collect_files(targets: Union[str, List[str]]) -> List[Path]:
     List[Path]
         A deduplicated list of files to scan.
     """
-    if isinstance(targets, (str, Path)):
+    if isinstance(targets, Path):
+        targets = [str(targets)]
+    elif isinstance(targets, str):
         try:
-            targets = shlex.split(str(targets))
+            targets = shlex.split(targets)
         except ValueError:
-            targets = [str(targets)]
+            targets = [targets]
 
     results: List[Path] = []
     for t in targets:
@@ -2438,11 +2440,13 @@ def scan_files(
             return float(prediction), bytes(padded_data)
 
     # Identify which files were explicitly passed as targets and deduplicate them
-    if isinstance(scan_targets, (str, Path)):
+    if isinstance(scan_targets, Path):
+        scan_targets = [str(scan_targets)]
+    elif isinstance(scan_targets, str):
         try:
-            scan_targets = shlex.split(str(scan_targets))
+            scan_targets = shlex.split(scan_targets)
         except ValueError:
-            scan_targets = [str(scan_targets)]
+            scan_targets = [scan_targets]
 
     scan_targets = list(dict.fromkeys(scan_targets))
 


### PR DESCRIPTION
Updated `collect_files` and `scan_files` in `gptscan.py` to handle `Path` objects explicitly. If a target is a `Path` instance, it is now treated as a single target, skipping the `shlex.split` logic that is intended only for space-separated strings. This fixes a logic bug where filesystem paths containing spaces (e.g., from a GUI file picker) were incorrectly fragmented into multiple non-existent targets. String-based inputs still support multiple space-separated targets as before. This change is non-breaking and improves the robustness of programmatic and GUI-driven scans.

---
*PR created automatically by Jules for task [3494197514948677456](https://jules.google.com/task/3494197514948677456) started by @RainRat*