### PR TITLE
Extract duplicated target normalization logic into a private helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1042,6 +1042,20 @@ def get_git_diff(path: str = ".") -> str:
         return ""
 
 
+def _normalize_targets(targets: Union[str, List[str], Path]) -> List[str]:
+    """Normalize scan targets (Path, string, or list) into a deduplicated list of strings."""
+    if isinstance(targets, Path):
+        targets = [str(targets)]
+    elif isinstance(targets, str):
+        try:
+            targets = shlex.split(targets)
+        except ValueError:
+            targets = [targets]
+
+    # Use dict keys to remove duplicates while preserving insertion order.
+    return list(dict.fromkeys(targets))
+
+
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:
     """Collect files from a single path or a list of paths (files, directories, or globs).
 
@@ -1056,13 +1070,7 @@ def collect_files(targets: Union[str, List[str]]) -> List[Path]:
     List[Path]
         A deduplicated list of files to scan.
     """
-    if isinstance(targets, Path):
-        targets = [str(targets)]
-    elif isinstance(targets, str):
-        try:
-            targets = shlex.split(targets)
-        except ValueError:
-            targets = [targets]
+    targets = _normalize_targets(targets)
 
     results: List[Path] = []
     for t in targets:
@@ -2555,15 +2563,7 @@ def scan_files(
             return float(prediction), bytes(padded_data)
 
     # Identify which files were explicitly passed as targets and deduplicate them
-    if isinstance(scan_targets, Path):
-        scan_targets = [str(scan_targets)]
-    elif isinstance(scan_targets, str):
-        try:
-            scan_targets = shlex.split(scan_targets)
-        except ValueError:
-            scan_targets = [scan_targets]
-
-    scan_targets = list(dict.fromkeys(scan_targets))
+    scan_targets = _normalize_targets(scan_targets)
 
     url_targets = [str(t) for t in scan_targets if str(t).startswith(('http://', 'https://'))]
     local_targets = [t for t in scan_targets if str(t) not in url_targets]


### PR DESCRIPTION
This PR resolves a code duplication issue in `gptscan.py`. 

### What
Extracted common logic for normalizing scan targets into a private helper function `_normalize_targets(targets)`. This logic was previously repeated in `collect_files` and `scan_files`.

### Why
By consolidating this logic, we reduce code redundancy and ensure that any future improvements to how scan targets are parsed (e.g., better shell quoting or more complex Path handling) only need to be implemented in one place. This improves readability and maintainability without changing the external behavior of the scanner.

### Verification
- Ran specific unit tests for file collection and scan logic: `tests/test_file_collection.py` and `tests/test_run_scan.py`.
- Ran the full test suite (620 tests) to ensure system-wide stability.
- All tests passed successfully.

---
*PR created automatically by Jules for task [1676822236325493721](https://jules.google.com/task/1676822236325493721) started by @RainRat*