### PR TITLE
Improve precision of manifest file detection in Config.is_container

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -295,13 +295,14 @@ class Config:
 
         # 2. Check by extension or basename
         path_s = str(file_path).lower()
-        # Extensions and manifest files
+        # Common archive and document extensions
         if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.yml', '.yaml',
-                            '.diff', '.patch', 'package.json', 'composer.json', 'deno.json', 'deno.jsonc')):
+                            '.diff', '.patch')):
             return True
-        # Dockerfile and Makefile variants
+        # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('dockerfile', 'makefile') or basename.endswith(('.dockerfile', '.makefile')):
+        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'dockerfile', 'makefile') or \
+           basename.endswith(('.dockerfile', '.makefile')):
             return True
         return False
 


### PR DESCRIPTION
This PR resolves a logic precision issue in the `Config.is_container` method within `gptscan.py`.

### Changes:
- Modified `Config.is_container` to separate extension-based checks from exact filename checks.
- Extensions that denote container types (e.g., `.zip`, `.tar`, `.ipynb`, `.md`, `.diff`) continue to use `.endswith()`.
- Manifest and build files that must match an exact name (e.g., `package.json`, `composer.json`, `deno.json`, `dockerfile`, `makefile`) are now verified using an exact `basename` comparison.

### Benefits:
- **Accuracy:** Prevents false positives where any file ending in a manifest name (like `sub-package.json` or `testpackage.json`) would be incorrectly treated as a container.
- **Maintainability:** Clearly separates the logic for extension matching vs. exact filename matching.
- **Safety:** The external behavior for valid manifest files remains unchanged, and no new dependencies or breaking changes were introduced.

### Verification:
- Created a reproduction script confirming that `testpackage.json` was incorrectly flagged before the fix and correctly ignored after the fix.
- Ran the full non-training test suite (`python3 -m pytest . --ignore=tests/test_train.py`), with all 601 tests passing successfully.

---
*PR created automatically by Jules for task [14538268824857467992](https://jules.google.com/task/14538268824857467992) started by @RainRat*