### PR TITLE
[TEST] Add pyproject.toml manifest scanning and coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -301,7 +301,7 @@ class Config:
             return True
         # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'dockerfile', 'makefile') or \
+        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile') or \
            basename.endswith(('.dockerfile', '.makefile')):
             return True
         return False
@@ -2135,6 +2135,62 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                     return
 
             # If it's a manifest but has no scripts/tasks, we don't want to scan it as a whole file
+            return
+        except Exception:
+            pass
+
+    # 4b. Check for pyproject.toml
+    if lowered_check.endswith('pyproject.toml'):
+        try:
+            text = content.decode('utf-8', errors='ignore')
+            # Extract [project.scripts], [tool.poetry.scripts], [tool.poe.tasks], [tool.taskipy.tasks]
+            sections = [
+                (r'\[project\.scripts\]', 'Script'),
+                (r'\[tool\.poetry\.scripts\]', 'Poetry Script'),
+                (r'\[tool\.poe\.tasks\]', 'Poe Task'),
+                (r'\[tool\.taskipy\.tasks\]', 'Taskipy Task')
+            ]
+
+            yielded_any = False
+            for section_regex, label in sections:
+                # Find the start of the section
+                match = re.search(section_regex, text)
+                if match:
+                    start_pos = match.end()
+                    # Find the start of the next section or end of file
+                    next_section = re.search(r'^\s*\[', text[start_pos:], re.MULTILINE)
+                    end_pos = start_pos + next_section.start() if next_section else len(text)
+                    section_text = text[start_pos:end_pos]
+
+                    # Extract key-value pairs
+                    for line in section_text.splitlines():
+                        line = line.strip()
+                        if not line or line.startswith('#'):
+                            continue
+
+                        # Match key = "value" or key = { ... }
+                        kv_match = re.match(r'^\s*([\w.-]+)\s*=\s*(.*)', line)
+                        if kv_match:
+                            script_name = kv_match.group(1).strip()
+                            value = kv_match.group(2).strip()
+
+                            command = None
+                            # If it's an inline table like { cmd = "..." } or { shell = "..." }
+                            if value.startswith('{'):
+                                cmd_match = re.search(r'(?:cmd|shell)\s*=\s*["\'](.*?)["\']', value)
+                                if cmd_match:
+                                    command = cmd_match.group(1)
+                            else:
+                                # If it's a string (possibly with trailing comment)
+                                str_match = re.match(r'^["\'](.*?)["\']', value)
+                                if str_match:
+                                    command = str_match.group(1)
+
+                            if command and command.strip():
+                                yield (f"{name} [{label}: {script_name}]", command.encode('utf-8'))
+                                yielded_any = True
+
+            # Whether or not we found scripts, we don't want to scan the TOML as a whole file
             return
         except Exception:
             pass
@@ -5544,7 +5600,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json, pyproject.toml), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 *   **Local & Remote Scanning:** Scan local files or fetch them directly from a web link.
 *   **PR/MR & Patch Scanning:** Fetch and scan code changes from GitHub Pull Requests, GitLab Merge Requests, or local `.diff`/`.patch` files.
 *   **Notebook Support:** Analyzes `.ipynb` cells for malicious commands.
-*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, and `deno.jsonc`.
+*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, `deno.jsonc`, and `pyproject.toml`.
 *   **Archive Unpacking:** Automatically unpacks `.zip`, `.tar`, and `.tar.gz` to scan their contents.
 *   **Two-step analysis:**
     1.  **Fast Local Scan:** A lightweight model identifies suspicious patterns in milliseconds.
@@ -47,7 +47,7 @@ Run `python gptscan.py` to open the GUI.
 Access these options from the **Browse** menu in the header:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, `pyproject.toml`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 

--- a/tests/test_is_container.py
+++ b/tests/test_is_container.py
@@ -30,7 +30,7 @@ def test_is_container_by_extension():
         assert Config.is_container(f"test{ext}") is True
 
 def test_is_container_by_manifest_name():
-    manifests = ['package.json', 'composer.json', 'deno.json', 'deno.jsonc']
+    manifests = ['package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml']
     for name in manifests:
         assert Config.is_container(name) is True
         assert Config.is_container(f"sub/dir/{name}") is True

--- a/tests/test_pyproject_scan.py
+++ b/tests/test_pyproject_scan.py
@@ -1,0 +1,111 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_unpack_pyproject_scripts():
+    """Test that unpack_content correctly extracts scripts from pyproject.toml."""
+    content = b"""
+[project]
+name = "test-project"
+
+[project.scripts]
+run-app = "myapp.main:run"
+test = "pytest"
+
+[tool.poetry.scripts]
+poetry-run = "poetry_app.main:start"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+
+    # Should find 3 scripts
+    assert len(results) == 3
+
+    names = [r[0] for r in results]
+    assert "pyproject.toml [Script: run-app]" in names
+    assert "pyproject.toml [Script: test]" in names
+    assert "pyproject.toml [Poetry Script: poetry-run]" in names
+
+    script_contents = [r[1] for r in results]
+    assert b"myapp.main:run" in script_contents
+    assert b"pytest" in script_contents
+    assert b"poetry_app.main:start" in script_contents
+
+def test_unpack_pyproject_tasks_inline_tables():
+    """Test extraction of tasks from poe and taskipy with inline tables."""
+    content = b"""
+[tool.poe.tasks]
+clean = "rm -rf dist"
+build = { cmd = "python -m build", help = "Build the package" }
+test = { shell = "pytest --cov", help = "Run tests" }
+
+[tool.taskipy.tasks]
+lint = "flake8"
+format = { cmd = "black .", help = "Format code" }
+"""
+    results = list(unpack_content("pyproject.toml", content))
+
+    # 3 from poe, 2 from taskipy
+    assert len(results) == 5
+
+    names = [r[0] for r in results]
+    assert "pyproject.toml [Poe Task: clean]" in names
+    assert "pyproject.toml [Poe Task: build]" in names
+    assert "pyproject.toml [Poe Task: test]" in names
+    assert "pyproject.toml [Taskipy Task: lint]" in names
+    assert "pyproject.toml [Taskipy Task: format]" in names
+
+    script_contents = [r[1] for r in results]
+    assert b"rm -rf dist" in script_contents
+    assert b"python -m build" in script_contents
+    assert b"pytest --cov" in script_contents
+    assert b"flake8" in script_contents
+    assert b"black ." in script_contents
+
+def test_pyproject_parsing_robustness():
+    """Test parsing logic with comments and different section orders."""
+    content = b"""
+# Top level comment
+[project.scripts]
+# Script comment
+start = "python main.py" # inline comment
+
+[tool.something-else]
+ignored = "value"
+
+[tool.poe.tasks]
+task1 = "echo 1"
+# middle comment
+task2 = "echo 2"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+
+    assert len(results) == 3
+    names = [r[0] for r in results]
+    assert "pyproject.toml [Script: start]" in names
+    assert "pyproject.toml [Poe Task: task1]" in names
+    assert "pyproject.toml [Poe Task: task2]" in names
+
+def test_pyproject_no_scripts():
+    """Test that pyproject.toml with no relevant sections yields nothing."""
+    content = b"""
+[project]
+name = "test"
+version = "0.1.0"
+
+[tool.poetry]
+description = "No scripts here"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    assert len(results) == 0
+
+def test_pyproject_malformed_section():
+    """Test behavior with malformed or empty sections."""
+    content = b"""
+[project.scripts]
+# Empty
+[tool.poe.tasks]
+valid = "command"
+invalid
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    assert len(results) == 1
+    assert results[0][0] == "pyproject.toml [Poe Task: valid]"


### PR DESCRIPTION
This PR implements support for scanning `pyproject.toml` files, filling a significant gap in the scanner's manifest analysis capabilities.

### Changes:
- **Core Logic:** Updated `unpack_content` in `gptscan.py` to parse `pyproject.toml` and extract scripts/tasks from `[project.scripts]`, `[tool.poetry.scripts]`, `[tool.poe.tasks]`, and `[tool.taskipy.tasks]`.
- **Container Detection:** Added `pyproject.toml` to `Config.is_container` to ensure it is correctly identified and unpacked during scans.
- **Tests:**
    - Created `tests/test_pyproject_scan.py` with 5 new test cases covering various TOML script formats, inline tables, and robustness against comments.
    - Updated `tests/test_is_container.py` to include `pyproject.toml`.
- **Documentation:** Updated `readme.md` and CLI help text to reflect support for `pyproject.toml`.

### Gap Analysis:
Previously, the scanner supported `package.json`, `composer.json`, and `deno.json`, but lacked support for the standard Python project manifest (`pyproject.toml`). This PR ensures that malicious commands hidden in Python project scripts are now detectable.

---
*PR created automatically by Jules for task [4583043956265294699](https://jules.google.com/task/4583043956265294699) started by @RainRat*