### PR TITLE
[TEST] Add SVG support and deep script extraction for web files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -352,7 +352,7 @@ class Config:
         # 2. Check by extension or basename
         path_s = str(file_path).lower()
         # Common archive and document extensions
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.yml', '.yaml',
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.svg', '.yml', '.yaml',
                             '.diff', '.patch')):
             return True
         # Explicit manifest files and build scripts (checked by basename)
@@ -2377,20 +2377,43 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Check for HTML script tags and other embedded elements
-    if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
+    # 6. Check for HTML/SVG script tags and other embedded elements
+    if check_name.lower().endswith(('.html', '.htm', '.xhtml', '.svg')):
         try:
             text = content.decode('utf-8', errors='ignore')
             extracted_any = False
-            
+
             # 1. Match <script> blocks (yield individually as they can be large)
             scripts = re.findall(r'<script\b[^>]*>(.*?)</script>', text, re.DOTALL | re.IGNORECASE)
             for i, script in enumerate(scripts, 1):
                 if script.strip():
                     yield (f"{name} [Script {i}]", script.encode('utf-8'))
                     extracted_any = True
-            
-            # 2. Match other embedded elements (bundle together as they are usually small)
+
+            # 2. Match event handlers (e.g., onclick, onload) and javascript: URLs
+            # Match attributes like onclick="..." or href='javascript:...'
+            # Group 1: attribute name, Group 2: quote, Group 3: value
+            attr_patterns = [
+                r'\s(on\w+)\s*=\s*(["\'])(.*?)\2',
+                r'\s(href|src)\s*=\s*(["\'])(javascript:.*?)\2'
+            ]
+
+            attr_snippets = []
+            for pattern in attr_patterns:
+                matches = re.findall(pattern, text, re.IGNORECASE | re.DOTALL)
+                for attr_name, quote, attr_value in matches:
+                    if attr_value.strip():
+                        # Unescape HTML entities in attribute values
+                        clean_value = html.unescape(attr_value.strip())
+                        if clean_value not in attr_snippets:
+                            attr_snippets.append(f"// {attr_name}\n{clean_value}")
+
+            if attr_snippets:
+                bundle = "\n\n".join(attr_snippets)
+                yield (f"{name} [Attributes]", bundle.encode('utf-8'))
+                extracted_any = True
+
+            # 3. Match other embedded elements (bundle together as they are usually small)
             embedded_patterns = [
                 r'<iframe\b[^>]*>.*?</iframe>',
                 r'<iframe\b[^>]*>',
@@ -2400,19 +2423,19 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 r'<applet\b[^>]*>.*?</applet>',
                 r'<applet\b[^>]*>'
             ]
-            
+
             embedded_elements = []
             for pattern in embedded_patterns:
                 matches = re.findall(pattern, text, re.DOTALL | re.IGNORECASE)
                 for match in matches:
                     if match.strip() and match not in embedded_elements:
                         embedded_elements.append(match.strip())
-            
+
             if embedded_elements:
                 bundle = "\n".join(embedded_elements)
                 yield (f"{name} [Embedded Elements]", bundle.encode('utf-8'))
                 extracted_any = True
-                
+
             if extracted_any:
                 return
         except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,8 @@ def reset_globals():
     gptscan._all_results_cache = []
     gptscan._model_cache = None
     gptscan._async_openai_client = None
+    gptscan._virtual_source_cache = {}
+    gptscan._last_scan_summary = ""
 
     # Save original Config state
     orig_exts = gptscan.Config.extensions_set.copy()

--- a/tests/test_html_extraction.py
+++ b/tests/test_html_extraction.py
@@ -91,7 +91,7 @@ def test_unpack_content_html_embedded_elements():
     assert len(snippets) == 2
     assert snippets[0][0] == "test.html [Script 1]"
     assert snippets[1][0] == "test.html [Embedded Elements]"
-    
+
     embedded_text = snippets[1][1].decode('utf-8')
     assert '<iframe src="http://malicious-iframe.com"></iframe>' in embedded_text
     assert '<object data="malicious.swf"></object>' in embedded_text
@@ -99,3 +99,26 @@ def test_unpack_content_html_embedded_elements():
     assert '<applet code="Malicious.class"></applet>' in embedded_text
     assert '<iframe src="no-closing-tag">' in embedded_text
 
+def test_unpack_content_html_attributes():
+    """Verify that event handlers and javascript: URLs are extracted from HTML."""
+    html_content = """
+    <body onload="alert(1)">
+        <div onclick="console.log('hit')"></div>
+        <a href="javascript:malicious()">Link</a>
+        <img src="javascript:evil()">
+    </body>
+    """
+    snippets = list(unpack_content("attr.html", html_content.encode('utf-8')))
+
+    # Should find Attributes
+    assert any(s[0] == "attr.html [Attributes]" for s in snippets)
+
+    attr_text = next(s[1].decode('utf-8') for s in snippets if s[0] == "attr.html [Attributes]")
+    assert "// onload" in attr_text
+    assert "alert(1)" in attr_text
+    assert "// onclick" in attr_text
+    assert "console.log('hit')" in attr_text
+    assert "// href" in attr_text
+    assert "javascript:malicious()" in attr_text
+    assert "// src" in attr_text
+    assert "javascript:evil()" in attr_text

--- a/tests/test_svg_scanning.py
+++ b/tests/test_svg_scanning.py
@@ -1,0 +1,59 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_is_container_svg():
+    """Verify that .svg files are recognized as containers."""
+    assert Config.is_container("test.svg") is True
+    assert Config.is_container("path/to/test.svg") is True
+
+def test_unpack_content_svg_extraction():
+    """Verify script and attribute extraction from SVG files."""
+    svg_content = """
+    <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+        <script>
+            alert('SVG Script');
+        </script>
+        <circle cx="50" cy="50" r="40" onclick="console.log('clicked')" onload="malicious()"/>
+        <a href="javascript:void(0)">
+            <rect width="10" height="10" />
+        </a>
+    </svg>
+    """
+    content_bytes = svg_content.encode('utf-8')
+    snippets = list(unpack_content("test.svg", content_bytes))
+
+    # Should find Script 1 and Attributes
+    assert len(snippets) == 2
+
+    names = [s[0] for s in snippets]
+    assert "test.svg [Script 1]" in names
+    assert "test.svg [Attributes]" in names
+
+    scripts = {s[0]: s[1].decode('utf-8') for s in snippets}
+
+    assert "alert('SVG Script');" in scripts["test.svg [Script 1]"]
+
+    attr_text = scripts["test.svg [Attributes]"]
+    assert "// onclick" in attr_text
+    assert "console.log('clicked')" in attr_text
+    assert "// onload" in attr_text
+    assert "malicious()" in attr_text
+    assert "// href" in attr_text
+    assert "javascript:void(0)" in attr_text
+
+def test_unpack_content_svg_entities():
+    """Verify that HTML entities in SVG attributes are unescaped."""
+    svg_content = '<circle onclick="alert(&quot;hit&quot;)"/>'
+    snippets = list(unpack_content("entities.svg", svg_content.encode('utf-8')))
+
+    assert len(snippets) == 1
+    assert 'alert("hit")' in snippets[0][1].decode('utf-8')
+
+def test_unpack_content_svg_no_scripts():
+    """Verify that SVG files with no scripts yield the original file as fallback."""
+    svg_content = '<svg><circle /></svg>'
+    content_bytes = svg_content.encode('utf-8')
+    snippets = list(unpack_content("noscripts.svg", content_bytes))
+
+    assert len(snippets) == 1
+    assert snippets[0] == ("noscripts.svg", content_bytes)


### PR DESCRIPTION
This PR enhances `gptscan` to recognize and deep-scan SVG files and improves script extraction from HTML/SVG attributes.

### Changes:
1.  **SVG Support**: Added `.svg` to `Config.is_container` and `unpack_content`, allowing the scanner to recursively unpack and inspect SVG files.
2.  **Deep Attribute Extraction**: Improved `unpack_content` to capture inline event handlers (e.g., `onclick`, `onload`, `onmouseover`) and `javascript:` URLs within `href` and `src` attributes.
3.  **Entity Unescaping**: Attribute values are now processed with `html.unescape` to ensure that dangerous code obfuscated using HTML entities (e.g., `&quot;`, `&#x...;`) is correctly identified.
4.  **New Tests**: 
    - Added `tests/test_svg_scanning.py` to verify SVG container detection and script/attribute extraction.
    - Updated `tests/test_html_extraction.py` with `test_unpack_content_html_attributes` to cover new extraction logic.
5.  **Test Hygiene**: Resolved a state leakage issue in `tests/conftest.py` that caused `tests/test_view_details.py::test_toggle_source_virtual_file` to fail when run as part of the full suite.

These improvements significantly close a gap in the scanner's ability to detect cross-site scripting (XSS) and other web-based attack vectors.

---
*PR created automatically by Jules for task [9219175307306036949](https://jules.google.com/task/9219175307306036949) started by @RainRat*