### PR TITLE
Improve alias fallback in standardize_result_dict

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3914,7 +3914,7 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
         return {k: "" for k in REPORT_FIELD_MAPPING}
 
     res = {
-        key: next((str(item[alt]) if item[alt] is not None else "" for alt in alts if alt in item), "")
+        key: next((str(item[alt]) for alt in alts if item.get(alt) not in (None, "")), "")
         for key, alts in REPORT_FIELD_MAPPING.items()
     }
     # Fallback: if own_conf is empty but gpt_conf has a value, they might be using a report

--- a/tests/test_standardize_fallback.py
+++ b/tests/test_standardize_fallback.py
@@ -1,0 +1,48 @@
+import pytest
+from gptscan import standardize_result_dict
+
+def test_standardize_result_dict_fallback_on_empty_string():
+    """
+    Test that standardize_result_dict correctly falls back to other aliases
+    if a primary alias exists but contains an empty string.
+    """
+    # 'path' is primary, 'File Path' is an alias.
+    # In the current buggy implementation, if 'path' is "", it returns "",
+    # instead of checking 'File Path'.
+    item = {
+        "path": "",
+        "File Path": "actual/path/to/file.py",
+        "Local Threat": "80%"
+    }
+
+    result = standardize_result_dict(item)
+
+    # This is expected to FAIL before the fix
+    assert result["path"] == "actual/path/to/file.py"
+    assert result["own_conf"] == "80%"
+
+def test_standardize_result_dict_fallback_on_none():
+    """
+    Test that it also handles None correctly.
+    """
+    item = {
+        "path": None,
+        "File Path": "actual/path/to/file.py"
+    }
+
+    result = standardize_result_dict(item)
+
+    # This currently passes because of 'if item[alt] is not None'
+    assert result["path"] == "actual/path/to/file.py"
+
+def test_standardize_result_dict_all_empty():
+    """
+    Test when all matching keys are empty.
+    """
+    item = {
+        "path": "",
+        "File Path": ""
+    }
+
+    result = standardize_result_dict(item)
+    assert result["path"] == ""


### PR DESCRIPTION
Improved the `standardize_result_dict` function to correctly handle empty string values for primary keys by falling back to alternative aliases. Previously, if a key like `path` existed in the input but was empty, the function would return an empty string instead of checking alternative aliases like `File Path` or `uri`. 

Key changes:
- Updated the dictionary comprehension in `standardize_result_dict` to skip aliases with `None` or `""` values.
- Added `tests/test_standardize_fallback.py` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [2450932659419642887](https://jules.google.com/task/2450932659419642887) started by @RainRat*