### PR TITLE
[TEST] Improve YAML script extraction coverage for CI/CD platforms

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2665,7 +2665,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         try:
             text = content.decode('utf-8', errors='ignore')
             snippets = []
-            script_keys = ['run', 'script', 'command', 'before_script', 'after_script', 'entrypoint']
+            script_keys = ['run', 'script', 'command', 'before_script', 'after_script', 'entrypoint', 'commands', 'entry', 'bash', 'powershell', 'pwsh', 'cmd']
             # Match keys, optionally prefixed by a dash (common in YAML lists)
             key_pattern = r'^\s*(?:-\s*)?(?:' + '|'.join(script_keys) + r'):\s*(.*)'
             lines = text.splitlines()

--- a/tests/test_yaml_extraction_gap.py
+++ b/tests/test_yaml_extraction_gap.py
@@ -1,0 +1,49 @@
+import pytest
+from gptscan import unpack_content
+
+def test_yaml_extraction_additional_keys():
+    """Verify that additional script keys like 'commands', 'entry', 'bash', etc. are now correctly extracted."""
+    yaml_content = b"""
+azure-pipelines:
+  steps:
+    - bash: |
+        echo "Azure bash"
+    - pwsh: echo "Azure pwsh"
+    - cmd: echo "Azure cmd"
+drone-ci:
+  steps:
+    - commands:
+        - echo "Drone command 1"
+        - echo "Drone command 2"
+pre-commit:
+  hooks:
+    - entry: python malicious.py
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+
+    # Check that individual snippets are extracted
+    names = [r[0] for r in results]
+
+    assert "test.yml [Script 1]" in names # bash
+    assert "test.yml [Script 2]" in names # pwsh
+    assert "test.yml [Script 3]" in names # cmd
+    assert "test.yml [Script 4]" in names # commands
+    assert "test.yml [Script 5]" in names # entry
+
+    contents = {r[0]: r[1].decode('utf-8') for r in results}
+    assert 'echo "Azure bash"' in contents["test.yml [Script 1]"]
+    assert 'echo "Azure pwsh"' in contents["test.yml [Script 2]"]
+    assert 'echo "Azure cmd"' in contents["test.yml [Script 3]"]
+    assert 'echo "Drone command 1"\necho "Drone command 2"' in contents["test.yml [Script 4]"]
+    assert 'python malicious.py' in contents["test.yml [Script 5]"]
+
+def test_yaml_powershell_key():
+    """Verify that the 'powershell' key is also supported."""
+    yaml_content = b"""
+steps:
+  - powershell: Write-Host "Hello"
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    assert len(results) == 1
+    assert results[0][0] == "test.yml [Script 1]"
+    assert results[0][1] == b'Write-Host "Hello"'


### PR DESCRIPTION
### User's Goal
The goal was to identify a coverage gap in the scanner and provide a specific improvement with a robust test.

### Improvements Made
- **YAML Script Extraction:** Expanded the `script_keys` list in the `unpack_content` function within `gptscan.py`. The scanner now recognizes and extracts snippets from:
    - **Azure Pipelines:** `bash`, `pwsh`, `powershell`, and `cmd` steps.
    - **Drone CI:** the `commands` key.
    - **pre-commit hooks:** the `entry` key.
- **New Test Coverage:** Created `tests/test_yaml_extraction_gap.py` which provides test cases for these newly supported keys, ensuring they are correctly extracted as individual snippets instead of being ignored or falling back to a full-file scan.

### Verification Results
- **New Tests:** `tests/test_yaml_extraction_gap.py` passed successfully.
- **Regression Testing:** The entire test suite (706 tests) passed, confirming that the changes did not break existing YAML parsing, archive scanning, or other core features.
- **Code Review:** The change was assessed as high-quality and correctly targeting a technical gap without introducing risks.

---
*PR created automatically by Jules for task [3547606448138492146](https://jules.google.com/task/3547606448138492146) started by @RainRat*