### PR TITLE
Exclude skipped large files from total bytes scanned metric

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2974,9 +2974,6 @@ def scan_files(
                     )
                 )
 
-        if file_size is not None:
-            total_bytes_scanned += file_size
-
         # Check file size limit (skip if not explicitly requested)
         if not is_explicit and file_size is not None and file_size > Config.MAX_FILE_SIZE:
             yield (
@@ -2992,6 +2989,9 @@ def scan_files(
                 )
             )
             continue
+
+        if file_size is not None:
+            total_bytes_scanned += file_size
 
         if dry_run:
             yield (

--- a/tests/test_repro_scan_summary_large_file.py
+++ b/tests/test_repro_scan_summary_large_file.py
@@ -1,0 +1,51 @@
+
+import pytest
+import os
+from pathlib import Path
+from gptscan import scan_files, Config
+
+def test_total_bytes_scanned_skips_large_files(tmp_path):
+    # Setup: Create a large file and a small file
+    # Ensure Config.MAX_FILE_SIZE is set to a known small value for the test
+    original_max_size = Config.MAX_FILE_SIZE
+    Config.MAX_FILE_SIZE = 100  # 100 bytes
+
+    try:
+        large_file = tmp_path / "large.py"
+        large_content = b"P" * 200
+        large_file.write_bytes(large_content)
+
+        small_file = tmp_path / "small.py"
+        small_content = b"print('hello')"
+        small_file.write_bytes(small_content)
+
+        # Run scan_files
+        # We need to pass targets as a list of strings
+        gen = scan_files([str(tmp_path)], deep_scan=False, show_all=True, use_gpt=False)
+
+        summary = None
+        results = []
+        for event_type, data in gen:
+            if event_type == 'result':
+                results.append(data)
+            elif event_type == 'summary':
+                summary = data
+
+        assert summary is not None
+        total_scanned, total_bytes, _ = summary
+
+        # Verify that large.py was skipped
+        large_results = [r for r in results if "large.py" in r[0]]
+        assert len(large_results) > 0
+        assert any("Large File" in str(r[1]) for r in large_results)
+
+        # The bug: total_bytes currently includes large_content size
+        # Correct behavior: total_bytes should only include small_content size
+        print(f"Total bytes reported: {total_bytes}")
+        print(f"Small file size: {len(small_content)}")
+        print(f"Large file size: {len(large_content)}")
+
+        assert total_bytes == len(small_content)
+
+    finally:
+        Config.MAX_FILE_SIZE = original_max_size


### PR DESCRIPTION
This PR fixes a logic bug in the `scan_files` function where the total bytes scanned metric incorrectly included files that were skipped because they exceeded the maximum file size limit.

Technical details:
- Relocated `total_bytes_scanned += file_size` in the local files loop to occur after the `MAX_FILE_SIZE` check.
- Placed the increment before the `dry_run` check to ensure dry runs still report the volume of data they would have processed.
- Verified that the fix correctly reports bytes for scanned files while excluding skipped large files.
- Added a new test `tests/test_repro_scan_summary_large_file.py` to verify the fix and prevent regressions.
- All 688 existing tests passed.

---
*PR created automatically by Jules for task [7853611758173062863](https://jules.google.com/task/7853611758173062863) started by @RainRat*