### PR TITLE
[TEST] Fix threshold fallback bug and add regression test

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2908,7 +2908,7 @@ def scan_files(
     if fail_threshold is not None:
         threshold_val = min(threshold_val, fail_threshold / 100.0)
 
-    def handle_scan_result(path: str, maxconf: float, max_window_bytes: bytes, line_num: Union[int, str], full_content: Optional[str] = None) -> Generator[Tuple[str, Any], None, None]:
+    def handle_scan_result(path: str, maxconf: float, max_window_bytes: bytes, line_num: Union[int, str], full_content: Optional[str] = None, force: bool = False) -> Generator[Tuple[str, Any], None, None]:
         if maxconf >= 0:
             percent = f"{maxconf:.0%}"
             snippet = ''.join(map(chr, max_window_bytes)).strip()
@@ -2928,7 +2928,7 @@ def scan_files(
                         "full_content": full_content,
                     }
                 )
-            elif maxconf >= threshold_val or show_all:
+            elif maxconf >= threshold_val or show_all or force:
                 yield (
                     'result',
                     (
@@ -3056,7 +3056,7 @@ def scan_files(
                             line_num = f.read(max_offset).count(b'\n') + 1
                     except Exception:
                         pass
-                    yield from handle_scan_result(str(file_path), maxconf, max_window_bytes, line_num)
+                    yield from handle_scan_result(str(file_path), maxconf, max_window_bytes, line_num, force=True)
 
     for name, content in extra_snippets:
         if cancel_event.is_set():
@@ -3106,7 +3106,7 @@ def scan_files(
             if hits_found == 0:
                 # Calculate line number for best hit
                 line_num = content[:max_offset].count(b'\n') + 1
-                yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content)
+                yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content, force=True)
 
     if cancel_event.is_set():
         return

--- a/tests/test_repro_threshold_fallback.py
+++ b/tests/test_repro_threshold_fallback.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+import gptscan
+
+@pytest.fixture
+def mock_scan_dependencies(monkeypatch):
+    """Mocks TensorFlow, Model, and file system for scan_files tests."""
+    mock_predict = MagicMock(return_value=[[0.1]]) # 10% threat
+    mock_model = SimpleNamespace(predict=mock_predict)
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+    mock_tf = SimpleNamespace(
+        constant=lambda x: x,
+        expand_dims=lambda x, axis: x,
+    )
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+    return mock_predict
+
+def test_scan_files_fallback_when_below_threshold(monkeypatch, tmp_path, mock_scan_dependencies):
+    """
+    Verify that if no segments exceed the threshold, it still falls back to the best hit
+    even if show_all is False (as per documentation).
+    """
+    test_file = tmp_path / "below_threshold.py"
+    test_file.write_bytes(b"print('hello')")
+
+    monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan.Config, "THRESHOLD", 50)
+
+    # Run scan with show_all=False
+    results = list(gptscan.scan_files(
+        scan_targets=str(tmp_path),
+        deep_scan=False,
+        show_all=False,
+        use_gpt=False
+    ))
+
+    result_events = [r for r in results if r[0] == 'result']
+
+    # This is EXPECTED TO FAIL currently (len will be 0)
+    assert len(result_events) == 1, "Should yield the best hit even if below threshold when show_all is False"
+    assert result_events[0][1][1] == "10%"


### PR DESCRIPTION
Fixed a logic bug in `gptscan.py` where the "best hit" fallback was suppressed by the threshold check. I introduced a `force` parameter to the `handle_scan_result` helper function to allow the scanner to yield the single most suspicious result even if it doesn't meet the primary threshold, as intended by the design. A new test case `tests/test_repro_threshold_fallback.py` was added to ensure this behavior is maintained.

---
*PR created automatically by Jules for task [2501086888678296388](https://jules.google.com/task/2501086888678296388) started by @RainRat*