### PR TITLE
Fix case-sensitive URL scheme detection in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2626,7 +2626,7 @@ def scan_files(
     # Identify which files were explicitly passed as targets and deduplicate them
     scan_targets = _normalize_targets(scan_targets)
 
-    url_targets = [str(t) for t in scan_targets if str(t).startswith(('http://', 'https://'))]
+    url_targets = [str(t) for t in scan_targets if str(t).lower().startswith(('http://', 'https://'))]
     local_targets = [t for t in scan_targets if str(t) not in url_targets]
 
     explicit_targets = {Path(t) for t in local_targets}


### PR DESCRIPTION
* **What:** Updated the `scan_files` function in `gptscan.py` to use a case-insensitive check when identifying URL targets by calling `.lower()` on the target string before checking for `http://` or `https://` prefixes.
* **Why:** URL schemes are case-insensitive per RFC 3986. The previous implementation only recognized lowercase schemes, causing URLs with uppercase protocols to be misclassified as local file paths and subsequently ignored. This fix ensures consistent behavior for all valid URL inputs without altering the original target strings used for fetching. verified with new reproduction test and existing test suite.

---
*PR created automatically by Jules for task [14613694760795486424](https://jules.google.com/task/14613694760795486424) started by @RainRat*