### PR TITLE
[FEAT] Git Revision Scanning Support

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1129,8 +1129,13 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
     return None
 
 
-def get_git_changed_files(path: str = ".") -> List[str]:
-    """Get a list of changed files (staged, unstaged, untracked) from git."""
+def get_git_changed_files(path: str = ".", ref: str = "HEAD") -> List[str]:
+    """Get a list of changed files (staged, unstaged, untracked) from git.
+
+    Args:
+        path: The directory or file path.
+        ref: The git revision to compare against. Defaults to "HEAD".
+    """
     toplevel, rel_target = _get_git_info(path)
     if toplevel is None:
         return []
@@ -1138,9 +1143,9 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     targets = [rel_target]
 
     files = set()
-    # Changed (staged and unstaged) relative to HEAD
+    # Changed relative to ref
     try:
-        cmd = ["git", "diff", "--name-only", "HEAD", "--"] + targets
+        cmd = ["git", "diff", "--name-only", ref, "--"] + targets
         output = subprocess.check_output(
             cmd,
             cwd=toplevel,
@@ -1151,24 +1156,30 @@ def get_git_changed_files(path: str = ".") -> List[str]:
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         pass
 
-    # Untracked files
-    try:
-        cmd = ["git", "ls-files", "--others", "--exclude-standard", "--"] + targets
-        output = subprocess.check_output(
-            cmd,
-            cwd=toplevel,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        )
-        files.update(line.strip() for line in output.splitlines() if line.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        pass
+    # Untracked files (only relevant when comparing against HEAD/working tree)
+    if ref == "HEAD":
+        try:
+            cmd = ["git", "ls-files", "--others", "--exclude-standard", "--"] + targets
+            output = subprocess.check_output(
+                cmd,
+                cwd=toplevel,
+                stderr=subprocess.PIPE,
+                universal_newlines=True
+            )
+            files.update(line.strip() for line in output.splitlines() if line.strip())
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            pass
 
     return [p for f in files if os.path.exists(p := os.path.join(toplevel, f))]
 
 
-def get_git_diff(path: str = ".") -> str:
-    """Get the current Git diff (staged and unstaged) as a string."""
+def get_git_diff(path: str = ".", ref: str = "HEAD") -> str:
+    """Get the Git diff as a string.
+
+    Args:
+        path: The directory or file path.
+        ref: The git revision to compare against. Defaults to "HEAD".
+    """
     toplevel, rel_target = _get_git_info(path)
     if toplevel is None:
         return ""
@@ -1176,8 +1187,8 @@ def get_git_diff(path: str = ".") -> str:
     targets = [rel_target] if rel_target != "." else []
 
     try:
-        # Get diff of staged and unstaged changes relative to HEAD
-        cmd = ["git", "diff", "HEAD", "--no-color", "--"] + targets
+        # Get diff relative to ref
+        cmd = ["git", "diff", ref, "--no-color", "--"] + targets
         output = subprocess.check_output(
             cmd,
             cwd=toplevel,
@@ -1677,6 +1688,33 @@ def scan_git_diff_click():
             messagebox.showinfo("Git Diff", "No Git changes detected (staged or unstaged) in the target path.")
     except Exception as e:
         messagebox.showwarning("Git Diff Error", f"Could not retrieve Git diff: {e}")
+
+
+def scan_git_revision_click():
+    """Scan files changed in a specific Git revision."""
+    try:
+        target_path = textbox.get().strip() if textbox else "."
+        if not target_path:
+            target_path = "."
+
+        toplevel, _ = _get_git_info(target_path)
+        if toplevel is None:
+            messagebox.showwarning("Git Error", "Target path is not part of a Git repository.")
+            return
+
+        ref = simpledialog.askstring("Scan Git Revision", "Enter a Git revision (e.g., main, HEAD~1, or a commit hash):")
+        if not ref:
+            return
+
+        changed_files = get_git_changed_files(target_path, ref=ref)
+        if changed_files:
+            # Update the textbox with the changed files list and trigger scan
+            _set_scan_target(changed_files)
+            button_click()
+        else:
+            messagebox.showinfo("Git Revision", f"No changed files found for revision '{ref}'.")
+    except Exception as e:
+        messagebox.showwarning("Git Revision Error", f"Could not scan Git revision: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5419,6 +5457,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
     browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click)
     browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click)
+    browse_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -5898,13 +5937,15 @@ def main():
     )
     scan_group.add_argument(
         '--git-changes',
-        action='store_true',
-        help='Only scan files that have changed in your Git project.'
+        nargs='?',
+        const='HEAD',
+        help='Only scan files changed in Git. Optionally provide a revision (e.g., "main").'
     )
     scan_group.add_argument(
         '--git-diff',
-        action='store_true',
-        help='Scan current Git changes (staged and unstaged).'
+        nargs='?',
+        const='HEAD',
+        help='Scan current Git changes as a diff. Optionally provide a revision (e.g., "HEAD~1").'
     )
     scan_group.add_argument(
         '--all-files',
@@ -6045,10 +6086,10 @@ def main():
             git_roots = scan_targets if scan_targets else ["."]
             git_files = []
             for root_dir in git_roots:
-                git_files.extend(get_git_changed_files(root_dir))
+                git_files.extend(get_git_changed_files(root_dir, ref=args.git_changes))
 
             if not git_files:
-                print("No git changes detected in provided targets.", file=sys.stderr)
+                print(f"No git changes detected in provided targets (ref: {args.git_changes}).", file=sys.stderr)
             # Scan only changed files
             scan_targets = git_files
 
@@ -6058,13 +6099,13 @@ def main():
             git_roots = scan_targets if scan_targets else ["."]
             diff_count = 0
             for root_dir in git_roots:
-                diff_content = get_git_diff(root_dir)
+                diff_content = get_git_diff(root_dir, ref=args.git_diff)
                 if diff_content:
                     extra_snippets.append((f"git-diff-{diff_count}.patch", diff_content.encode('utf-8')))
                     diff_count += 1
 
             if not extra_snippets:
-                print("No Git diff detected in provided targets.", file=sys.stderr)
+                print(f"No Git diff detected in provided targets (ref: {args.git_diff}).", file=sys.stderr)
 
         if not scan_targets and not args.git_changes and not args.git_diff:
             # Default to current directory if no targets provided and NOT using git-changes

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+import pytest
+from gptscan import get_git_changed_files, get_git_diff
+
+def test_get_git_changed_files_with_revision():
+    """Test that the revision argument is correctly passed to git diff."""
+    with patch("subprocess.check_output") as mock_check_output, \
+         patch("os.path.exists") as mock_exists:
+
+        # 1. rev-parse (to get toplevel)
+        # 2. git diff --name-only revision -- target
+        mock_check_output.side_effect = ["/repo", "file1.py\nfile2.py\n"]
+        mock_exists.return_value = True
+
+        revision = "main..feature"
+        files = get_git_changed_files("/repo/subdir", ref=revision)
+
+        # rev-parse
+        assert "rev-parse" in mock_check_output.call_args_list[0][0][0]
+
+        # git diff
+        args, kwargs = mock_check_output.call_args_list[1]
+        cmd = args[0]
+        assert cmd[0] == "git"
+        assert cmd[1] == "diff"
+        assert cmd[2] == "--name-only"
+        assert cmd[3] == revision
+
+        # ls-files should NOT be called when ref != "HEAD"
+        assert mock_check_output.call_count == 2
+        assert len(files) == 2
+
+def test_get_git_diff_with_revision():
+    """Test that get_git_diff correctly uses the revision argument."""
+    with patch("subprocess.check_output") as mock_check_output:
+        # 1. rev-parse
+        # 2. git diff revision
+        mock_check_output.side_effect = ["/repo", "diff content"]
+
+        revision = "HEAD~1"
+        diff = get_git_diff("/repo", ref=revision)
+
+        assert diff == "diff content"
+
+        # git diff
+        args, kwargs = mock_check_output.call_args_list[1]
+        cmd = args[0]
+        assert cmd[0] == "git"
+        assert cmd[1] == "diff"
+        assert cmd[2] == revision
+        assert "--no-color" in cmd
+
+def test_get_git_changed_files_default_head_includes_untracked():
+    """Verify that untracked files are still included by default (HEAD)."""
+    with patch("subprocess.check_output") as mock_check_output, \
+         patch("os.path.exists") as mock_exists:
+
+        # 1. rev-parse
+        # 2. git diff
+        # 3. git ls-files
+        mock_check_output.side_effect = ["/repo", "changed.py", "untracked.py"]
+        mock_exists.return_value = True
+
+        files = get_git_changed_files("/repo")
+
+        assert mock_check_output.call_count == 3
+        assert len(files) == 2
+        assert any("changed.py" in f for f in files)
+        assert any("untracked.py" in f for f in files)
+
+def test_get_git_changed_files_real_git_revision(tmp_path):
+    """Real git test for revision scanning."""
+    # Initialize repo
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "config", "user.name", "Your Name"], cwd=str(tmp_path), check=True)
+
+    # First commit
+    f1 = tmp_path / "file1.py"
+    f1.write_text("print('v1')")
+    subprocess.run(["git", "add", "file1.py"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=str(tmp_path), check=True)
+
+    # Second commit
+    f2 = tmp_path / "file2.py"
+    f2.write_text("print('v2')")
+    subprocess.run(["git", "add", "file2.py"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "commit", "-m", "second"], cwd=str(tmp_path), check=True)
+
+    # Scan difference between HEAD~1 and HEAD
+    results = get_git_changed_files(str(tmp_path), ref="HEAD~1..HEAD")
+
+    result_paths = [os.path.basename(r) for r in results]
+    assert "file2.py" in result_paths
+    assert "file1.py" not in result_paths


### PR DESCRIPTION
This PR introduces the ability to scan files changed in specific Git revisions, branches, or ranges.

Previously, the tool only supported scanning uncommitted changes (staged, unstaged, and untracked) in the working tree. With this change, users can now perform deep-dive scans on historical changes or specific feature branches.

### Technical Changes:
- **Core Logic:** `get_git_changed_files` and `get_git_diff` now support a `ref` argument. Untracked files are automatically included when scanning against `HEAD` but excluded for other revisions where they wouldn't logically exist.
- **CLI:** `--git-changes` and `--git-diff` now use `nargs='?'` and `const='HEAD'`, allowing them to remain backward-compatible while supporting an optional revision string (e.g., `python gptscan.py --git-changes main --cli`).
- **GUI:** Added a "Scan Git Revision..." menu item that prompts the user for a Git reference and automatically populates the scan targets.
- **Testing:** New tests in `tests/test_git_revision.py` cover both mock-based and real Git repository scenarios.

---
*PR created automatically by Jules for task [2081044897324505238](https://jules.google.com/task/2081044897324505238) started by @RainRat*