### PR TITLE
[TEST] CI/CD YAML list parsing robustness and fix

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "/some/path",
+    "last_path": "file1.py file2.js",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,8 +12,8 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "/some/path",
         "file1.py file2.js",
+        "/some/path",
         "/some/repo",
         "1",
         "2",

--- a/gptscan.py
+++ b/gptscan.py
@@ -2218,7 +2218,8 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                         list_items = []
                         j = i + 1
                         while j < len(lines):
-                            if not lines[j].strip():
+                            stripped_j = lines[j].strip()
+                            if not stripped_j or stripped_j.startswith('#'):
                                 j += 1
                                 continue
                             curr_indent = len(lines[j]) - len(lines[j].lstrip())

--- a/tests/test_ci_yaml_robustness.py
+++ b/tests/test_ci_yaml_robustness.py
@@ -1,0 +1,52 @@
+import pytest
+from gptscan import unpack_content
+
+def test_yaml_list_with_comments():
+    content = b"""
+script:
+  - echo "1"
+  # comment
+  - echo "2"
+"""
+    snippets = list(unpack_content("test.yml", content))
+    commands = [s[1].decode('utf-8') for s in snippets]
+    assert 'echo "1"\necho "2"' in commands
+
+def test_yaml_list_with_empty_lines():
+    content = b"""
+script:
+  - echo "1"
+
+  - echo "2"
+"""
+    snippets = list(unpack_content("test.yml", content))
+    commands = [s[1].decode('utf-8') for s in snippets]
+    assert 'echo "1"\necho "2"' in commands
+
+def test_yaml_list_indented_comments():
+    content = b"""
+script:
+  - echo "1"
+    # comment same level as script
+  - echo "2"
+"""
+    snippets = list(unpack_content("test.yml", content))
+    commands = [s[1].decode('utf-8') for s in snippets]
+    assert 'echo "1"\necho "2"' in commands
+
+def test_yaml_complex_list():
+    content = b"""
+before_script:
+  - export VAR=1
+  # Setup steps
+  - ./setup.sh
+
+script:
+  - make build
+  # Run tests
+  - make test
+"""
+    snippets = list(unpack_content(".gitlab-ci.yml", content))
+    assert len(snippets) == 2
+    assert b"export VAR=1\n./setup.sh" in snippets[0][1]
+    assert b"make build\nmake test" in snippets[1][1]


### PR DESCRIPTION
*   **Type:** New Coverage / Bug Fix
*   **What:** Improved the YAML parsing logic in `unpack_content` within `gptscan.py` to handle list-based script sections that contain comments or empty lines. Added a new test suite `tests/test_ci_yaml_robustness.py` covering these edge cases.
*   **Why:** Previously, the iterative parser for YAML lists would break or stop prematurely when encountering a comment line, resulting in only a partial extraction of scripts from CI/CD configuration files (like `.gitlab-ci.yml` or GitHub Actions workflows). This fix ensures complete coverage for these file types.

---
*PR created automatically by Jules for task [8648513395914934186](https://jules.google.com/task/8648513395914934186) started by @RainRat*