### PR TITLE
[FEAT] Add Pastebin and Hugging Face URL Resolution

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -74,7 +74,7 @@ _virtual_source_cache: Dict[str, str] = {}
 
 
 def resolve_remote_url(url: str) -> str:
-    """Resolve GitHub/GitLab/Bitbucket repository, blob, tag, or PR URLs to their raw content or archive.
+    """Resolve GitHub/GitLab/Bitbucket/Pastebin/Hugging Face repository, blob, tag, or PR URLs to their raw content or archive.
 
     Args:
         url: The original URL to resolve.
@@ -194,6 +194,21 @@ def resolve_remote_url(url: str) -> str:
     if bb_repo_match:
         user, repo = bb_repo_match.groups()
         return f"https://bitbucket.org/{user}/{repo}/get/HEAD.zip"
+
+    # 16. Pastebin -> Raw
+    # Example: https://pastebin.com/abcdefgh -> https://pastebin.com/raw/abcdefgh
+    pb_match = re.match(r'https?://(?:www\.)?pastebin\.com/([a-zA-Z0-9]+)$', url, re.IGNORECASE)
+    if pb_match:
+        paste_id = pb_match.group(1)
+        if paste_id.lower() not in ('archive', 'tools', 'faq', 'contact', 'night_mode', 'pro', 'doc', 'signup', 'login', 'api', 'trends', 'languages'):
+            return f"https://pastebin.com/raw/{paste_id}"
+
+    # 17. Hugging Face Blob -> Raw
+    # Example: https://huggingface.co/user/repo/blob/main/script.py -> https://huggingface.co/user/repo/raw/main/script.py
+    hf_blob_match = re.match(r'(https?://(?:www\.)?huggingface\.co/.+)/blob/(.+)', url, re.IGNORECASE)
+    if hf_blob_match:
+        base, path = hf_blob_match.groups()
+        return f"{base}/raw/{path}"
 
     return url
 
@@ -5663,7 +5678,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Docker Compose (entrypoint), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist including PRs, tags and multi-file gists) for malicious code using AI.",
+        description="Scan scripts, archives (ZIP/TAR), Jupyter Notebooks, package manifests (package.json, composer.json, deno.json), CI/CD workflows (GitHub Actions, GitLab CI), Docker Compose (entrypoint), Markdown files, HTML files, patches (.diff/.patch), git diffs, and web links (GitHub/GitLab/Bitbucket/Gist/Pastebin/Hugging Face including PRs, tags and multi-file gists) for malicious code using AI.",
         epilog="Examples:\n"
                "  # Scan a folder using AI analysis\n"
                "  python gptscan.py ./my_scripts --cli --use-gpt\n\n"
@@ -5679,6 +5694,8 @@ def main():
                "  python gptscan.py https://github.com/user/repo --cli\n\n"
                "  # Scan a GitHub Pull Request or GitLab Merge Request directly\n"
                "  python gptscan.py https://github.com/user/repo/pull/123 --cli\n\n"
+               "  # Scan a Pastebin paste or a Hugging Face script directly\n"
+               "  python gptscan.py https://pastebin.com/abcdefgh --cli\n\n"
                "Note: Always run the script from inside its own folder so it can find its required data files (like scripts.h5).",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Scan your files for dangerous code with AI. This tool uses a machine learning mo
 
 ## Features
 *   **Scan Local & Web Files:** Scan files on your computer or from a web link.
-*   **Platform Support:** Scan code from GitHub, GitLab, and Bitbucket (including PRs, Commits, Tags, and Snippets).
+*   **Platform Support:** Scan code from GitHub, GitLab, Bitbucket, Pastebin, and Hugging Face (including PRs, Commits, Tags, and Snippets).
 *   **Notebook Support:** Scan cells in `.ipynb` files for dangerous commands.
 *   **Project & Build Files:** Scan `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, `deno.jsonc`, `Dockerfile`, `Makefile`, Docker Compose, HTML, and Markdown.
 *   **Unpack Archives:** Open `.zip`, `.tar`, and `.tar.gz` files automatically to scan the contents.
@@ -40,7 +40,7 @@ Run `python gptscan.py` to open the scanner window.
 Access these options from the **Browse** menu:
 *   **Select File(s)...:** Choose one or more scripts to scan.
 *   **Select Folder...:** Choose a whole directory to scan.
-*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, Dockerfile, Makefile, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab/Bitbucket), or archive (.zip, .tar, .tar.gz) directly from a web link.
+*   **Scan URL...:** Scan a script, Notebook, HTML, Markdown file, Dockerfile, Makefile, manifest (package.json, `deno.jsonc`, etc.), PR/MR (GitHub/GitLab/Bitbucket), Pastebin paste, Hugging Face blob, or archive (.zip, .tar, .tar.gz) directly from a web link.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
 *   **Scan Git Diff:** Scan changes in your local Git repository.
 

--- a/tests/test_url_resolution_expansion.py
+++ b/tests/test_url_resolution_expansion.py
@@ -1,0 +1,33 @@
+import pytest
+from gptscan import resolve_remote_url
+
+def test_resolve_pastebin_url():
+    # Test typical paste
+    url = "https://pastebin.com/abcdefgh"
+    # Expected behavior after implementation
+    assert resolve_remote_url(url) == "https://pastebin.com/raw/abcdefgh"
+
+def test_resolve_huggingface_url():
+    # Test typical HF blob
+    url = "https://huggingface.co/user/repo/blob/main/model.py"
+    # Expected behavior after implementation
+    assert resolve_remote_url(url) == "https://huggingface.co/user/repo/raw/main/model.py"
+
+def test_pastebin_safe_urls():
+    # These should NOT be transformed to /raw/
+    safe_urls = [
+        "https://pastebin.com/archive",
+        "https://pastebin.com/tools",
+        "https://pastebin.com/faq",
+        "https://pastebin.com/contact",
+        "https://pastebin.com/night_mode",
+        "https://pastebin.com/pro",
+        "https://pastebin.com/doc",
+        "https://pastebin.com/signup",
+        "https://pastebin.com/login",
+        "https://pastebin.com/api",
+        "https://pastebin.com/trends",
+        "https://pastebin.com/languages",
+    ]
+    for url in safe_urls:
+        assert resolve_remote_url(url) == url


### PR DESCRIPTION
This PR expands the remote URL resolution capabilities of the GPT Virus Scanner to include **Pastebin** and **Hugging Face**.

### Changes:
1.  **Core Logic:** Added regex patterns to `resolve_remote_url` in `gptscan.py` to automatically transform Pastebin paste URLs and Hugging Face blob URLs into their "raw" equivalents for direct scanning.
    - Pastebin: `https://pastebin.com/ID` -> `https://pastebin.com/raw/ID` (with exclusions for site pages like `/archive` or `/tools`).
    - Hugging Face: `.../blob/...` -> `.../raw/...`.
2.  **Documentation:** 
    - Updated the `main()` function's CLI help text to include these new platforms in the description and added a specific example to the epilog.
    - Updated `readme.md` to reflect support in both the 'Features' and 'Scan URL...' sections.
3.  **Testing:** Created `tests/test_url_resolution_expansion.py` covering standard resolution, safe-path exclusion for Pastebin, and Hugging Face blob-to-raw transformation.

This improvement allows users to scan scripts and snippets hosted on these platforms directly by providing the browser URL, mirroring the existing support for GitHub, GitLab, and Bitbucket.

---
*PR created automatically by Jules for task [691923311365874590](https://jules.google.com/task/691923311365874590) started by @RainRat*