### PR TITLE
[DOCS] Update supported formats and Python 3.12 compatibility

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5544,7 +5544,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json, deno.jsonc), build scripts (Dockerfile, Makefile), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 *   **Local & Remote Scanning:** Scan local files or fetch them directly from a web link.
 *   **PR/MR & Patch Scanning:** Fetch and scan code changes from GitHub Pull Requests, GitLab Merge Requests, or local `.diff`/`.patch` files.
 *   **Notebook Support:** Analyzes `.ipynb` cells for malicious commands.
+*   **Build & DevOps Scanning:** Scans `Dockerfile`, `Makefile`, and CI/CD workflows (GitHub Actions, GitLab CI).
 *   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, and `deno.jsonc`.
 *   **Archive Unpacking:** Automatically unpacks `.zip`, `.tar`, and `.tar.gz` to scan their contents.
 *   **Two-step analysis:**
@@ -20,7 +21,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 ## Installation
 
 ### Prerequisites
-*   Python 3.9, 3.10, or 3.11. (Python 3.12 is not supported yet due to model compatibility).
+*   Python 3.9, 3.10, 3.11, or 3.12. (Note: 3.12 requires TensorFlow 2.16 or newer).
 *   **Tkinter:** Usually included with Python. On Linux, you might need to install `python3-tk`.
 *   (Optional) An API key for [OpenAI](https://platform.openai.com/) or [OpenRouter](https://openrouter.ai/).
 *   (Optional) [Ollama](https://ollama.com/) for local AI analysis.
@@ -47,7 +48,7 @@ Run `python gptscan.py` to open the GUI.
 Access these options from the **Browse** menu in the header:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), build script (Dockerfile, Makefile), CI/CD workflow, PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 


### PR DESCRIPTION
This PR improves the project documentation and internal help strings to accurately reflect the current capabilities and environment support of the GPT Virus Scanner.

Key changes:
1.  **CLI Help Text:** Updated the `argparse` description in `gptscan.py` to explicitly mention support for `deno.jsonc`, `Dockerfile`, and `Makefile`, ensuring users are aware of these features when using `--help`.
2.  **README Features:** Added a "Build & DevOps Scanning" bullet to the Features section in `readme.md` to highlight support for `Dockerfile`, `Makefile`, and CI/CD workflows.
3.  **Python 3.12 Support:** Updated the Prerequisites section in `readme.md` to include Python 3.12, noting that it requires `tensorflow>=2.16` for compatibility.
4.  **Target Clarification:** Updated the "**Scan URL...**" description in the README to include DevOps and build files, matching the tool's actual remote scanning capabilities.

These changes ensure that both new and existing users have a clear understanding of what the tool can do and how to set it up correctly on modern Python environments.

---
*PR created automatically by Jules for task [1528129058669749865](https://jules.google.com/task/1528129058669749865) started by @RainRat*