### PR TITLE
Remove duplicate global variable resets in tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,6 @@ def reset_globals():
     gptscan._virtual_source_cache = {}
     gptscan._model_cache = None
     gptscan._async_openai_client = None
-    gptscan._virtual_source_cache = {}
-    gptscan._last_scan_summary = ""
 
     # Save original Config state
     orig_exts = gptscan.Config.extensions_set.copy()


### PR DESCRIPTION
* **What:** Removed redundant assignments of `gptscan._virtual_source_cache` and `gptscan._last_scan_summary` within the `reset_globals` fixture in `tests/conftest.py`.
* **Why:** This cleanup removes unnecessary duplication in the test setup logic, improving code quality without changing the behavior of the test suite. Verification confirms that all intended global variables are still correctly reset between tests.

---
*PR created automatically by Jules for task [3213133182945307108](https://jules.google.com/task/3213133182945307108) started by @RainRat*