### PR TITLE
[TEST] Fix scan summary metrics accuracy for skipped large files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2955,7 +2955,6 @@ def scan_files(
         yield ('progress', (progress_count, total_progress, f"Scanning: {file_path.name}"))
 
         is_explicit = file_path in explicit_files
-        actual_files_scanned += 1
         try:
             file_size = file_path.stat().st_size
         except OSError as err:
@@ -2974,9 +2973,6 @@ def scan_files(
                     )
                 )
 
-        if file_size is not None:
-            total_bytes_scanned += file_size
-
         # Check file size limit (skip if not explicitly requested)
         if not is_explicit and file_size is not None and file_size > Config.MAX_FILE_SIZE:
             yield (
@@ -2992,6 +2988,10 @@ def scan_files(
                 )
             )
             continue
+
+        actual_files_scanned += 1
+        if file_size is not None:
+            total_bytes_scanned += file_size
 
         if dry_run:
             yield (

--- a/tests/test_repro_scan_summary_large_file.py
+++ b/tests/test_repro_scan_summary_large_file.py
@@ -1,0 +1,49 @@
+import pytest
+from pathlib import Path
+import gptscan
+
+def test_scan_summary_excludes_skipped_large_files(tmp_path, monkeypatch):
+    """Verify that files skipped due to size limits are not counted in the final summary."""
+    target_dir = tmp_path / "test_summary"
+    target_dir.mkdir()
+
+    # Create a small file (should be scanned)
+    small_file = target_dir / "small.py"
+    small_file.write_text("print('small')")
+    small_size = small_file.stat().st_size
+
+    # Create a large file (should be skipped)
+    large_file = target_dir / "large.py"
+    large_file.write_text("print('large')" * 1000)
+
+    # Set limit to be between small and large file sizes
+    monkeypatch.setattr(gptscan.Config, 'MAX_FILE_SIZE', 100)
+
+    # Scan the directory (so files are not explicit)
+    # We must mock get_model and _tf_module to avoid loading the actual model
+    from unittest.mock import MagicMock
+    monkeypatch.setattr(gptscan, 'get_model', lambda: MagicMock())
+    monkeypatch.setattr(gptscan, '_tf_module', MagicMock())
+
+    gen = gptscan.scan_files([str(target_dir)], deep_scan=False, show_all=True, use_gpt=False)
+
+    summary = None
+    results = []
+    for event_type, data in gen:
+        if event_type == 'result':
+            results.append(data)
+        elif event_type == 'summary':
+            summary = data
+
+    # results[0] should be the Large File result indicating it was skipped
+    # results[1] should be the small.py result
+
+    assert any(r[0] == str(large_file) and r[1] == 'Large File' for r in results)
+    assert any(r[0] == str(small_file) for r in results)
+
+    assert summary is not None
+    total_files, total_bytes, elapsed_time = summary
+
+    # ONLY small_file should be counted
+    assert total_files == 1
+    assert total_bytes == small_size


### PR DESCRIPTION
* **Type:** Bug Fix / New Coverage 
* **What:** Updated `scan_files` in `gptscan.py` to increment `actual_files_scanned` and `total_bytes_scanned` only after the `MAX_FILE_SIZE` check. Added `tests/test_repro_scan_summary_large_file.py` to verify this behavior. 
* **Why:** Previously, the scan summary included the count and size of files that were skipped due to size limits, leading to inaccurate throughput metrics and misleading file counts in the final report.

---
*PR created automatically by Jules for task [12566844744762077249](https://jules.google.com/task/12566844744762077249) started by @RainRat*