### PR TITLE
[TEST] Expand container detection for notebooks and manifest variants

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -338,11 +338,14 @@ class Config:
     @staticmethod
     def is_container(file_path: Union[Path, str], content: Optional[bytes] = None) -> bool:
         """Check if a file is a container that should be unpacked (archives, notebooks, manifests, etc.)."""
-        # 1. Check by magic bytes if content is available
+        # 1. Check by magic bytes or content markers if available
         if content:
             if content.startswith(b'PK\x03\x04') or content.startswith(b'\x1f\x8b'):
                 return True
             if len(content) > 262 and content[257:262] == b'ustar':
+                return True
+            # Detect Jupyter Notebooks by content
+            if content.startswith(b'{') and b'"cells"' in content:
                 return True
 
         # 2. Check by extension or basename
@@ -353,8 +356,7 @@ class Config:
             return True
         # Explicit manifest files and build scripts (checked by basename)
         basename = os.path.basename(path_s)
-        if basename in ('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile') or \
-           basename.endswith(('.dockerfile', '.makefile')):
+        if basename.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'dockerfile', 'makefile')):
             return True
         return False
 

--- a/tests/test_is_container.py
+++ b/tests/test_is_container.py
@@ -30,10 +30,24 @@ def test_is_container_by_extension():
         assert Config.is_container(f"test{ext}") is True
 
 def test_is_container_by_manifest_name():
-    manifests = ['package.json', 'composer.json', 'deno.json', 'deno.jsonc']
+    manifests = ['package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml']
     for name in manifests:
         assert Config.is_container(name) is True
         assert Config.is_container(f"sub/dir/{name}") is True
+
+def test_is_container_manifest_variants():
+    # Should match variants like my.package.json if consistency with unpack_content is desired
+    variants = ['my.package.json', 'prod.composer.json', 'custom.deno.json']
+    for name in variants:
+        assert Config.is_container(name) is True
+
+def test_is_container_notebook_by_content():
+    content = b'{"cells": [], "metadata": {}}'
+    assert Config.is_container("unknown_file", content=content) is True
+
+    # Negative case: JSON but not a notebook
+    content_not_notebook = b'{"key": "value"}'
+    assert Config.is_container("unknown_file", content=content_not_notebook) is False
 
 def test_is_container_by_devops_name():
     devops = ['Dockerfile', 'Makefile', 'my.dockerfile', 'project.makefile']


### PR DESCRIPTION
Identified and fixed gaps in the container detection logic. Jupyter Notebooks are now detected by content (starting with `{` and containing `"cells"`), and manifest/build files are detected using a broader suffix-based approach on their basenames. Added comprehensive tests to `tests/test_is_container.py` to verify these changes and ensure no regressions.

---
*PR created automatically by Jules for task [4171860744391774729](https://jules.google.com/task/4171860744391774729) started by @RainRat*