### PR TITLE
[TEST] Add content-based Jupyter Notebook detection to is_container

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -344,6 +344,9 @@ class Config:
                 return True
             if len(content) > 262 and content[257:262] == b'ustar':
                 return True
+            # Jupyter Notebook signature
+            if content.startswith(b'{') and b'"cells"' in content:
+                return True
 
         # 2. Check by extension or basename
         path_s = str(file_path).lower()

--- a/tests/test_is_container.py
+++ b/tests/test_is_container.py
@@ -21,6 +21,13 @@ def test_is_container_magic_bytes_too_short():
     content = b'ustar' # Too short to check offset 257
     assert Config.is_container("file.unknown", content=content) is False
 
+def test_is_container_notebook_by_content():
+    # Jupyter Notebook: starts with { and contains "cells"
+    content = b'{\n "cells": [],\n "metadata": {}\n}'
+    assert Config.is_container("notebook", content=content) is True
+    # Negative case: starts with { but no "cells"
+    assert Config.is_container("data.json", content=b'{"key": "value"}') is False
+
 def test_is_container_by_extension():
     extensions = [
         '.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml',


### PR DESCRIPTION
### Description
* **Type:** Bug Fix / New Coverage
* **What:** Updated `Config.is_container` in `gptscan.py` to support content-based detection of Jupyter Notebooks and added a corresponding unit test in `tests/test_is_container.py`.
* **Why:** Previously, Jupyter Notebooks were only recognized as containers (to be unpacked) by their `.ipynb` extension. However, `unpack_content` supported detection via content. This change aligns the two functions, ensuring that notebooks without the correct extension are still identified for unpacking and scanning, increasing the tool's robustness.

### Verification
- Ran `python3 -m pytest tests/test_is_container.py` (all 10 passed).
- Ran full test suite (664 passed).
- Verified the logic handles both positive (valid notebook) and negative (generic JSON) cases.

---
*PR created automatically by Jules for task [12994454937299056122](https://jules.google.com/task/12994454937299056122) started by @RainRat*