### PR TITLE
[UI/UX] Consolidate 'Copy' actions in the Result Details window

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4520,17 +4520,15 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
     # Group: Copy & Export
-    copy_btn = ttk.Button(btn_frame, text="Copy Analysis", width=15, command=copy_analysis)
-    copy_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_btn, "Copy the full analysis and snippet to clipboard. (Ctrl+Shift+C)", label=status_bar)
+    copy_details_btn = ttk.Menubutton(btn_frame, text="Copy...", width=10)
+    copy_details_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(copy_details_btn, "Copy results or code to the clipboard.", label=status_bar)
 
-    copy_json_btn = ttk.Button(btn_frame, text="Copy JSON", width=12, command=copy_as_json_details)
-    copy_json_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_json_btn, "Copy the current result as a JSON object. (Ctrl+J)", label=status_bar)
-
-    copy_code_btn = ttk.Button(btn_frame, text="Copy Code", width=12, command=copy_code)
-    copy_code_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_code_btn, "Copy the displayed code to the clipboard. (Ctrl+S)", label=status_bar)
+    copy_details_menu = tk.Menu(copy_details_btn, tearoff=0)
+    copy_details_menu.add_command(label="Copy Analysis", command=copy_analysis, accelerator="Ctrl+Shift+C")
+    copy_details_menu.add_command(label="Copy JSON", command=copy_as_json_details, accelerator="Ctrl+J")
+    copy_details_menu.add_command(label="Copy Code", command=copy_code, accelerator="Ctrl+S")
+    copy_details_btn["menu"] = copy_details_menu
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -4558,6 +4556,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         open_btn.config(state='disabled' if is_scanning else 'normal')
         vt_btn.config(state='disabled' if is_scanning else 'normal')
         path_copy_btn.config(state='disabled' if is_scanning else 'normal')
+        copy_details_btn.config(state='disabled' if is_scanning else 'normal')
         reveal_btn.config(state='disabled' if is_scanning else 'normal')
 
         # vals: (path, own_conf, admin, user, gpt_conf, snippet, line)

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -108,6 +108,26 @@ def mock_view_details_env(monkeypatch):
         return btn
     monkeypatch.setattr(gptscan.ttk, 'Button', mock_button_init)
 
+    def mock_menubutton_init(master, **kwargs):
+        btn = MagicMock()
+        text = kwargs.get('text', '')
+        if text:
+            captured[f"btn_{text}"] = (btn, kwargs.get('command'))
+        return btn
+    monkeypatch.setattr(gptscan.ttk, 'Menubutton', mock_menubutton_init)
+
+    class MockMenu:
+        def __init__(self, master=None, **kwargs):
+            self.items = []
+        def add_command(self, **kwargs):
+            label = kwargs.get('label', '')
+            if label:
+                captured[f"btn_{label}"] = (self, kwargs.get('command'))
+            self.items.append(kwargs)
+        def post(self, x, y): pass
+        def add_separator(self): pass
+    monkeypatch.setattr(gptscan.tk, 'Menu', MockMenu)
+
     def mock_labelframe_init(master, **kwargs):
         lf = MagicMock()
         text = kwargs.get('text', '')


### PR DESCRIPTION
### Context: GUI
### Problem:
The Result Details window previously displayed three separate buttons for different copy actions ("Copy Analysis", "Copy JSON", and "Copy Code"). This created significant visual clutter in the footer and diluted the visual hierarchy of more primary actions like "Rescan" or "Analyze with AI".

### Solution:
This PR consolidates the three copy actions into a single **"Copy..."** `ttk.Menubutton`. 
- **Friction Reduction:** Related actions are now grouped logically under a single entry point.
- **Visual Hierarchy:** Reducing the number of footer buttons from 10 to 8 allows the more important scanning and remediation buttons to stand out.
- **Consistency:** The implementation uses standard `tk.Menu` accelerators (Ctrl+Shift+C, Ctrl+J, Ctrl+S) to ensure keyboard shortcut discoverability remains high.
- **Robustness:** The new `copy_details_btn` is correctly wired into the `refresh_content` state logic, ensuring it is disabled during active scans.

### Changes:
- Modified `view_details` in `gptscan.py` to implement the `Menubutton` and its associated `Menu`.
- Updated `refresh_content` in `gptscan.py` to manage the `Menubutton` state.
- Updated `tests/test_view_details.py` to mock `ttk.Menubutton` and `tk.Menu`, ensuring existing unit tests continue to validate copy functionality via the new menu structure.

---
*PR created automatically by Jules for task [18345879702545775441](https://jules.google.com/task/18345879702545775441) started by @RainRat*