### PR TITLE
Refactor VirusTotal URL generation in check_virustotal

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5204,27 +5204,22 @@ def check_virustotal(event_or_path: Union[tk.Event, str, None] = None) -> None:
 
     found_any = False
     for file_path, snippet in targets:
-        h = None
-        if file_path.startswith("["):
-            if snippet is None:
-                # Try to find it in the tree if snippet wasn't provided (explicit path case)
-                for item_id in tree.get_children():
-                    vals = _get_item_raw_values(item_id)
-                    if vals and vals[0] == file_path:
-                        snippet = str(vals[5])
-                        break
-            
-            if snippet:
-                h = get_file_sha256(snippet.encode('utf-8'))
-        else:
-            if os.path.exists(file_path):
-                h = get_file_sha256(file_path)
-            elif isinstance(event_or_path, str):
+        if file_path.startswith("[") and snippet is None:
+            # Try to find it in the tree if snippet wasn't provided (explicit path case)
+            for item_id in tree.get_children():
+                vals = _get_item_raw_values(item_id)
+                if vals and vals[0] == file_path:
+                    snippet = str(vals[5])
+                    break
+
+        if not file_path.startswith("[") and not os.path.exists(file_path):
+            if isinstance(event_or_path, str):
                 messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
                 return
+            continue
 
-        if h:
-            url = f"https://www.virustotal.com/gui/file/{h}"
+        url = get_virustotal_url(file_path, snippet)
+        if url:
             webbrowser.open(url)
             found_any = True
 


### PR DESCRIPTION
The `check_virustotal` function contained redundant logic for calculating SHA256 hashes and formatting VirusTotal URLs, which was already implemented in the `get_virustotal_url` helper.

This PR refactors `check_virustotal` to utilize `get_virustotal_url`, improving maintainability and ensuring consistent behavior for both local and virtual (e.g., clipboard, stdin) scan targets. The refactor also simplifies the internal loop by flattening conditional checks and explicitly handling snippet resolution for virtual paths from the results tree when necessary.

No breaking changes were introduced; external behavior remains identical, and all existing tests pass.

---
*PR created automatically by Jules for task [10004097998728976250](https://jules.google.com/task/10004097998728976250) started by @RainRat*