### PR TITLE
[UI/UX] Consolidate copy actions in details view

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4519,18 +4519,16 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
-    # Group: Copy & Export
-    copy_btn = ttk.Button(btn_frame, text="Copy Analysis", width=15, command=copy_analysis)
-    copy_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_btn, "Copy the full analysis and snippet to clipboard. (Ctrl+Shift+C)", label=status_bar)
+    # Group: Copy Actions
+    copy_menu_btn = ttk.Menubutton(btn_frame, text="Copy...", width=12)
+    copy_menu_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(copy_menu_btn, "Copy analysis, JSON, or code to the clipboard.", label=status_bar)
 
-    copy_json_btn = ttk.Button(btn_frame, text="Copy JSON", width=12, command=copy_as_json_details)
-    copy_json_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_json_btn, "Copy the current result as a JSON object. (Ctrl+J)", label=status_bar)
-
-    copy_code_btn = ttk.Button(btn_frame, text="Copy Code", width=12, command=copy_code)
-    copy_code_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(copy_code_btn, "Copy the displayed code to the clipboard. (Ctrl+S)", label=status_bar)
+    copy_menu = tk.Menu(copy_menu_btn, tearoff=0)
+    copy_menu.add_command(label="Copy Analysis", command=copy_analysis, accelerator="Ctrl+Shift+C")
+    copy_menu.add_command(label="Copy as JSON", command=copy_as_json_details, accelerator="Ctrl+J")
+    copy_menu.add_command(label="Copy Code", command=copy_code, accelerator="Ctrl+S")
+    copy_menu_btn["menu"] = copy_menu
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -108,6 +108,29 @@ def mock_view_details_env(monkeypatch):
         return btn
     monkeypatch.setattr(gptscan.ttk, 'Button', mock_button_init)
 
+    class MockMenu:
+        def __init__(self, master=None, **kwargs):
+            self.master = master
+            self.items = {}
+        def add_command(self, **kwargs):
+            label = kwargs.get('label')
+            if label:
+                self.items[label] = kwargs.get('command')
+                captured[f"menu_{label}"] = kwargs.get('command')
+        def add_separator(self): pass
+        def add_cascade(self, **kwargs): pass
+        def entryconfig(self, index, **kwargs): pass
+
+    monkeypatch.setattr(gptscan.tk, 'Menu', MockMenu)
+
+    def mock_menubutton_init(master, **kwargs):
+        mb = MagicMock()
+        text = kwargs.get('text', '')
+        if text:
+            captured[f"mb_{text}"] = mb
+        return mb
+    monkeypatch.setattr(gptscan.ttk, 'Menubutton', mock_menubutton_init)
+
     def mock_labelframe_init(master, **kwargs):
         lf = MagicMock()
         text = kwargs.get('text', '')
@@ -343,7 +366,8 @@ def test_view_details_copy_analysis(mock_view_details_env):
     captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
     setup_details(mock_view_details_env, "item1", "test.py", own_conf="90%", admin="Admin Notes", user="User Notes", gpt_conf="80%", snippet="print('test')")
     from gptscan import root as mock_root
-    copy_cmd = captured["btn_Copy Analysis"][1]
+    # Command is now in the menu
+    copy_cmd = captured["menu_Copy Analysis"]
     copy_cmd()
     mock_root.clipboard_clear.assert_called_once()
     copied_text = mock_root.clipboard_append.call_args[0][0]

--- a/tests/test_view_details_json.py
+++ b/tests/test_view_details_json.py
@@ -22,9 +22,9 @@ def test_view_details_copy_json(mock_view_details_env):
     with patch("gptscan._get_tree_results_as_dicts", return_value=mock_json_result):
         gptscan.view_details(item_id="item1")
 
-        # Find the Copy JSON button and command
-        assert "btn_Copy JSON" in captured
-        btn_mock, copy_json_cmd = captured["btn_Copy JSON"]
+        # Find the Copy as JSON menu item and command
+        assert "menu_Copy as JSON" in captured
+        copy_json_cmd = captured["menu_Copy as JSON"]
 
         # Execute the command
         from gptscan import root as mock_root

--- a/tests/test_view_details_ux.py
+++ b/tests/test_view_details_ux.py
@@ -15,9 +15,9 @@ def test_view_details_copy_code(mock_view_details_env):
 
     gptscan.view_details(item_id="item1")
 
-    # Find the Copy Code button and command
-    assert "btn_Copy Code" in captured
-    btn_mock, copy_code_cmd = captured["btn_Copy Code"]
+    # Find the Copy Code menu item and command
+    assert "menu_Copy Code" in captured
+    copy_code_cmd = captured["menu_Copy Code"]
 
     # Execute the command
     from gptscan import root as mock_root


### PR DESCRIPTION
**PR Title:** [UI/UX] Consolidate copy actions in details view 
**Description:** 
* **Context:** GUI 
* **Problem:** The "View Details" footer was cluttered with multiple individual copy buttons ("Copy Analysis", "Copy JSON", and "Copy Code"), which reduced visual hierarchy and made the interface feel less organized.
* **Solution:** Consolidated these related actions into a single "Copy..." dropdown menu using a `ttk.Menubutton`. This improvement maintains all existing functionality and keyboard shortcuts while providing a cleaner, more professional layout in the details window.
**Changes:** 
* Modified `view_details` in `gptscan.py` to replace individual copy buttons with a grouped Menubutton.
* Updated `tests/test_view_details.py`, `tests/test_view_details_json.py`, and `tests/test_view_details_ux.py` to correctly mock and verify the new menu-based interface.


---
*PR created automatically by Jules for task [1799065636277958322](https://jules.google.com/task/1799065636277958322) started by @RainRat*