### PR TITLE
[UI/UX] Add keyboard shortcuts for Clipboard and Git Diff scanning

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "file1.py file2.js",
+    "last_path": "/some/path",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,8 +12,8 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "file1.py file2.js",
         "/some/path",
+        "file1.py file2.js",
         "/some/repo",
         "1",
         "2",

--- a/gptscan.py
+++ b/gptscan.py
@@ -5402,7 +5402,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (File, Folder, URL, File List, or Clipboard).")
+    bind_hover_message(browse_button, "Browse for scan targets (File, Folder, URL, File List, Clipboard, or Git Diff).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5417,8 +5417,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Select Folder...", command=browse_dir_click)
     browse_menu.add_command(label="Scan URL...", command=select_url_click)
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
-    browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click)
-    browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click)
+    browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click, accelerator="Ctrl+Shift+V")
+    browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -5799,6 +5799,10 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-E>', copy_cli_command)
     root.bind('<Control-v>', import_from_clipboard)
     root.bind('<Command-v>', import_from_clipboard)
+    root.bind('<Control-Shift-V>', lambda e: scan_clipboard_click())
+    root.bind('<Command-Shift-V>', lambda e: scan_clipboard_click())
+    root.bind('<Control-Shift-D>', lambda e: scan_git_diff_click())
+    root.bind('<Command-Shift-D>', lambda e: scan_git_diff_click())
     root.bind('<Control-f>', focus_filter)
     root.bind('<Command-f>', focus_filter)
     root.bind('<Control-j>', copy_as_json)


### PR DESCRIPTION
### UI/UX Improvement: Friction Reduction

**Context:** GUI
**Problem:** Power users frequently scanning from the clipboard or checking Git changes had to navigate the "Browse" dropdown menu for every scan, increasing friction. Additionally, the "Git Diff" feature was not mentioned in the main browse button's tooltip, making it less discoverable.

**Solution:**
- Implemented **global keyboard shortcuts** (`Ctrl+Shift+V` and `Ctrl+Shift+D`) to trigger these scans instantly from the main window.
- Added **menu accelerators** to the "Browse" dropdown so users can see the shortcuts while navigating the menu.
- Updated the **hover message** (tooltip) for the "Browse" button to explicitly include "Git Diff", improving feature discoverability.

These changes follow "Invisible Design" principles by enhancing power-user efficiency without changing the core visual layout.

---
*PR created automatically by Jules for task [4602646342240245383](https://jules.google.com/task/4602646342240245383) started by @RainRat*