### PR TITLE
[TEST] Add coverage for target normalization and fix mixed-type deduplication bug

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1085,8 +1085,8 @@ def _normalize_targets(targets: Union[str, List[str], Path]) -> List[str]:
         except ValueError:
             targets = [targets]
 
-    # Use dict keys to remove duplicates while preserving insertion order.
-    return list(dict.fromkeys(targets))
+    # Ensure all targets are strings and deduplicate while preserving order.
+    return list(dict.fromkeys(str(t) for t in targets))
 
 
 def collect_files(targets: Union[str, List[str]]) -> List[Path]:

--- a/tests/test_normalize_targets.py
+++ b/tests/test_normalize_targets.py
@@ -1,0 +1,49 @@
+import pytest
+from pathlib import Path
+from gptscan import _normalize_targets
+
+def test_normalize_targets_path():
+    p = Path("/tmp/test")
+    assert _normalize_targets(p) == ["/tmp/test"]
+
+def test_normalize_targets_string():
+    s = "/tmp/a /tmp/b"
+    assert _normalize_targets(s) == ["/tmp/a", "/tmp/b"]
+
+def test_normalize_targets_string_quoted():
+    s = "'/tmp/path with space' /tmp/b"
+    assert _normalize_targets(s) == ["/tmp/path with space", "/tmp/b"]
+
+def test_normalize_targets_string_malformed_quotes():
+    s = "'malformed quote"
+    # Fallback to returning the string as a single-element list
+    assert _normalize_targets(s) == [s]
+
+def test_normalize_targets_list_strings():
+    l = ["/tmp/a", "/tmp/b", "/tmp/a"]
+    assert _normalize_targets(l) == ["/tmp/a", "/tmp/b"]
+
+def test_normalize_targets_list_paths():
+    l = [Path("/tmp/a"), Path("/tmp/b"), Path("/tmp/a")]
+    # Current implementation fails this: it returns [Path("/tmp/a"), Path("/tmp/b"), Path("/tmp/a")]
+    # Expected: ["/tmp/a", "/tmp/b"]
+    result = _normalize_targets(l)
+    assert result == ["/tmp/a", "/tmp/b"]
+    for item in result:
+        assert isinstance(item, str)
+
+def test_normalize_targets_mixed_list():
+    l = [Path("/tmp/a"), "/tmp/a", "/tmp/b"]
+    # Current implementation fails this: [Path("/tmp/a"), "/tmp/a", "/tmp/b"]
+    # Expected: ["/tmp/a", "/tmp/b"]
+    result = _normalize_targets(l)
+    assert result == ["/tmp/a", "/tmp/b"]
+    for item in result:
+        assert isinstance(item, str)
+
+def test_normalize_targets_empty_list():
+    assert _normalize_targets([]) == []
+
+def test_normalize_targets_preserves_order():
+    l = ["b", "a", "b", "c"]
+    assert _normalize_targets(l) == ["b", "a", "c"]


### PR DESCRIPTION
Fixed a logic gap in `_normalize_targets` where list elements (like `pathlib.Path` objects) were not converted to strings, leading to inconsistent return types and deduplication failures. Added a new test suite `tests/test_normalize_targets.py` covering 9 distinct scenarios to ensure robustness. Verified that all 641 tests pass with this change.

---
*PR created automatically by Jules for task [11538300817968803792](https://jules.google.com/task/11538300817968803792) started by @RainRat*