### PR TITLE
[UI/UX] Enhanced Keyboard Shortcuts and Tooltips for Triage Efficiency

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "/some/path",
+    "last_path": "file1.py file2.js",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,8 +12,8 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "/some/path",
         "file1.py file2.js",
+        "/some/path",
         "/some/repo",
         "1",
         "2",

--- a/gptscan.py
+++ b/gptscan.py
@@ -4327,7 +4327,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     reveal_btn = ttk.Button(header_frame, text="Reveal", width=10, command=lambda: show_in_folder(path_entry.get()))
     reveal_btn.grid(row=1, column=3, padx=2)
-    bind_hover_message(reveal_btn, "Show this file in the system file manager.", label=status_bar)
+    bind_hover_message(reveal_btn, "Show this file in the system file manager. (Ctrl+Enter)", label=status_bar)
 
     open_btn = ttk.Button(header_frame, text="Open", width=10, command=lambda: open_file(path_entry.get()))
     open_btn.grid(row=1, column=4, padx=2)
@@ -4440,7 +4440,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     # Group: Actions
     analyze_btn = ttk.Button(btn_frame, text="Analyze with AI", width=18, command=on_analyze_now, style='Primary.TButton')
     analyze_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(analyze_btn, "Use AI to analyze this code snippet.", label=status_bar)
+    bind_hover_message(analyze_btn, "Use AI to analyze this code snippet. (Ctrl+G)", label=status_bar)
     if not Config.GPT_ENABLED:
         analyze_btn.config(state='disabled')
 
@@ -4464,7 +4464,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     # Group: Copy & Export
     copy_btn = ttk.Button(btn_frame, text="Copy Analysis", width=15, command=copy_analysis)
     copy_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_btn, "Copy the full analysis and snippet to clipboard.", label=status_bar)
+    bind_hover_message(copy_btn, "Copy the full analysis and snippet to clipboard. (Ctrl+Shift+C)", label=status_bar)
 
     copy_json_btn = ttk.Button(btn_frame, text="Copy JSON", width=12, command=copy_as_json_details)
     copy_json_btn.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -4479,7 +4479,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     # Group: View
     source_toggle_btn = ttk.Button(btn_frame, text="Show Full Source", width=18, command=toggle_source)
     source_toggle_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(source_toggle_btn, "Toggle between the suspicious snippet and the full file content.", label=status_bar)
+    bind_hover_message(source_toggle_btn, "Toggle between the suspicious snippet and the full file content. (Ctrl+U)", label=status_bar)
 
     # Group: System
     close_btn = ttk.Button(btn_frame, text="Close", command=details_win.destroy)
@@ -4611,10 +4611,18 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     details_win.bind('<Delete>', lambda e: on_exclude())
     details_win.bind('<Escape>', lambda e: details_win.destroy())
     details_win.bind('<Shift-Return>', lambda e: open_file(path_entry.get()))
+    details_win.bind('<Control-Return>', lambda e: show_in_folder(path_entry.get()))
+    details_win.bind('<Command-Return>', lambda e: show_in_folder(path_entry.get()))
     details_win.bind('<Control-s>', lambda e: copy_code())
     details_win.bind('<Command-s>', lambda e: copy_code())
     details_win.bind('<Control-j>', lambda e: copy_as_json_details())
     details_win.bind('<Command-j>', lambda e: copy_as_json_details())
+    details_win.bind('<Control-g>', lambda e: on_analyze_now())
+    details_win.bind('<Command-g>', lambda e: on_analyze_now())
+    details_win.bind('<Control-Shift-C>', lambda e: copy_analysis())
+    details_win.bind('<Command-Shift-C>', lambda e: copy_analysis())
+    details_win.bind('<Control-u>', lambda e: toggle_source())
+    details_win.bind('<Command-u>', lambda e: toggle_source())
     details_win.bind('<F5>', lambda e: on_rescan())
     details_win.bind('r', lambda e: on_rescan())
     details_win.bind('R', lambda e: on_rescan())


### PR DESCRIPTION
### PR Title: [UI/UX] Enhanced Keyboard Shortcuts and Tooltips for Triage Efficiency

**Description:**

*   **Context:** GUI
*   **Problem:** Users performing triage in the 'Result Details' window must rely on mouse clicks for common actions like AI analysis, toggling source view, or revealing files in the folder. This creates significant friction and slows down the workflow during high-volume security reviews.
*   **Solution:** Improved the triage experience by adding keyboard shortcuts for the most frequent actions and updating hover messages to aid discoverability.
    *   **New Shortcuts:**
        *   `Ctrl+G` (or `Cmd+G` on macOS): Trigger AI Analysis for the current snippet.
        *   `Ctrl+Shift+C` (or `Cmd+Shift+C` on macOS): Copy the full analysis report.
        *   `Ctrl+U` (or `Cmd+U` on macOS): Toggle between the suspicious code snippet and the full source view.
        *   `Ctrl+Enter` (or `Cmd+Enter` on macOS): Reveal the file in the system file manager.
    *   **Discoverability:** Updated the hover tooltips for the "Analyze with AI", "Copy Analysis", "Show Full Source", and "Reveal" buttons to explicitly mention these new shortcuts.
    *   **Consistency:** These changes align the details window with common UX patterns found in the main application window and standard development tools.

**Changes:**

- Modified the `view_details` function in `gptscan.py` to implement `details_win.bind` calls for the new shortcuts.
- Updated `bind_hover_message` strings for the corresponding buttons in the details window.
- Verified that all shortcuts correctly handle the Tkinter event argument and trigger the intended logic.
- Confirmed that existing functionality (Rescan with `F5`, Close with `Esc`, etc.) remains unaffected.
- Verified that the non-training test suite passes after these modifications.

---
*PR created automatically by Jules for task [6401807333369115814](https://jules.google.com/task/6401807333369115814) started by @RainRat*