### PR TITLE
Fix pyproject.toml script extraction for array-based commands

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2442,6 +2442,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 in_script_section = False
                 current_nested_script = None
 
+                def yield_pyproject_scripts(label_name, val):
+                    if val.startswith('['):
+                        # Array of commands: ["a", "b"]
+                        items = re.findall(r'"([^"]*)"|\'([^\']*)\'', val)
+                        for idx, item in enumerate(items, 1):
+                            cmd = item[0] or item[1]
+                            if cmd.strip():
+                                yield (f"{name} [Script: {label_name} ({idx})]", cmd.encode('utf-8'))
+                    else:
+                        # Single command: "a"
+                        cmd = val.strip('"\'')
+                        if cmd.strip():
+                            yield (f"{name} [Script: {label_name}]", cmd.encode('utf-8'))
+
                 for line in lines:
                     line = line.strip()
                     if not line or line.startswith('#'):
@@ -2469,13 +2483,9 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                             # Look for cmd, shell, command, or composite keys
                             match = re.match(r'^(?:cmd|shell|command|composite)\s*=\s*(.*)', line, re.IGNORECASE)
                             if match:
-                                command_val = match.group(1).strip()
-                                if command_val.startswith(('"', "'", "[")):
-                                    command = command_val.strip('"\'[] ')
-                                    if command:
-                                        yield (f"{name} [Script: {current_nested_script}]", command.encode('utf-8'))
-                                        # Only yield once per nested section
-                                        in_script_section = False
+                                yield from yield_pyproject_scripts(current_nested_script, match.group(1).strip())
+                                # Only yield once per nested section
+                                in_script_section = False
                         else:
                             # Inside a flat section like [project.scripts]
                             # Match key = "value" or key = { ... }
@@ -2484,18 +2494,13 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                 script_name = match.group(1).strip().strip('"\'')
                                 command_val = match.group(2).strip()
 
-                                # If it's a string, use it directly
-                                if command_val.startswith(('"', "'")):
-                                    command = command_val.strip('"\'')
-                                    if command:
-                                        yield (f"{name} [Script: {script_name}]", command.encode('utf-8'))
-                                elif command_val.startswith('{'):
+                                if command_val.startswith('{'):
                                     # Try to extract 'cmd' or 'command' or 'shell' from inline table
                                     cmd_match = re.search(r'(?:cmd|command|shell|composite)\s*=\s*("[^"]*"|\'[^\']*\'|\[[^\]]*\])', command_val)
                                     if cmd_match:
-                                        cmd_val = cmd_match.group(1).strip('"\'[] ')
-                                        if cmd_val:
-                                            yield (f"{name} [Script: {script_name}]", cmd_val.encode('utf-8'))
+                                        yield from yield_pyproject_scripts(script_name, cmd_match.group(1).strip())
+                                else:
+                                    yield from yield_pyproject_scripts(script_name, command_val)
                 return
 
             if lowered_check.endswith('.jsonc'):

--- a/tests/test_pyproject_robustness.py
+++ b/tests/test_pyproject_robustness.py
@@ -22,8 +22,10 @@ composite = ["lint", "test"]
     assert "pyproject.toml [Script: post_install]" in scripts
     assert scripts["pyproject.toml [Script: post_install]"] == "echo done"
 
-    assert "pyproject.toml [Script: multi]" in scripts
-    assert scripts["pyproject.toml [Script: multi]"] == "lint\", \"test" # Due to simple regex stripping of []
+    assert "pyproject.toml [Script: multi (1)]" in scripts
+    assert scripts["pyproject.toml [Script: multi (1)]"] == "lint"
+    assert "pyproject.toml [Script: multi (2)]" in scripts
+    assert scripts["pyproject.toml [Script: multi (2)]"] == "test"
 
 def test_pyproject_hatch_scripts():
     content = b"""

--- a/tests/test_pyproject_scanning.py
+++ b/tests/test_pyproject_scanning.py
@@ -25,7 +25,8 @@ ignored = "rm -rf /"
     assert "pyproject.toml [Script: spam-cli]" in names
     assert "pyproject.toml [Script: poetry-run]" in names
     assert "pyproject.toml [Script: pdm-task]" in names
-    assert "pyproject.toml [Script: composite]" in names
+    assert "pyproject.toml [Script: composite (1)]" in names
+    assert "pyproject.toml [Script: composite (2)]" in names
     assert "pyproject.toml [Script: hatch-test]" in names
     assert "pyproject.toml [Script: ignored]" not in names
 


### PR DESCRIPTION
**What:** Improved the `unpack_content` function in `gptscan.py` to correctly handle array-based scripts in `pyproject.toml` (e.g. PDM composite scripts). Added a helper function `yield_pyproject_scripts` to extract individual elements from these arrays as separate snippets with indexed labels.

**Why:** Previously, array-based script commands were being mangled into a single string by a brittle `strip()` operation. This change ensures accurate extraction and better visibility of individual commands within complex script definitions, while maintaining identical behavior for standard string-based scripts. No breaking changes were introduced.

---
*PR created automatically by Jules for task [14929678443186114868](https://jules.google.com/task/14929678443186114868) started by @RainRat*