### PR TITLE
[DOCS] Correct CLI flag for API base URL in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--provider [name]`: Select the AI service provider (`openai`, `openrouter`, or `ollama`).
 *   `--model [name]`: Set the AI model (for example: `gpt-4o`, `llama3.2`).
 *   `--api-key [key], -k [key]`: Set the API key.
-*   `--api-url [url]`: Set a custom base URL for the API.
+*   `--api-base [url]`: Set a custom base URL for the API.
 *   `--max-size [MB]`: Maximum file size to scan (e.g., "10MB"). Default is 10MB.
 *   `--output [file], -o [file]`: Save results to a file (JSON, CSV, SARIF, Markdown, or HTML).
 *   `--report`: Output a human-friendly triage report to the console.


### PR DESCRIPTION
The `readme.md` file incorrectly listed `--api-url` as the flag for setting a custom API base URL. This PR updates it to `--api-base` to match the actual code implementation in `gptscan.py`, ensuring accurate usage instructions for developers using custom or local AI services.

---
*PR created automatically by Jules for task [17519596054617594934](https://jules.google.com/task/17519596054617594934) started by @RainRat*