### PR TITLE
[FEAT] Support for script extraction from pyproject.toml

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -301,7 +301,7 @@ class Config:
             return True
         # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'dockerfile', 'makefile') or \
+        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile') or \
            basename.endswith(('.dockerfile', '.makefile')):
             return True
         return False
@@ -2090,15 +2090,42 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc)
+    # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc, pyproject.toml)
     lowered_check = check_name.lower()
-    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc')):
+    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml')):
         try:
             text = content.decode('utf-8', errors='ignore')
+            if lowered_check.endswith('pyproject.toml'):
+                # Handle TOML manifest
+                sections = re.split(r'^\[', text, flags=re.MULTILINE)
+                for section in sections:
+                    if not section:
+                        continue
+                    lines = section.splitlines()
+                    header = lines[0].strip().rstrip(']')
+                    if header in ('project.scripts', 'tool.poetry.scripts', 'tool.poe.tasks', 'tool.taskipy.tasks'):
+                        for line in lines[1:]:
+                            line = line.strip()
+                            if not line or line.startswith('#') or line.startswith('['):
+                                continue
+                            if '=' in line:
+                                parts = line.split('=', 1)
+                                key = parts[0].strip().strip('"\'')
+                                val = parts[1].strip()
+                                cmd = ""
+                                if val.startswith(('"', "'")):
+                                    cmd = val.strip('"\'')
+                                elif val.startswith('{') and val.endswith('}'):
+                                    m = re.search(r'(?:cmd|shell)\s*=\s*["\'](.*?)["\']', val)
+                                    if m:
+                                        cmd = m.group(1)
+                                if cmd:
+                                    label = 'Script' if 'scripts' in header else 'Task'
+                                    yield (f"{name} [{label}: {key}]", cmd.encode('utf-8'))
+                return
+
+            # Handle JSON manifests
             if lowered_check.endswith('.jsonc'):
-                # Strip single-line and multi-line comments for JSONC support
-                # This regex strips /* ... */ comments and // ... comments while attempting to ignore
-                # // if it appears inside a double-quoted string (to avoid mangling URLs).
                 text = re.sub(
                     r'(/\*.*?\*/)|("(?:\\.|[^"\\])*")|(//[^\n]*)',
                     lambda m: m.group(2) if m.group(2) else " ",
@@ -2110,7 +2137,6 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             if not isinstance(manifest, dict):
                 return
 
-            # Determine key and label based on manifest type
             key = 'scripts'
             label = 'Script'
             if 'deno.json' in lowered_check:
@@ -2119,22 +2145,14 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
 
             scripts = manifest.get(key, {})
             if isinstance(scripts, dict):
-                yielded_any = False
                 for script_name, command in scripts.items():
                     if isinstance(command, str):
                         if command.strip():
                             yield (f"{name} [{label}: {script_name}]", command.encode('utf-8'))
-                            yielded_any = True
                     elif isinstance(command, list):
-                        # Support for array-based scripts (common in composer.json)
                         for i, cmd in enumerate(command, 1):
                             if isinstance(cmd, str) and cmd.strip():
                                 yield (f"{name} [{label}: {script_name} ({i})]", cmd.encode('utf-8'))
-                                yielded_any = True
-                if yielded_any:
-                    return
-
-            # If it's a manifest but has no scripts/tasks, we don't want to scan it as a whole file
             return
         except Exception:
             pass
@@ -5544,7 +5562,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json, pyproject.toml), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 *   **Local & Remote Scanning:** Scan local files or fetch them directly from a web link.
 *   **PR/MR & Patch Scanning:** Fetch and scan code changes from GitHub Pull Requests, GitLab Merge Requests, or local `.diff`/`.patch` files.
 *   **Notebook Support:** Analyzes `.ipynb` cells for malicious commands.
-*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, and `deno.jsonc`.
+*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, `deno.jsonc`, and `pyproject.toml`.
 *   **Archive Unpacking:** Automatically unpacks `.zip`, `.tar`, and `.tar.gz` to scan their contents.
 *   **Two-step analysis:**
     1.  **Fast Local Scan:** A lightweight model identifies suspicious patterns in milliseconds.
@@ -47,7 +47,7 @@ Run `python gptscan.py` to open the GUI.
 Access these options from the **Browse** menu in the header:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `pyproject.toml`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 

--- a/tests/test_pyproject_scan.py
+++ b/tests/test_pyproject_scan.py
@@ -1,0 +1,66 @@
+import pytest
+from gptscan import unpack_content
+
+def test_unpack_pyproject_toml_scripts():
+    content = b"""
+[project]
+name = "test-project"
+
+[project.scripts]
+my-cmd = "my_module:main"
+another = 'run_this --flag'
+
+[tool.poetry.scripts]
+poetry-cmd = "poetry_mod:app"
+
+[tool.poe.tasks]
+task1 = "echo hello"
+task2 = { cmd = "ls -la", help = "list files" }
+task3 = { shell = "rm -rf /" }
+
+[tool.taskipy.tasks]
+test = "pytest"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+
+    # Check if all scripts and tasks were extracted
+    names = [r[0] for r in results]
+    assert "pyproject.toml [Script: my-cmd]" in names
+    assert "pyproject.toml [Script: another]" in names
+    assert "pyproject.toml [Script: poetry-cmd]" in names
+    assert "pyproject.toml [Task: task1]" in names
+    assert "pyproject.toml [Task: task2]" in names
+    assert "pyproject.toml [Task: task3]" in names
+    assert "pyproject.toml [Task: test]" in names
+
+    # Check extracted values
+    script_vals = {r[0]: r[1].decode() for r in results}
+    assert script_vals["pyproject.toml [Script: my-cmd]"] == "my_module:main"
+    assert script_vals["pyproject.toml [Script: another]"] == "run_this --flag"
+    assert script_vals["pyproject.toml [Task: task2]"] == "ls -la"
+    assert script_vals["pyproject.toml [Task: task3]"] == "rm -rf /"
+
+def test_unpack_pyproject_toml_no_scripts():
+    content = b"""
+[project]
+name = "test-project"
+version = "0.1.0"
+"""
+    # Should yield nothing if no scripts/tasks are found
+    results = list(unpack_content("pyproject.toml", content))
+    assert len(results) == 0
+
+def test_unpack_pyproject_toml_robustness():
+    content = b"""
+[project.scripts]
+# A comment
+valid = "cmd"
+# Another comment
+[tool.poetry.scripts]
+pvalid = "pcmd"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    assert len(results) == 2
+    names = [r[0] for r in results]
+    assert "pyproject.toml [Script: valid]" in names
+    assert "pyproject.toml [Script: pvalid]" in names


### PR DESCRIPTION
### [FEAT] Support for script extraction from pyproject.toml

#### What:
Added support for identifying and extracting executable scripts and tasks from Python `pyproject.toml` manifests. The tool now parses:
- Standard PEP 621 `[project.scripts]`
- Poetry `[tool.poetry.scripts]`
- PoeThePoet `[tool.poe.tasks]`
- Taskipy `[tool.taskipy.tasks]`

The implementation handles both simple string assignments and inline tables (e.g., `task = { cmd = "..." }`).

#### Why:
I noticed that while the codebase has excellent support for Node.js (`package.json`), PHP (`composer.json`), and Deno manifests, it was missing support for the Python standard manifest. Python projects often define custom entry points or maintenance tasks in `pyproject.toml`, which could be used to hide malicious commands. This change provides symmetry with other supported ecosystems and enhances the tool's utility for Python developers.

#### Changes:
- **gptscan.py**:
    - Modified `Config.is_container` to include `pyproject.toml`.
    - Extended `unpack_content` to parse TOML manifest sections and yield individual snippets.
    - Updated `main()` argparse description and examples.
- **readme.md**: Updated features and usage sections to include `pyproject.toml`.
- **tests/test_pyproject_scan.py**: Added new tests for various script formats and edge cases.

---
*PR created automatically by Jules for task [9446527437292999371](https://jules.google.com/task/9446527437292999371) started by @RainRat*