### PR TITLE
Refactor Git repository resolution logic to remove duplication

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -948,8 +948,8 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
             tree.item(iid, values=new_vals)
 
 
-def get_git_changed_files(path: str = ".") -> List[str]:
-    """Get a list of changed files (staged, unstaged, untracked) from git."""
+def _get_git_info(path: str) -> Optional[Tuple[str, str]]:
+    """Resolve the Git top-level directory and the relative path for a given target."""
     abs_path = os.path.abspath(path)
     search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
@@ -961,13 +961,23 @@ def get_git_changed_files(path: str = ".") -> List[str]:
             universal_newlines=True
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return []
+        return None
 
     try:
         rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target]
+        return toplevel, rel_target
     except ValueError:
+        return None
+
+
+def get_git_changed_files(path: str = ".") -> List[str]:
+    """Get a list of changed files (staged, unstaged, untracked) from git."""
+    git_info = _get_git_info(path)
+    if not git_info:
         return []
+
+    toplevel, rel_target = git_info
+    targets = [rel_target]
 
     files = set()
     # Changed (staged and unstaged) relative to HEAD
@@ -1001,24 +1011,12 @@ def get_git_changed_files(path: str = ".") -> List[str]:
 
 def get_git_diff(path: str = ".") -> str:
     """Get the current Git diff (staged and unstaged) as a string."""
-    abs_path = os.path.abspath(path)
-    search_dir = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
-
-    try:
-        toplevel = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=search_dir,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    git_info = _get_git_info(path)
+    if not git_info:
         return ""
 
-    try:
-        rel_target = os.path.relpath(abs_path, toplevel)
-        targets = [rel_target] if rel_target != "." else []
-    except ValueError:
-        return ""
+    toplevel, rel_target = git_info
+    targets = [rel_target] if rel_target != "." else []
 
     try:
         # Get diff of staged and unstaged changes relative to HEAD


### PR DESCRIPTION
* **What:** Extracted identical Git repository resolution logic into a private helper function `_get_git_info(path)`, which resolves the toplevel directory and relative path. This helper is now utilized by `get_git_changed_files` and `get_git_diff`.
* **Why:** This improves code maintainability and readability by eliminating duplication. The external behavior remains unchanged, and all relevant tests pass.

---
*PR created automatically by Jules for task [3244712633468033555](https://jules.google.com/task/3244712633468033555) started by @RainRat*