### PR TITLE
[FEAT] Add pyproject.toml support for script scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -301,7 +301,7 @@ class Config:
             return True
         # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'dockerfile', 'makefile') or \
+        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile') or \
            basename.endswith(('.dockerfile', '.makefile')):
             return True
         return False
@@ -2139,7 +2139,59 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 5. Check for Markdown code blocks
+    # 5. Check for pyproject.toml
+    if check_name.lower().endswith('pyproject.toml'):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Extract values from scripts/tasks sections in TOML.
+            # Using regex to avoid adding a 'toml' dependency.
+            sections = [
+                'project.scripts',
+                'tool.poetry.scripts',
+                'tool.pdm.scripts',
+                'tool.hatch.scripts',
+                'tool.pixi.tasks'
+            ]
+            lines = text.splitlines()
+            current_section = None
+            extracted_any = False
+
+            for line in lines:
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+
+                # Check for section headers
+                header_match = re.match(r'^\s*\[(.*?)\]\s*', stripped)
+                if header_match:
+                    section_name = header_match.group(1).strip()
+                    if section_name in sections:
+                        current_section = section_name
+                    else:
+                        current_section = None
+                    continue
+
+                # Extract script/task definitions in the active section
+                if current_section:
+                    # Match "key = value" or key = "value"
+                    kv_match = re.match(r'^\s*([A-Za-z0-9_\-\.]+)\s*=\s*(.*)', stripped)
+                    if kv_match:
+                        key, val = kv_match.groups()
+                        # Clean up value (remove quotes and inline comments)
+                        val = val.split('#')[0].strip()
+                        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+                            val = val[1:-1]
+
+                        if val.strip():
+                            yield (f"{name} [Script: {key}]", val.encode('utf-8'))
+                            extracted_any = True
+
+            if extracted_any:
+                return
+        except Exception:
+            pass
+
+    # 6. Check for Markdown code blocks
     if check_name.lower().endswith('.md'):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -2152,7 +2204,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Check for HTML script tags and other embedded elements
+    # 7. Check for HTML script tags and other embedded elements
     if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -2193,7 +2245,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 7. Check for Dockerfile
+    # 8. Check for Dockerfile
     lowered_check = check_name.lower()
     if 'dockerfile' in lowered_check and (os.path.basename(lowered_check) == 'dockerfile' or lowered_check.endswith('.dockerfile')):
         try:
@@ -2234,7 +2286,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 8. Check for CI/CD Workflows (YAML)
+    # 9. Check for CI/CD Workflows (YAML)
     if lowered_check.endswith(('.yml', '.yaml')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -2305,7 +2357,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 9. Check for Unified Diff (.diff or .patch)
+    # 10. Check for Unified Diff (.diff or .patch)
     if check_name.lower().endswith(('.diff', '.patch')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -2351,7 +2403,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 10. Check for Makefile
+    # 11. Check for Makefile
     if 'makefile' in lowered_check and (os.path.basename(lowered_check) == 'makefile' or lowered_check.endswith('.makefile')):
         try:
             text = content.decode('utf-8', errors='ignore')
@@ -5544,7 +5596,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json, pyproject.toml), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 *   **Local & Remote Scanning:** Scan local files or fetch them directly from a web link.
 *   **PR/MR & Patch Scanning:** Fetch and scan code changes from GitHub Pull Requests, GitLab Merge Requests, or local `.diff`/`.patch` files.
 *   **Notebook Support:** Analyzes `.ipynb` cells for malicious commands.
-*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, and `deno.jsonc`.
+*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, and `deno.jsonc`.
 *   **Archive Unpacking:** Automatically unpacks `.zip`, `.tar`, and `.tar.gz` to scan their contents.
 *   **Two-step analysis:**
     1.  **Fast Local Scan:** A lightweight model identifies suspicious patterns in milliseconds.
@@ -47,7 +47,7 @@ Run `python gptscan.py` to open the GUI.
 Access these options from the **Browse** menu in the header:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `pyproject.toml`, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 

--- a/tests/test_pyproject_scan.py
+++ b/tests/test_pyproject_scan.py
@@ -1,0 +1,60 @@
+import pytest
+from gptscan import unpack_content
+
+def test_pyproject_unpacking():
+    content = b"""
+[project]
+name = "test-project"
+
+[project.scripts]
+run-app = "python main.py"
+test = "pytest"
+
+[tool.poetry.scripts]
+poetry-run = "poetry run cmd"
+
+[tool.pdm.scripts]
+pdm-task = "pdm run something"
+
+[tool.hatch.scripts]
+hatch-script = "hatch run script"
+
+[tool.pixi.tasks]
+pixi-task = "pixi run task"
+
+[other.section]
+ignored = "should not be yielded"
+"""
+    snippets = list(unpack_content("pyproject.toml", content))
+
+    expected = [
+        ("pyproject.toml [Script: run-app]", b"python main.py"),
+        ("pyproject.toml [Script: test]", b"pytest"),
+        ("pyproject.toml [Script: poetry-run]", b"poetry run cmd"),
+        ("pyproject.toml [Script: pdm-task]", b"pdm run something"),
+        ("pyproject.toml [Script: hatch-script]", b"hatch run script"),
+        ("pyproject.toml [Script: pixi-task]", b"pixi run task"),
+    ]
+
+    assert len(snippets) == len(expected)
+    for s in expected:
+        assert s in snippets
+
+def test_pyproject_quoting_and_comments():
+    content = b"""
+[project.scripts]
+single = 'single-quoted'
+double = "double-quoted"
+with-comment = "command" # some comment
+"""
+    snippets = list(unpack_content("pyproject.toml", content))
+
+    expected = [
+        ("pyproject.toml [Script: single]", b"single-quoted"),
+        ("pyproject.toml [Script: double]", b"double-quoted"),
+        ("pyproject.toml [Script: with-comment]", b"command"),
+    ]
+
+    assert len(snippets) == len(expected)
+    for s in expected:
+        assert s in snippets


### PR DESCRIPTION
This Pull Request adds support for scanning `pyproject.toml` files, specifically extracting executable scripts and tasks defined in standard and tool-specific sections.

### What:
- Added `pyproject.toml` to the list of manifests handled by the scanner.
- Implemented a lightweight, regex-based parser in `unpack_content` to identify and extract commands from the following sections:
  - `[project.scripts]` (PEP 621)
  - `[tool.poetry.scripts]`
  - `[tool.pdm.scripts]`
  - `[tool.hatch.scripts]`
  - `[tool.pixi.tasks]`
- Updated the CLI `--help` description and `readme.md` features/usage sections.
- Added a new test file `tests/test_pyproject_scan.py` covering various formats, quoting styles, and comments.

### Why:
I noticed that while the tool supports `package.json`, `composer.json`, and `deno.json`, it was missing support for the standard Python project manifest, `pyproject.toml`. As a Python-centric tool, being able to scan the entry points and task definitions in `pyproject.toml` is a high-value addition that follows the existing "Symmetry" and "Interoperability" heuristics. The implementation remains "Zero-Configuration" by using manual parsing instead of adding a `toml` library dependency.

---
*PR created automatically by Jules for task [12411158829905099978](https://jules.google.com/task/12411158829905099978) started by @RainRat*