### PR TITLE
[FEAT] Multiple Hits per File Detection

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2826,6 +2826,8 @@ def scan_files(
                 maxconf = -1.0
                 max_window_bytes = b""
                 max_offset = 0
+                hits_found = 0
+                file_content_for_lines = None
                 error_message: Optional[str] = None
 
                 try:
@@ -2839,6 +2841,16 @@ def scan_files(
                                 maxconf = result
                                 max_window_bytes = padded_bytes
                                 max_offset = offset
+
+                            if result >= threshold_val:
+                                hits_found += 1
+                                if file_content_for_lines is None:
+                                    curr_pos = f.tell()
+                                    f.seek(0)
+                                    file_content_for_lines = f.read()
+                                    f.seek(curr_pos)
+                                line_num = file_content_for_lines[:offset].count(b'\n') + 1
+                                yield from handle_scan_result(str(file_path), result, padded_bytes, line_num)
                 except OSError as err:
                     error_message = f"Error reading file: {err}"
 
@@ -2855,8 +2867,8 @@ def scan_files(
                             '-',
                         )
                     )
-                else:
-                    # Calculate line number
+                elif hits_found == 0:
+                    # Calculate line number for best hit
                     line_num = 1
                     try:
                         with open(file_path, 'rb') as f:
@@ -2893,6 +2905,8 @@ def scan_files(
             maxconf = -1.0
             max_window_bytes = b""
             max_offset = 0
+            hits_found = 0
+            decoded_content = content.decode('utf-8', errors='ignore')
             with io.BytesIO(content) as f:
                 for offset, window in iter_windows(f, file_size, deep_scan):
                     if cancel_event.is_set():
@@ -2903,10 +2917,15 @@ def scan_files(
                         max_window_bytes = padded_bytes
                         max_offset = offset
 
-            # Calculate line number for snippet
-            line_num = content[:max_offset].count(b'\n') + 1
-            decoded_content = content.decode('utf-8', errors='ignore')
-            yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content)
+                    if result >= threshold_val:
+                        hits_found += 1
+                        line_num = content[:offset].count(b'\n') + 1
+                        yield from handle_scan_result(name, result, padded_bytes, line_num, full_content=decoded_content)
+
+            if hits_found == 0:
+                # Calculate line number for best hit
+                line_num = content[:max_offset].count(b'\n') + 1
+                yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content)
 
     if cancel_event.is_set():
         return
@@ -5754,7 +5773,7 @@ def main():
         '--threshold', '-t',
         type=int,
         default=50,
-        help='Only show results with a threat level at or above this number (0-100). The default is 50.'
+        help='Show all results with a threat level at or above this number (0-100). If no results meet the threshold, only the most suspicious one is shown. The default is 50.'
     )
     scan_group.add_argument(
         '--stdin',

--- a/tests/test_multi_hit.py
+++ b/tests/test_multi_hit.py
@@ -1,0 +1,123 @@
+import io
+import pytest
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+import gptscan
+
+@pytest.fixture
+def mock_multi_hit_model(monkeypatch):
+    """Mocks the model to return specific threat levels for different windows."""
+
+    def mock_predict(tf_data, batch_size=1, steps=1):
+        # Extract the first byte of the data to decide the return value
+        # tf_data is a tensor, we assume it's passed as a list or similar in mock
+        data = tf_data.data if hasattr(tf_data, 'data') else tf_data
+        first_byte = data[0]
+        if first_byte == ord('H'): # 'H' for High threat
+            return [[0.9]]
+        return [[0.1]]
+
+    mock_model = MagicMock()
+    mock_model.predict.side_effect = mock_predict
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    # Mock TensorFlow module
+    mock_tf = SimpleNamespace(
+        constant=lambda x: SimpleNamespace(data=x),
+        expand_dims=lambda x, axis: x,
+    )
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+
+    return mock_model
+
+def test_scan_files_reports_multiple_hits_in_one_file(monkeypatch, tmp_path, mock_multi_hit_model):
+    """Verify that multiple suspicious segments in one file are all reported."""
+    # Create a file with two suspicious segments
+    # Segment 1 starts at 0 with 'H', Segment 2 starts at 1024 with 'H'
+    content = b'H' + b'a' * 1023 + b'H' + b'b' * 1023
+    test_file = tmp_path / "multi_hit.py"
+    test_file.write_bytes(content)
+
+    monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+
+    # Run scan with deep_scan=True to find both windows
+    results = list(gptscan.scan_files(
+        scan_targets=str(tmp_path),
+        deep_scan=True,
+        show_all=False,
+        use_gpt=False
+    ))
+
+    # Expect: Progress (start), Progress (file), Result (Hit 1), Result (Hit 2), Summary
+    result_events = [r for r in results if r[0] == 'result']
+    assert len(result_events) == 2
+
+    # Verify Hit 1 (offset 0 -> line 1)
+    assert result_events[0][1][1] == "90%"
+    assert result_events[0][1][6] == 1
+
+    # Verify Hit 2 (offset 1024 -> line 1 because no newline)
+    assert result_events[1][1][6] == 1
+
+    # Test with newline to verify line counting
+    # 1023 bytes at 0...1022. Then '\n' at 1023. Then 'H' at 1024.
+    content_with_newline = b'H' + b'a' * 1022 + b'\n' + b'H' + b'b' * 1023
+    test_file.write_bytes(content_with_newline)
+
+    results = list(gptscan.scan_files(
+        scan_targets=str(tmp_path),
+        deep_scan=True,
+        show_all=False,
+        use_gpt=False
+    ))
+
+    result_events = [r for r in results if r[0] == 'result']
+    assert len(result_events) == 2
+    assert result_events[0][1][6] == 1
+    assert result_events[1][1][6] == 2 # Second hit is after the newline
+
+def test_scan_files_extra_snippets_multiple_hits(monkeypatch, mock_multi_hit_model):
+    """Verify that multiple suspicious segments in an extra snippet are all reported."""
+    # Hit 1 at 0. '\n' at 1023. Hit 2 at 1024.
+    content = b'H' + b'a' * 1022 + b'\n' + b'H' + b'b' * 1023
+    extra_snippets = [("[Clipboard]", content)]
+
+    monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
+
+    # Run scan
+    results = list(gptscan.scan_files(
+        scan_targets=[],
+        deep_scan=True,
+        show_all=False,
+        use_gpt=False,
+        extra_snippets=extra_snippets
+    ))
+
+    result_events = [r for r in results if r[0] == 'result']
+    assert len(result_events) == 2
+    assert result_events[0][1][0] == "[Clipboard]"
+    assert result_events[0][1][6] == 1
+    assert result_events[1][1][6] == 2
+
+def test_scan_files_fallback_if_no_multi_hits(monkeypatch, tmp_path, mock_multi_hit_model):
+    """Verify that if no segments exceed the threshold, it still falls back to the best hit (if show_all)."""
+    # File with only low threat segments (not starting with 'H')
+    content = b'low threat'
+    test_file = tmp_path / "safe.py"
+    test_file.write_bytes(content)
+
+    monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+
+    # Run scan with show_all=True
+    results = list(gptscan.scan_files(
+        scan_targets=str(tmp_path),
+        deep_scan=True,
+        show_all=True,
+        use_gpt=False
+    ))
+
+    result_events = [r for r in results if r[0] == 'result']
+    assert len(result_events) == 1
+    assert result_events[0][1][1] == "10%"


### PR DESCRIPTION
* **What:** Updated the scanning engine to report all suspicious code segments within a single file or snippet that exceed the configured threat threshold. Previously, the scanner only reported the single segment with the highest confidence score per file.
* **Why:** Security analysts need to see all potential threats within a file to perform a complete triage. Reporting only the "best" hit could hide other malicious segments if one segment happens to have a higher local model score than the others. This change aligns the tool's behavior with industry-standard static analysis tools that report all findings.

---
*PR created automatically by Jules for task [1157528027386686420](https://jules.google.com/task/1157528027386686420) started by @RainRat*