### PR TITLE
[FEAT] Add 'Scan System PATH' functionality

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1051,6 +1051,26 @@ def get_shell_history_paths() -> List[str]:
     return paths
 
 
+def get_system_path_directories() -> List[str]:
+    """Identify all directories listed in the system's PATH environment variable."""
+    path_env = os.environ.get("PATH", "")
+    if not path_env:
+        return []
+
+    # Split and filter out empty strings and non-existent directories
+    dirs = []
+    seen = set()
+    for p in path_env.split(os.pathsep):
+        if not p:
+            continue
+        abs_p = os.path.abspath(p)
+        if abs_p not in seen and os.path.isdir(abs_p):
+            dirs.append(abs_p)
+            seen.add(abs_p)
+
+    return dirs
+
+
 def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the Git toplevel directory and the relative path of the target."""
     abs_path = os.path.abspath(path)
@@ -1789,6 +1809,19 @@ def scan_shell_history_click():
             messagebox.showinfo("Shell History", "No common shell history files were found on this system.")
     except Exception as e:
         messagebox.showwarning("Shell History Error", f"Could not scan shell history: {e}")
+
+
+def scan_system_path_click():
+    """Scan all directories in the system's PATH environment variable."""
+    try:
+        path_dirs = get_system_path_directories()
+        if path_dirs:
+            _set_scan_target(path_dirs)
+            button_click()
+        else:
+            messagebox.showinfo("System PATH", "No valid directories found in the system PATH.")
+    except Exception as e:
+        messagebox.showwarning("System PATH Error", f"Could not scan system PATH: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5618,7 +5651,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5639,6 +5672,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     browse_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
     browse_menu.add_command(label="Scan Shell History", command=scan_shell_history_click, accelerator="Ctrl+Shift+H")
+    browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -6016,6 +6050,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-D>', lambda event: scan_git_diff_click())
     root.bind('<Control-Shift-H>', lambda event: scan_shell_history_click())
     root.bind('<Command-Shift-H>', lambda event: scan_shell_history_click())
+    root.bind('<Control-Shift-P>', lambda event: scan_system_path_click())
+    root.bind('<Command-Shift-P>', lambda event: scan_system_path_click())
     root.bind('<Control-e>', export_results)
     root.bind('<Command-e>', export_results)
     root.bind('<Control-t>', check_virustotal)
@@ -6160,6 +6196,11 @@ def main():
         '--shell-history',
         action='store_true',
         help='Scan common shell history files.'
+    )
+    scan_group.add_argument(
+        '--system-path',
+        action='store_true',
+        help='Scan all directories in the system PATH.'
     )
     scan_group.add_argument(
         '--import-results', '--import',
@@ -6348,6 +6389,13 @@ def main():
                 scan_targets.extend(history_paths)
             else:
                 print("No common shell history files were found on this system.", file=sys.stderr)
+
+        if args.system_path:
+            path_dirs = get_system_path_directories()
+            if path_dirs:
+                scan_targets.extend(path_dirs)
+            else:
+                print("No valid directories found in the system PATH.", file=sys.stderr)
 
         threats = run_cli(
             scan_targets,

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Diff:** Scan changes in your local project.
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for malicious one-liners.
+*   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 
 ### Using the Terminal (CLI)
 To run the scanner in your terminal, use the `--cli` flag:
@@ -67,6 +68,12 @@ To scan your shell history from the terminal:
 ```bash
 python3 gptscan.py --shell-history --cli
 ```
+
+To scan all directories in your system PATH:
+```bash
+python3 gptscan.py --system-path --cli
+```
+
 You can also scan multiple files, folders, or web links:
 ```bash
 python3 gptscan.py file1.py folder/ https://github.com/user/repo --cli

--- a/tests/test_system_path.py
+++ b/tests/test_system_path.py
@@ -1,0 +1,80 @@
+import os
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+import argparse
+
+def test_get_system_path_directories(monkeypatch, tmp_path):
+    # Create mock directories
+    dir1 = tmp_path / "bin1"
+    dir1.mkdir()
+    dir2 = tmp_path / "bin2"
+    dir2.mkdir()
+
+    # Non-existent directory
+    dir3 = tmp_path / "nonexistent"
+
+    # Mock PATH environment variable
+    mock_path = f"{dir1}{os.pathsep}{dir2}{os.pathsep}{dir3}{os.pathsep}{dir1}"
+    monkeypatch.setenv("PATH", mock_path)
+
+    dirs = gptscan.get_system_path_directories()
+
+    # Should contain dir1 and dir2, but not dir3 (non-existent) or duplicates
+    assert os.path.abspath(str(dir1)) in dirs
+    assert os.path.abspath(str(dir2)) in dirs
+    assert os.path.abspath(str(dir3)) not in dirs
+    assert len(dirs) == 2
+
+def test_scan_system_path_click_found(monkeypatch):
+    # Mock dependencies
+    mock_get_dirs = MagicMock(return_value=["/mock/bin"])
+    monkeypatch.setattr(gptscan, "get_system_path_directories", mock_get_dirs)
+
+    mock_set_target = MagicMock()
+    monkeypatch.setattr(gptscan, "_set_scan_target", mock_set_target)
+
+    mock_button_click = MagicMock()
+    monkeypatch.setattr(gptscan, "button_click", mock_button_click)
+
+    gptscan.scan_system_path_click()
+
+    mock_set_target.assert_called_once_with(["/mock/bin"])
+    mock_button_click.assert_called_once()
+
+def test_scan_system_path_click_not_found(monkeypatch):
+    # Mock dependencies
+    monkeypatch.setattr(gptscan, "get_system_path_directories", lambda: [])
+
+    mock_info = MagicMock()
+    monkeypatch.setattr(gptscan.messagebox, "showinfo", mock_info)
+
+    gptscan.scan_system_path_click()
+
+    mock_info.assert_called_once()
+    assert "No valid directories found" in mock_info.call_args[0][1]
+
+def test_cli_system_path_flag(monkeypatch):
+    # This tests that the --system-path flag is accepted by the parser
+    # and that the logic in main would call get_system_path_directories
+
+    mock_get_dirs = MagicMock(return_value=["/mock/bin"])
+    monkeypatch.setattr(gptscan, "get_system_path_directories", mock_get_dirs)
+
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+
+    # Mock sys.argv to simulate --system-path --cli
+    monkeypatch.setattr("sys.argv", ["gptscan.py", "--system-path", "--cli"])
+
+    # Run main() but catch SystemExit if it happens
+    try:
+        gptscan.main()
+    except SystemExit:
+        pass
+
+    mock_get_dirs.assert_called_once()
+    # Check that the directories from PATH were added to scan_targets
+    args, kwargs = mock_run_cli.call_args
+    scan_targets = args[0]
+    assert "/mock/bin" in scan_targets


### PR DESCRIPTION
This PR introduces a new "Scan System PATH" feature, allowing users to automatically audit all directories listed in their system's PATH environment variable.

### Changes
- **Core Logic:** Added `get_system_path_directories()` to robustly parse, deduplicate, and validate directories from the `PATH` environment variable.
- **GUI:** Added "Scan System PATH" to the Browse menu, updated the hover tooltips, and bound `Ctrl+Shift+P` (and `Command+Shift+P` on macOS) for quick access.
- **CLI:** Added the `--system-path` flag to enable this functionality in terminal-based workflows.
- **Documentation:** Updated `readme.md` to reflect the new capabilities in both GUI and CLI sections.
- **Testing:** Added `tests/test_system_path.py` covering the logic, GUI interactions, and CLI argument parsing. All 701 tests passed successfully.

This feature provides immediate value by automating the selection of common executable locations, making it easier for users to perform a broad security audit of their environment.

---
*PR created automatically by Jules for task [14405552563779016272](https://jules.google.com/task/14405552563779016272) started by @RainRat*