### PR TITLE
[TEST] [FEAT] Add SVG support and deep HTML attribute script extraction

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -352,7 +352,7 @@ class Config:
         # 2. Check by extension or basename
         path_s = str(file_path).lower()
         # Common archive and document extensions
-        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.yml', '.yaml',
+        if path_s.endswith(('.zip', '.tar', '.tar.gz', '.ipynb', '.md', '.html', '.htm', '.xhtml', '.svg', '.yml', '.yaml',
                             '.diff', '.patch')):
             return True
         # Explicit manifest files and build scripts (checked by basename)
@@ -2377,19 +2377,19 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 6. Check for HTML script tags and other embedded elements
-    if check_name.lower().endswith(('.html', '.htm', '.xhtml')):
+    # 6. Check for HTML/SVG script tags and other embedded elements
+    if check_name.lower().endswith(('.html', '.htm', '.xhtml', '.svg')):
         try:
             text = content.decode('utf-8', errors='ignore')
             extracted_any = False
-            
+
             # 1. Match <script> blocks (yield individually as they can be large)
             scripts = re.findall(r'<script\b[^>]*>(.*?)</script>', text, re.DOTALL | re.IGNORECASE)
             for i, script in enumerate(scripts, 1):
                 if script.strip():
                     yield (f"{name} [Script {i}]", script.encode('utf-8'))
                     extracted_any = True
-            
+
             # 2. Match other embedded elements (bundle together as they are usually small)
             embedded_patterns = [
                 r'<iframe\b[^>]*>.*?</iframe>',
@@ -2400,19 +2400,42 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 r'<applet\b[^>]*>.*?</applet>',
                 r'<applet\b[^>]*>'
             ]
-            
+
             embedded_elements = []
             for pattern in embedded_patterns:
                 matches = re.findall(pattern, text, re.DOTALL | re.IGNORECASE)
                 for match in matches:
                     if match.strip() and match not in embedded_elements:
                         embedded_elements.append(match.strip())
-            
+
             if embedded_elements:
                 bundle = "\n".join(embedded_elements)
                 yield (f"{name} [Embedded Elements]", bundle.encode('utf-8'))
                 extracted_any = True
-                
+
+            # 3. Match inline event handlers and javascript: URLs in attributes
+            # Matches on...="script", on...='script', or on...=script (unquoted)
+            # Also handles leading whitespace in javascript: URLs
+            attr_patterns = [
+                (r'\s+(on[a-z]+)\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)', True),
+                (r'\s+(?:href|src)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|\s*javascript:[^\s>]+)', False)
+            ]
+            extracted_attrs = []
+            for pattern, has_name_group in attr_patterns:
+                matches = re.findall(pattern, text, re.IGNORECASE)
+                for match in matches:
+                    val = match[1] if has_name_group else match
+                    script = val.strip('"\'').strip()
+                    if script:
+                        unescaped = html.unescape(script)
+                        if unescaped not in extracted_attrs:
+                            extracted_attrs.append(unescaped)
+
+            if extracted_attrs:
+                bundle = "\n".join(extracted_attrs)
+                yield (f"{name} [Attributes]", bundle.encode('utf-8'))
+                extracted_any = True
+
             if extracted_any:
                 return
         except Exception:

--- a/tests/test_html_deep_scan.py
+++ b/tests/test_html_deep_scan.py
@@ -1,0 +1,78 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_unpack_content_html_attribute_extraction():
+    """Verify that inline event handlers and javascript: URLs are extracted from HTML."""
+    html_content = """
+    <html>
+        <body>
+            <button onclick="alert('clicked')">Click me</button>
+            <img src="valid.png" onerror="eval(atob('bWFsY29kZSgp'))">
+            <a href="javascript:console.log('link')">Link</a>
+            <div onmouseover=" malicious_code() ">Hover</div>
+            <a href='javascript:alert("single quotes")'>Single</a>
+        </body>
+    </html>
+    """
+    content_bytes = html_content.encode('utf-8')
+    snippets = list(unpack_content("test.html", content_bytes))
+
+    # Currently this will fail as these are not extracted yet
+    # After implementation, we expect an [Attributes] snippet
+    attr_snippets = [s for s in snippets if "[Attributes]" in s[0]]
+    assert len(attr_snippets) == 1
+
+    attr_text = attr_snippets[0][1].decode('utf-8')
+    assert "alert('clicked')" in attr_text
+    assert "eval(atob('bWFsY29kZSgp'))" in attr_text
+    assert "console.log('link')" in attr_text
+    assert "malicious_code()" in attr_text
+    assert 'alert("single quotes")' in attr_text
+
+def test_unpack_content_html_attribute_extraction_unquoted():
+    """Verify that unquoted attributes and leading spaces in javascript: URLs are handled."""
+    html_content = """
+    <html>
+        <body>
+            <button onclick=alert(1)>Click</button>
+            <a href="  javascript:alert(2)">Space</a>
+            <a href=javascript:alert(3)>Unquoted JS</a>
+        </body>
+    </html>
+    """
+    snippets = list(unpack_content("test.html", html_content.encode('utf-8')))
+    attr_text = [s for s in snippets if "[Attributes]" in s[0]][0][1].decode('utf-8')
+    assert "alert(1)" in attr_text
+    assert "javascript:alert(2)" in attr_text
+    assert "javascript:alert(3)" in attr_text
+
+def test_unpack_content_svg_extraction():
+    """Verify that SVG files are treated as containers and scanned for scripts."""
+    svg_content = """
+    <svg xmlns="http://www.w3.org/2000/svg">
+        <script>alert('svg script')</script>
+        <circle cx="50" cy="50" r="40" onclick="svg_evil()"/>
+    </svg>
+    """
+    content_bytes = svg_content.encode('utf-8')
+
+    # SVG must be in Config.is_container for this to work
+    snippets = list(unpack_content("test.svg", content_bytes))
+
+    assert any("[Script 1]" in s[0] for s in snippets)
+    assert any("[Attributes]" in s[0] for s in snippets)
+
+    script_snippet = [s for s in snippets if "[Script 1]" in s[0]][0][1].decode('utf-8')
+    attr_snippet = [s for s in snippets if "[Attributes]" in s[0]][0][1].decode('utf-8')
+
+    assert "alert('svg script')" in script_snippet
+    assert "svg_evil()" in attr_snippet
+
+def test_html_unescape_in_attributes():
+    """Verify that HTML entities in attributes are unescaped before scanning."""
+    html_content = '<button onclick="alert(&quot;hello&quot;)">Click</button>'
+    content_bytes = html_content.encode('utf-8')
+    snippets = list(unpack_content("test.html", content_bytes))
+
+    attr_snippet = [s for s in snippets if "[Attributes]" in s[0]][0][1].decode('utf-8')
+    assert 'alert("hello")' in attr_snippet


### PR DESCRIPTION
This PR addresses a gap in the current scanning logic where malicious code hidden in HTML/SVG attributes (like event handlers or `javascript:` links) was not being extracted and analyzed. It also adds first-class support for SVG files as containers, allowing the scanner to look inside them for `<script>` tags and dangerous attributes.

Key changes:
- Updated `Config.is_container` to include `.svg` files.
- Modified `unpack_content` to extract scripts from event handlers (`on*`) and `javascript:` URLs in `href`/`src` attributes.
- The extraction logic handles quoted and unquoted attributes, leading whitespace in URLs, and unescapes HTML entities.
- Added comprehensive unit tests in `tests/test_html_deep_scan.py`.

---
*PR created automatically by Jules for task [8674848995476849419](https://jules.google.com/task/8674848995476849419) started by @RainRat*