### PR TITLE
[FEAT] Scan Git Diff support for CLI and GUI

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -998,6 +998,41 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     return [p for f in files if os.path.exists(p := os.path.join(toplevel, f))]
 
 
+def get_git_diff(path: str = ".") -> str:
+    """Get the current Git diff (staged and unstaged) as a string."""
+    abs_path = os.path.abspath(path)
+    search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
+
+    try:
+        toplevel = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=search_dir,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+    try:
+        rel_target = os.path.relpath(abs_path, toplevel)
+        targets = [rel_target] if rel_target != "." else []
+    except ValueError:
+        return ""
+
+    try:
+        # Get diff of staged and unstaged changes relative to HEAD
+        cmd = ["git", "diff", "HEAD", "--no-color", "--"] + targets
+        output = subprocess.check_output(
+            cmd,
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+        return output
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:
     """Collect files from a single path or a list of paths (files, directories, or globs).
 
@@ -1461,6 +1496,23 @@ def scan_clipboard_click():
                 button_click(extra_snippets=[("[Clipboard]", content.encode('utf-8'))])
     except Exception as e:
         messagebox.showwarning("Clipboard Error", f"Could not read from clipboard: {e}")
+
+
+def scan_git_diff_click():
+    """Scan current Git diff (staged and unstaged changes)."""
+    try:
+        # Get path from textbox or default to current directory
+        target_path = textbox.get().strip() if textbox else "."
+        if not target_path:
+            target_path = "."
+
+        diff_content = get_git_diff(target_path)
+        if diff_content:
+            button_click(extra_snippets=[("[Git Diff]", diff_content.encode('utf-8'))])
+        else:
+            messagebox.showinfo("Git Diff", "No Git changes detected (staged or unstaged) in the target path.")
+    except Exception as e:
+        messagebox.showwarning("Git Diff Error", f"Could not retrieve Git diff: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5076,6 +5128,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Select Folder...", command=browse_dir_click)
     browse_menu.add_command(label="Scan URL...", command=select_url_click)
     browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click)
+    browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click)
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -5484,7 +5537,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"
@@ -5492,6 +5545,8 @@ def main():
                "  python gptscan.py ./my_script.py --cli --json\n\n"
                "  # Scan only changed files in Git and fail if threats are found\n"
                "  python gptscan.py --git-changes --cli --fail-threshold 50\n\n"
+               "  # Scan current local Git diff (staged and unstaged changes)\n"
+               "  python gptscan.py --git-diff --cli\n\n"
                "  # Scan a snippet sent from another command\n"
                "  echo \"print('hello')\" | python gptscan.py --cli --stdin\n\n"
                "  # Scan a remote script or a GitHub repository directly from a web link\n"
@@ -5532,6 +5587,11 @@ def main():
         '--git-changes',
         action='store_true',
         help='Only scan files that have changed in your Git repository.'
+    )
+    scan_group.add_argument(
+        '--git-diff',
+        action='store_true',
+        help='Scan the current Git diff (staged and unstaged changes) as a patch.'
     )
     scan_group.add_argument(
         '--all-files',
@@ -5679,7 +5739,21 @@ def main():
             # Scan only changed files
             scan_targets = git_files
 
-        if not scan_targets and not args.git_changes:
+        extra_snippets = []
+        if args.git_diff:
+            # Use specified targets as git roots, or current directory if none.
+            git_roots = scan_targets if scan_targets else ["."]
+            diff_count = 0
+            for root_dir in git_roots:
+                diff_content = get_git_diff(root_dir)
+                if diff_content:
+                    extra_snippets.append((f"git-diff-{diff_count}.patch", diff_content.encode('utf-8')))
+                    diff_count += 1
+
+            if not extra_snippets:
+                print("No Git diff detected in provided targets.", file=sys.stderr)
+
+        if not scan_targets and not args.git_changes and not args.git_diff:
             # Default to current directory if no targets provided and NOT using git-changes
             scan_targets = ["."]
 
@@ -5712,7 +5786,6 @@ def main():
 
         final_excludes = list(set((Config.ignore_patterns or []) + (args.exclude or [])))
 
-        extra_snippets = []
         if args.stdin:
             try:
                 # Read from stdin buffer for binary safety

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Access these options from the **Browse** menu in the header:
 *   **Select Folder...:** Choose a whole directory to scan.
 *   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
+*   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 
 #### Scan Options
 *   **Git changes only:** Only scan files that are modified or untracked in your Git repository.
@@ -92,6 +93,9 @@ python gptscan.py --cli --git-changes -t 80
 # Scan a remote GitHub Pull Request or GitLab Merge Request
 python gptscan.py --cli https://github.com/user/repo/pull/123
 
+# Scan current local Git diff (staged and unstaged changes)
+python gptscan.py --cli --git-diff
+
 # Import and filter results from a previous scan
 python gptscan.py --cli --import results.json -o report.html
 ```
@@ -115,6 +119,7 @@ python gptscan.py --cli --import results.json -o report.html
 *   `--threshold [0-100], -t [0-100]`: Set the minimum threat level to report (default: 50).
 *   `--fail-threshold [0-100]`: Exit with an error if any file meets this threat level.
 *   `--git-changes`: Only scan files that have changed in Git.
+*   `--git-diff`: Scan the current Git diff (staged and unstaged changes) as a patch.
 *   `--all-files`: Force the scanner to check every file, even those without common script extensions (like .txt or .log) or a script starting line (like `#!/bin/bash`).
 *   `--exclude [patterns], -e [patterns]`: Skip files that match these patterns.
 *   `--file-list [file]`: Scan a list of files from a text file.

--- a/tests/test_git_diff.py
+++ b/tests/test_git_diff.py
@@ -1,0 +1,64 @@
+import subprocess
+import pytest
+from pathlib import Path
+from gptscan import get_git_diff
+
+def test_get_git_diff_no_repo(tmp_path, monkeypatch):
+    """Test get_git_diff in a directory that is not a git repo."""
+    monkeypatch.chdir(tmp_path)
+    assert get_git_diff() == ""
+
+def test_get_git_diff_with_changes(tmp_path, monkeypatch):
+    """Test get_git_diff with staged and unstaged changes."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("initial content")
+    subprocess.run(["git", "add", "file1.txt"], check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], check=True)
+
+    # Unstaged change
+    file1.write_text("unstaged change")
+
+    diff = get_git_diff()
+    assert "unstaged change" in diff
+    assert "file1.txt" in diff
+
+    # Staged change
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("staged content")
+    subprocess.run(["git", "add", "file2.txt"], check=True)
+
+    diff = get_git_diff()
+    assert "staged content" in diff
+    assert "file2.txt" in diff
+
+def test_get_git_diff_specific_path(tmp_path, monkeypatch):
+    """Test get_git_diff on a specific path."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    file1 = subdir / "file1.txt"
+    file1.write_text("initial content")
+    subprocess.run(["git", "add", "subdir/file1.txt"], check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], check=True)
+
+    file1.write_text("changed content")
+
+    # Diff of the whole repo
+    assert "subdir/file1.txt" in get_git_diff()
+
+    # Diff of a different (empty) subdir
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    assert get_git_diff(str(other_dir)) == ""
+
+    # Diff of the specific subdir
+    assert "subdir/file1.txt" in get_git_diff(str(subdir))


### PR DESCRIPTION
I have implemented a new "Scan Git Diff" feature that allows users to analyze their local, uncommitted changes (both staged and unstaged) before they are committed to a repository.

**Key Changes:**
1.  **Core Logic:** Added `get_git_diff(path)` to `gptscan.py` to retrieve the current diff relative to `HEAD` using `git diff --no-color`.
2.  **CLI Support:** Introduced the `--git-diff` flag. When used, the scanner automatically fetches the diff for the target directory and includes it in the scan as a virtual patch file.
3.  **GUI Support:** Added a "Scan Git Diff" option to the "Browse" menu. This provides a one-click way to check local changes for suspicious patterns.
4.  **Documentation:** Updated the CLI help text and `readme.md` with descriptions and usage examples for the new feature.
5.  **Testing:** Added a new test file `tests/test_git_diff.py` to verify the diff retrieval logic across different scenarios (no repo, repo with changes, specific subdirectories).

This feature follows the **Symmetry** heuristic (matching existing support for remote PRs and local patches) and provides significant **Convenience** for secure development workflows.

---
*PR created automatically by Jules for task [6455427853789029985](https://jules.google.com/task/6455427853789029985) started by @RainRat*