### PR TITLE
Mitigate SSRF vulnerability in fetch_url_content

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -245,6 +245,9 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
     # Resolve GitHub/GitLab URLs to raw content/archives
     url = resolve_remote_url(url)
 
+    if not url.lower().startswith(('http://', 'https://')):
+        raise ValueError(f"Unauthorized URL scheme: {url}")
+
     with urllib.request.urlopen(url, timeout=timeout) as response:
         content_length = response.getheader('Content-Length')
         if content_length and int(content_length) > max_size:

--- a/tests/test_url_security.py
+++ b/tests/test_url_security.py
@@ -1,0 +1,28 @@
+import pytest
+from gptscan import fetch_url_content
+
+def test_fetch_url_content_unauthorized_scheme():
+    """Verify that fetch_url_content rejects non-HTTP(S) schemes."""
+    with pytest.raises(ValueError, match="Unauthorized URL scheme"):
+        fetch_url_content("file:///etc/passwd")
+
+    with pytest.raises(ValueError, match="Unauthorized URL scheme"):
+        fetch_url_content("ftp://example.com/file")
+
+    with pytest.raises(ValueError, match="Unauthorized URL scheme"):
+        fetch_url_content("gopher://example.com")
+
+def test_fetch_url_content_authorized_scheme(mocker):
+    """Verify that fetch_url_content allows HTTP(S) schemes."""
+    # Mock urllib.request.urlopen to avoid actual network requests
+    # Use MagicMock for context manager support
+    mock_response = mocker.MagicMock()
+    mock_response.getheader.return_value = "100"
+    mock_response.read.return_value = b"test content"
+    mock_response.__enter__.return_value = mock_response
+
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    # These should not raise ValueError for the scheme
+    fetch_url_content("http://example.com")
+    fetch_url_content("https://example.com")


### PR DESCRIPTION
This PR addresses a security vulnerability where the `fetch_url_content` function in `gptscan.py` could be used to access local files or internal services by providing a URL with an unauthorized scheme (e.g., `file://`).

Changes:
- Implemented scheme validation in `fetch_url_content` to only allow `http://` and `https://`.
- Added `tests/test_url_security.py` with test cases for authorized and unauthorized schemes.

This fix ensures that remote scanning is restricted to web-based resources as intended. All existing tests passed, and new tests confirm the mitigation.

---
*PR created automatically by Jules for task [12501605936088325783](https://jules.google.com/task/12501605936088325783) started by @RainRat*