### PR TITLE
Extract redundant Git resolution logic into _get_git_info helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -948,8 +948,8 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
             tree.item(iid, values=new_vals)
 
 
-def get_git_changed_files(path: str = ".") -> List[str]:
-    """Get a list of changed files (staged, unstaged, untracked) from git."""
+def _get_git_info(path: str) -> Optional[Tuple[str, str]]:
+    """Helper to resolve git toplevel and relative path for a given target."""
     abs_path = os.path.abspath(path)
     search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
@@ -960,14 +960,20 @@ def get_git_changed_files(path: str = ".") -> List[str]:
             stderr=subprocess.PIPE,
             universal_newlines=True
         ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        rel_target = os.path.relpath(abs_path, toplevel)
+        return toplevel, rel_target
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return None
+
+
+def get_git_changed_files(path: str = ".") -> List[str]:
+    """Get a list of changed files (staged, unstaged, untracked) from git."""
+    git_info = _get_git_info(path)
+    if not git_info:
         return []
 
-    try:
-        rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target]
-    except ValueError:
-        return []
+    toplevel, rel_target = git_info
+    targets = [rel_target]
 
     files = set()
     # Changed (staged and unstaged) relative to HEAD
@@ -1001,24 +1007,12 @@ def get_git_changed_files(path: str = ".") -> List[str]:
 
 def get_git_diff(path: str = ".") -> str:
     """Get the current Git diff (staged and unstaged) as a string."""
-    abs_path = os.path.abspath(path)
-    search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
-
-    try:
-        toplevel = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=search_dir,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    git_info = _get_git_info(path)
+    if not git_info:
         return ""
 
-    try:
-        rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target] if rel_target != "." else []
-    except ValueError:
-        return ""
+    toplevel, rel_target = git_info
+    targets = [rel_target] if rel_target != "." else []
 
     try:
         # Get diff of staged and unstaged changes relative to HEAD


### PR DESCRIPTION
This PR addresses code duplication in `gptscan.py` by extracting common Git repository resolution logic into a private helper function `_get_git_info(path)`.

### Changes:
- Added `_get_git_info(path)` which handles:
    - Resolving absolute path and search directory.
    - Executing `git rev-parse --show-toplevel`.
    - Calculating relative path from toplevel.
    - Handling common exceptions (subprocess error, file not found, value error).
- Updated `get_git_changed_files(path)` to use the new helper.
- Updated `get_git_diff(path)` to use the new helper.

### Impact:
- **Reduces Code Duplication:** Identical blocks of code in two primary Git integration functions are now centralized.
- **Maintainability:** Fixes or improvements to Git resolution logic only need to be applied in one place.
- **Non-breaking:** The external behavior and error handling of `get_git_changed_files` and `get_git_diff` remain unchanged, returning `[]` or `""` respectively upon failure.

Verified with 626 tests passing, including specific Git integration and diff tests.

---
*PR created automatically by Jules for task [12411047909872014328](https://jules.google.com/task/12411047909872014328) started by @RainRat*