### PR TITLE
[UI/UX] Enhance Browse menu with keyboard shortcuts and discoverability

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5402,7 +5402,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (File, Folder, URL, File List, or Clipboard).")
+    bind_hover_message(browse_button, "Browse for scan targets (File, Folder, URL, File List, Clipboard, or Git Diff). Shortcuts: Ctrl+Shift+O/U/V/D.")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5413,12 +5413,12 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     bind_hover_message(cancel_button, "Stop the current scan. (Esc)")
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
-    browse_menu.add_command(label="Select File(s)...", command=browse_file_click)
+    browse_menu.add_command(label="Select File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")
     browse_menu.add_command(label="Select Folder...", command=browse_dir_click)
-    browse_menu.add_command(label="Scan URL...", command=select_url_click)
+    browse_menu.add_command(label="Scan URL...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
-    browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click)
-    browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click)
+    browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click, accelerator="Ctrl+Shift+V")
+    browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -5805,6 +5805,14 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-j>', copy_as_json)
     root.bind('<Control-g>', analyze_selected_with_ai)
     root.bind('<Command-g>', analyze_selected_with_ai)
+    root.bind('<Control-Shift-O>', lambda e: browse_file_click())
+    root.bind('<Command-Shift-O>', lambda e: browse_file_click())
+    root.bind('<Control-Shift-U>', lambda e: select_url_click())
+    root.bind('<Command-Shift-U>', lambda e: select_url_click())
+    root.bind('<Control-Shift-V>', lambda e: scan_clipboard_click())
+    root.bind('<Command-Shift-V>', lambda e: scan_clipboard_click())
+    root.bind('<Control-Shift-D>', lambda e: scan_git_diff_click())
+    root.bind('<Command-Shift-D>', lambda e: scan_git_diff_click())
     tree.bind('<<TreeviewSelect>>', update_button_states)
     tree.bind('<Control-a>', select_all_items)
     tree.bind('<Command-a>', select_all_items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,8 @@ def reset_globals():
     import gptscan
     gptscan.current_cancel_event = None
     gptscan._all_results_cache = []
+    gptscan._virtual_source_cache = {}
+    gptscan._last_scan_summary = ""
     gptscan._model_cache = None
     gptscan._async_openai_client = None
 


### PR DESCRIPTION
### Context
GUI

### Problem
Common scanning actions in the "Browse" menu (Files, URL, Clipboard, Git Diff) required multiple clicks and lacked keyboard shortcuts, creating friction for power users and slowing down the workflow.

### Solution
- Added keyboard accelerators to the "Browse" menu items for better discoverability.
- Implemented global root window bindings for `Ctrl+Shift+O` (Files), `Ctrl+Shift+U` (URL), `Ctrl+Shift+V` (Clipboard), and `Ctrl+Shift+D` (Git Diff), supporting both Linux/Windows and macOS modifiers.
- Updated the "Browse" button's hover message to document these new shortcuts and include "Git Diff" in the list of targets.
- Resolved a test isolation issue by ensuring `_virtual_source_cache` and `_last_scan_summary` are reset between unit tests in `tests/conftest.py`.

### Changes
- Modified `gptscan.py` to add menu accelerators and root level key event bindings.
- Updated `tests/conftest.py` to fix cross-test state leakage.

---
*PR created automatically by Jules for task [2632725481316985685](https://jules.google.com/task/2632725481316985685) started by @RainRat*