### PR TITLE
[TEST] Enforce URL scheme validation in fetch_url_content and add security tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -245,6 +245,10 @@ def fetch_url_content(url: str, timeout: int = 10, max_size: Optional[int] = Non
     # Resolve GitHub/GitLab URLs to raw content/archives
     url = resolve_remote_url(url)
 
+    # Ensure URL scheme is http or https to prevent SSRF/local file access
+    if not url.lower().startswith(('http://', 'https://')):
+        raise ValueError(f"Unsupported URL scheme: {url.split(':', 1)[0] if ':' in url else 'unknown'}")
+
     with urllib.request.urlopen(url, timeout=timeout) as response:
         content_length = response.getheader('Content-Length')
         if content_length and int(content_length) > max_size:

--- a/tests/test_url_security.py
+++ b/tests/test_url_security.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from gptscan import fetch_url_content
+
+def test_fetch_url_content_allowed_schemes():
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = "10"
+    mock_response.read.return_value = b"test content"
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        # Test http
+        content = fetch_url_content("http://example.com/script.py")
+        assert content == b"test content"
+        mock_urlopen.assert_called_with("http://example.com/script.py", timeout=10)
+
+        # Test https
+        content = fetch_url_content("https://example.com/script.py")
+        assert content == b"test content"
+        mock_urlopen.assert_called_with("https://example.com/script.py", timeout=10)
+
+def test_fetch_url_content_unauthorized_schemes(tmp_path):
+    # Test file://
+    secrets = tmp_path / "secrets.txt"
+    secrets.write_text("secret")
+    file_url = f"file://{secrets.absolute()}"
+
+    with pytest.raises(ValueError, match="Unsupported URL scheme: file"):
+        fetch_url_content(file_url)
+
+    # Test ftp://
+    with pytest.raises(ValueError, match="Unsupported URL scheme: ftp"):
+        fetch_url_content("ftp://example.com/file")
+
+    # Test data://
+    with pytest.raises(ValueError, match="Unsupported URL scheme: data"):
+        fetch_url_content("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==")
+
+def test_fetch_url_content_case_insensitive_scheme():
+    mock_response = MagicMock()
+    mock_response.getheader.return_value = "10"
+    mock_response.read.return_value = b"test"
+    mock_response.__enter__.return_value = mock_response
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        content = fetch_url_content("HTTP://example.com/script.py")
+        assert content == b"test"
+
+        content = fetch_url_content("Https://example.com/script.py")
+        assert content == b"test"


### PR DESCRIPTION
This PR hardens the `fetch_url_content` function against SSRF and local file disclosure vulnerabilities.

### Changes:
- **Security Hardening:** `fetch_url_content` now explicitly validates the URL scheme after resolution, raising a `ValueError` if the protocol is not `http` or `https`. This mitigates risks associated with `urllib.request.urlopen`'s native support for schemes like `file://`.
- **New Test Coverage:** Created `tests/test_url_security.py` to ensure that valid URLs continue to work while unauthorized schemes are correctly blocked.

### Verification:
- All 660 tests in the suite passed, including the new security tests and existing URL resolution/scanning logic.
- Verified that `file://` URLs now correctly trigger a `ValueError` instead of attempting to read local files.

---
*PR created automatically by Jules for task [8019265798451182643](https://jules.google.com/task/8019265798451182643) started by @RainRat*