### PR TITLE
[UI/UX] Consolidate scan options and declutter filter bar

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5538,7 +5538,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     settings_frame.grid(row=1, column=0, sticky="ew", padx=10, pady=5)
 
     # --- Options Frame ---
-    options_frame = ttk.LabelFrame(settings_frame, text="Scan Options", padding=10)
+    options_frame = ttk.LabelFrame(settings_frame, text="Options", padding=10)
     options_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=False, padx=(0, 5))
 
     gpt_var = tk.BooleanVar(value=Config.use_ai_analysis)
@@ -5583,13 +5583,35 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     max_size_spin.bind('<KeyRelease>', lambda e: on_max_size_change())
     bind_hover_message(max_size_spin, "Skip files larger than this size (in Megabytes).")
 
+    threshold_row = ttk.Frame(options_frame)
+    threshold_row.grid(row=3, column=0, columnspan=2, sticky='w', padx=10, pady=2)
+
+    def on_threshold_change():
+        try:
+            val = int(threshold_spin.get())
+            Config.THRESHOLD = max(0, min(100, val))
+            _apply_filter()
+        except ValueError:
+            pass
+
+    ttk.Label(threshold_row, text="Min. Threat Level:").pack(side=tk.LEFT)
+    threshold_spin = ttk.Spinbox(threshold_row, from_=0, to=100, width=5, command=on_threshold_change)
+    threshold_spin.delete(0, tk.END)
+    threshold_spin.insert(0, str(Config.THRESHOLD))
+    threshold_spin.pack(side=tk.LEFT, padx=5)
+    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
+    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
+
+    all_checkbox = ttk.Checkbutton(threshold_row, text="Show all results", variable=all_var, command=_apply_filter)
+    all_checkbox.pack(side=tk.LEFT, padx=(10, 0))
+    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Provider Frame ---
     provider_frame = ttk.LabelFrame(settings_frame, text="AI Analysis", padding=10)
     provider_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5)
 
     copy_cmd_button = ttk.Button(options_frame, text="Copy CLI Command", command=copy_cli_command)
-    copy_cmd_button.grid(row=3, column=0, columnspan=2, sticky='ew', padx=10, pady=(5, 0), ipady=5)
+    copy_cmd_button.grid(row=4, column=0, columnspan=2, sticky='ew', padx=10, pady=(5, 0), ipady=5)
     bind_hover_message(copy_cmd_button, "Copy the current scan settings as a CLI command for use in scripts or automation.")
 
     provider_frame.columnconfigure(1, weight=1)
@@ -5725,33 +5747,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         _apply_filter()
 
     clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
-    clear_filter_btn.grid(row=0, column=2, padx=(5, 5), ipady=5)
+    clear_filter_btn.grid(row=0, column=2, padx=(5, 0), ipady=5)
     bind_hover_message(clear_filter_btn, "Clear the filter.")
-
-    ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)
-
-    def on_threshold_change():
-        try:
-            val = int(threshold_spin.get())
-            Config.THRESHOLD = max(0, min(100, val))
-            _apply_filter()
-        except ValueError:
-            pass
-
-    threshold_frame = ttk.Frame(filter_frame)
-    threshold_frame.grid(row=0, column=4, sticky='w')
-
-    ttk.Label(threshold_frame, text="Min. Threat Level:").pack(side=tk.LEFT)
-    threshold_spin = ttk.Spinbox(threshold_frame, from_=0, to=100, width=5, command=on_threshold_change)
-    threshold_spin.delete(0, tk.END)
-    threshold_spin.insert(0, str(Config.THRESHOLD))
-    threshold_spin.pack(side=tk.LEFT, padx=5)
-    threshold_spin.bind('<KeyRelease>', lambda e: on_threshold_change())
-    bind_hover_message(threshold_spin, "Files with a threat level lower than this will be ignored.")
-
-    all_checkbox = ttk.Checkbutton(threshold_frame, text="Show all files", variable=all_var, command=_apply_filter)
-    all_checkbox.pack(side=tk.LEFT, padx=(5, 0))
-    bind_hover_message(all_checkbox, "Display all scanned files, including safe ones.")
 
     # --- Treeview ---
     style.configure('Scanner.Treeview', rowheight=50)


### PR DESCRIPTION
This improvement consolidates the scanner's configuration settings by moving the threat threshold and display toggles from the filter bar to the main Options panel. This grouping improves visual hierarchy by separating "how to scan" (Options) from "how to view" (Filter/Search), while decluttering the bottom of the window to provide more space for the search interface. Terminology was also refined to be more consistent with the application's reporting features.

---
*PR created automatically by Jules for task [10651301655532018206](https://jules.google.com/task/10651301655532018206) started by @RainRat*