### PR TITLE
[FEAT] Add support for pyproject.toml manifest scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -301,7 +301,7 @@ class Config:
             return True
         # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'dockerfile', 'makefile') or \
+        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile') or \
            basename.endswith(('.dockerfile', '.makefile')):
             return True
         return False
@@ -2090,11 +2090,64 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc)
+    # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc, pyproject.toml)
     lowered_check = check_name.lower()
-    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc')):
+    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml')):
         try:
             text = content.decode('utf-8', errors='ignore')
+            if lowered_check.endswith('.pyproject.toml') or os.path.basename(lowered_check) == 'pyproject.toml':
+                # Parse pyproject.toml using regex to avoid toml dependency
+                # We look for scripts in:
+                # [project.scripts], [tool.poetry.scripts], [tool.pdm.scripts], [tool.hatch.scripts]
+                script_sections = [
+                    r'\[project\.scripts\]',
+                    r'\[tool\.poetry\.scripts\]',
+                    r'\[tool\.pdm\.scripts\]',
+                    r'\[tool\.hatch\.scripts\]',
+                    r'\[tool\.pdm\.dev-dependencies\]' # Sometimes has scripts too, but usually it's just scripts
+                ]
+
+                # More robust: just look for any [*.scripts]
+                section_pattern = r'\[(?:.*?\.)?scripts\]'
+
+                lines = text.splitlines()
+                in_script_section = False
+                for line in lines:
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+
+                    if line.startswith('[') and line.endswith(']'):
+                        if re.match(section_pattern, line, re.IGNORECASE) or \
+                           any(re.match(s, line, re.IGNORECASE) for s in script_sections):
+                            in_script_section = True
+                        else:
+                            in_script_section = False
+                        continue
+
+                    if in_script_section:
+                        # Match key = "value" or key = { ... }
+                        # Handles simple: test = "pytest"
+                        # Handles complex: test = { cmd = "pytest", help = "run tests" }
+                        match = re.match(r'^([^=\s]+)\s*=\s*(.*)', line)
+                        if match:
+                            script_name = match.group(1).strip().strip('"\'')
+                            command_val = match.group(2).strip()
+
+                            # If it's a string, use it directly
+                            if command_val.startswith(('"', "'")):
+                                command = command_val.strip('"\'')
+                                if command:
+                                    yield (f"{name} [Script: {script_name}]", command.encode('utf-8'))
+                            elif command_val.startswith('{'):
+                                # Try to extract 'cmd' or 'command' or 'shell' from inline table
+                                cmd_match = re.search(r'(?:cmd|command|shell|composite)\s*=\s*("[^"]*"|\'[^\']*\'|\[[^\]]*\])', command_val)
+                                if cmd_match:
+                                    cmd_val = cmd_match.group(1).strip('"\'[] ')
+                                    if cmd_val:
+                                        yield (f"{name} [Script: {script_name}]", cmd_val.encode('utf-8'))
+                return
+
             if lowered_check.endswith('.jsonc'):
                 # Strip single-line and multi-line comments for JSONC support
                 # This regex strips /* ... */ comments and // ... comments while attempting to ignore

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ AI-powered script analysis for local and remote files. This tool uses a pre-trai
 *   **Local & Remote Scanning:** Scan local files or fetch them directly from a web link.
 *   **PR/MR & Patch Scanning:** Fetch and scan code changes from GitHub Pull Requests, GitLab Merge Requests, or local `.diff`/`.patch` files.
 *   **Notebook Support:** Analyzes `.ipynb` cells for malicious commands.
-*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `deno.json`, and `deno.jsonc`.
+*   **Web & Manifest Analysis:** Scans HTML, Markdown, `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, and `deno.jsonc`.
 *   **Archive Unpacking:** Automatically unpacks `.zip`, `.tar`, and `.tar.gz` to scan their contents.
 *   **Two-step analysis:**
     1.  **Fast Local Scan:** A lightweight model identifies suspicious patterns in milliseconds.
@@ -47,7 +47,7 @@ Run `python gptscan.py` to open the GUI.
 Access these options from the **Browse** menu in the header:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, manifest (package.json, `pyproject.toml`, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab), or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan the current Git diff (staged and unstaged changes) for potential threats.
 

--- a/test_pyproject/pyproject.toml
+++ b/test_pyproject/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry.scripts]
+malicious = "os.system('rm -rf /')"

--- a/tests/test_pyproject_scanning.py
+++ b/tests/test_pyproject_scanning.py
@@ -1,0 +1,39 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_pyproject_toml_extraction():
+    content = b"""
+[project.scripts]
+spam-cli = "spam:main_cli"
+
+[tool.poetry.scripts]
+poetry-run = "module.sub:func"
+
+[tool.pdm.scripts]
+pdm-task = "echo pdm"
+composite = { composite = ["pdm-task", "ls"] }
+
+[tool.hatch.scripts]
+hatch-test = "pytest"
+
+[other.section]
+ignored = "rm -rf /"
+"""
+    snippets = list(unpack_content("pyproject.toml", content))
+    names = [s[0] for s in snippets]
+
+    assert "pyproject.toml [Script: spam-cli]" in names
+    assert "pyproject.toml [Script: poetry-run]" in names
+    assert "pyproject.toml [Script: pdm-task]" in names
+    assert "pyproject.toml [Script: composite]" in names
+    assert "pyproject.toml [Script: hatch-test]" in names
+    assert "pyproject.toml [Script: ignored]" not in names
+
+    # Verify content
+    scripts = {s[0]: s[1].decode() for s in snippets}
+    assert scripts["pyproject.toml [Script: spam-cli]"] == "spam:main_cli"
+    assert scripts["pyproject.toml [Script: pdm-task]"] == "echo pdm"
+
+def test_is_container_pyproject():
+    assert Config.is_container("pyproject.toml") is True
+    assert Config.is_container("path/to/pyproject.toml") is True


### PR DESCRIPTION
This PR implements scanning for `pyproject.toml` files, extracting script definitions from common sections like `[project.scripts]`, `[tool.poetry.scripts]`, `[tool.pdm.scripts]`, and `[tool.hatch.scripts]`. This provides better coverage for modern Python projects without adding new dependencies.

---
*PR created automatically by Jules for task [1974827648610836564](https://jules.google.com/task/1974827648610836564) started by @RainRat*