### PR TITLE
Fix logic bug in report standardization fallback

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3914,7 +3914,7 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
         return {k: "" for k in REPORT_FIELD_MAPPING}
 
     res = {
-        key: next((str(item[alt]) if item[alt] is not None else "" for alt in alts if alt in item), "")
+        key: next((str(item[alt]) for alt in alts if item.get(alt) not in (None, "")), "")
         for key, alts in REPORT_FIELD_MAPPING.items()
     }
     # Fallback: if own_conf is empty but gpt_conf has a value, they might be using a report

--- a/tests/test_standardize_fallback.py
+++ b/tests/test_standardize_fallback.py
@@ -1,0 +1,27 @@
+import pytest
+from gptscan import standardize_result_dict
+
+def test_standardize_result_dict_fallback():
+    # Item with an empty 'path' key but a valid 'File Path' key
+    item = {
+        "path": "",
+        "File Path": "correct/path.py",
+        "Confidence": "85%"
+    }
+
+    standardized = standardize_result_dict(item)
+
+    # Before the fix, it would have picked the empty string from 'path'
+    assert standardized["path"] == "correct/path.py"
+    # own_conf should pick up 'Confidence'
+    assert standardized["own_conf"] == "85%"
+
+def test_standardize_result_dict_none_handling():
+    # Item with None value for a key
+    item = {
+        "path": None,
+        "uri": "path/via/uri.py"
+    }
+
+    standardized = standardize_result_dict(item)
+    assert standardized["path"] == "path/via/uri.py"


### PR DESCRIPTION
* **What:** Updated the generator expression in `standardize_result_dict` to skip keys that evaluate to `None` or an empty string (`""`) when mapping report fields to the internal format.
* **Why:** Previously, the function would stop at the first matching key even if it was empty, preventing it from finding data in alternative alias keys. This change ensures more robust data extraction when importing results from diverse formats like CSV, JSON, or Markdown. The fix is non-breaking and verified with new tests.

---
*PR created automatically by Jules for task [17496750247102440168](https://jules.google.com/task/17496750247102440168) started by @RainRat*