### PR TITLE
Ensure consistent string return type in target normalization

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1085,8 +1085,8 @@ def _normalize_targets(targets: Union[str, List[str], Path]) -> List[str]:
         except ValueError:
             targets = [targets]
 
-    # Use dict keys to remove duplicates while preserving insertion order.
-    return list(dict.fromkeys(targets))
+    # Ensure all elements are strings and remove duplicates while preserving order.
+    return list(dict.fromkeys(str(t) for t in targets))
 
 
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:


### PR DESCRIPTION
* **What:** Updated the `_normalize_targets` private helper function to explicitly convert all input elements to strings during the deduplication process.
* **Why:** The function's type hint and documentation specified a `List[str]` return type, but it previously preserved `pathlib.Path` objects if they were passed within a list. This inconsistency could lead to mixed-type lists downstream, potentially breaking components that expect string-only paths. This fix ensures robust and predictable behavior across the scan initialization pipeline. All 648 tests in the suite passed after this change.

---
*PR created automatically by Jules for task [1125072465320184994](https://jules.google.com/task/1125072465320184994) started by @RainRat*