### PR TITLE
Fix case-sensitive URL scheme detection in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2626,7 +2626,7 @@ def scan_files(
     # Identify which files were explicitly passed as targets and deduplicate them
     scan_targets = _normalize_targets(scan_targets)
 
-    url_targets = [str(t) for t in scan_targets if str(t).startswith(('http://', 'https://'))]
+    url_targets = [str(t) for t in scan_targets if str(t).lower().startswith(('http://', 'https://'))]
     local_targets = [t for t in scan_targets if str(t) not in url_targets]
 
     explicit_targets = {Path(t) for t in local_targets}


### PR DESCRIPTION
* **What:** Updated the URL identification logic in the `scan_files` function to perform a case-insensitive check for `http://` and `https://` schemes.
* **Why:** Previously, URLs with uppercase schemes (e.g., `HTTP://`) were misidentified as local files, leading to them being ignored or causing errors during the local file collection phase. This change ensures all valid URLs are correctly processed regardless of case, improving the robustness of the scanner's input handling. No breaking changes were introduced.

---
*PR created automatically by Jules for task [14898538037875081173](https://jules.google.com/task/14898538037875081173) started by @RainRat*