### PR TITLE
Extract common Git resolution logic into helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -948,8 +948,8 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
             tree.item(iid, values=new_vals)
 
 
-def get_git_changed_files(path: str = ".") -> List[str]:
-    """Get a list of changed files (staged, unstaged, untracked) from git."""
+def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """Helper to resolve Git toplevel and relative path for a given target."""
     abs_path = os.path.abspath(path)
     search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
@@ -960,15 +960,19 @@ def get_git_changed_files(path: str = ".") -> List[str]:
             stderr=subprocess.PIPE,
             universal_newlines=True
         ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        rel_path = os.path.relpath(abs_path, toplevel)
+        return toplevel, rel_path
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return None, None
+
+
+def get_git_changed_files(path: str = ".") -> List[str]:
+    """Get a list of changed files (staged, unstaged, untracked) from git."""
+    toplevel, rel_path = _get_git_info(path)
+    if toplevel is None:
         return []
 
-    try:
-        rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target]
-    except ValueError:
-        return []
-
+    targets = [rel_path]
     files = set()
     # Changed (staged and unstaged) relative to HEAD
     try:
@@ -1001,24 +1005,11 @@ def get_git_changed_files(path: str = ".") -> List[str]:
 
 def get_git_diff(path: str = ".") -> str:
     """Get the current Git diff (staged and unstaged) as a string."""
-    abs_path = os.path.abspath(path)
-    search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
-
-    try:
-        toplevel = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=search_dir,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    toplevel, rel_path = _get_git_info(path)
+    if toplevel is None:
         return ""
 
-    try:
-        rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target] if rel_target != "." else []
-    except ValueError:
-        return ""
+    targets = [rel_path] if rel_path != "." else []
 
     try:
         # Get diff of staged and unstaged changes relative to HEAD


### PR DESCRIPTION
* **What:** Extracted the duplicated Git repository setup and path resolution logic from `get_git_changed_files` and `get_git_diff` into a new private helper function `_get_git_info(path)`.
* **Why:** This reduces code duplication and improves maintainability by centralizing the interaction with the `git rev-parse --show-toplevel` command and relative path calculation. All existing tests pass, ensuring that the refactor is non-breaking and preserves current behavior.

---
*PR created automatically by Jules for task [11632912178848349598](https://jules.google.com/task/11632912178848349598) started by @RainRat*