### PR TITLE
[FEAT] Scan Running Processes

### DIFF
--- a/.gptscan_settings.json
+++ b/.gptscan_settings.json
@@ -1,5 +1,5 @@
 {
-    "last_path": "file1.py file2.js",
+    "last_path": "/some/path",
     "deep_scan": false,
     "git_changes_only": false,
     "show_all_files": false,
@@ -12,8 +12,8 @@
     "max_file_size": 10485760,
     "max_source_view_size": 2097152,
     "recent_paths": [
-        "file1.py file2.js",
         "/some/path",
+        "file1.py file2.js",
         "/some/repo",
         "1",
         "2",

--- a/gptscan.py
+++ b/gptscan.py
@@ -1104,6 +1104,42 @@ def get_system_path_directories() -> List[str]:
     return dirs
 
 
+def get_running_process_commands() -> List[Tuple[str, bytes]]:
+    """Collect command lines of all running processes."""
+    processes = []
+    try:
+        if sys.platform == "win32":
+            # Use PowerShell to get process name and command line
+            cmd = ["powershell", "-NoProfile", "-Command",
+                   "Get-CimInstance Win32_Process | Select-Object Name, CommandLine | ConvertTo-Json"]
+            output = subprocess.check_output(cmd, stderr=subprocess.PIPE, universal_newlines=True)
+            if output.strip():
+                data = json.loads(output)
+                if isinstance(data, dict):
+                    data = [data]
+                for item in data:
+                    name = item.get("Name", "Unknown")
+                    cmdline = item.get("CommandLine")
+                    if cmdline:
+                        processes.append((f"[Process] {name}", cmdline.encode('utf-8')))
+        else:
+            # Linux/macOS
+            # ps -eo args returns the command line
+            # We skip the first line (header)
+            output = subprocess.check_output(["ps", "-eo", "args"], stderr=subprocess.PIPE, universal_newlines=True)
+            lines = output.splitlines()
+            for line in lines[1:]:
+                line = line.strip()
+                if line and not line.startswith('[') and not line.endswith(']'): # Filter out kernel threads
+                    # Use the first part of the command as a name hint
+                    name = line.split()[0] if line.split() else "Unknown"
+                    processes.append((f"[Process] {os.path.basename(name)}", line.encode('utf-8')))
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    return processes
+
+
 def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the Git toplevel directory and the relative path of the target."""
     abs_path = os.path.abspath(path)
@@ -1855,6 +1891,18 @@ def scan_system_path_click():
             messagebox.showinfo("System PATH", "No valid directories found in the system PATH.")
     except Exception as e:
         messagebox.showwarning("System PATH Error", f"Could not scan system PATH: {e}")
+
+
+def scan_running_processes_click():
+    """Scan command lines of all running processes."""
+    try:
+        processes = get_running_process_commands()
+        if processes:
+            button_click(extra_snippets=processes)
+        else:
+            messagebox.showinfo("Running Processes", "No running processes with command lines were found.")
+    except Exception as e:
+        messagebox.showwarning("Running Processes Error", f"Could not scan running processes: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5688,7 +5736,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5710,6 +5758,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
     browse_menu.add_command(label="Scan Shell History", command=scan_shell_history_click, accelerator="Ctrl+Shift+H")
     browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
+    browse_menu.add_command(label="Scan Running Processes", command=scan_running_processes_click, accelerator="Ctrl+Shift+K")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -6089,6 +6138,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-H>', lambda event: scan_shell_history_click())
     root.bind('<Control-Shift-P>', lambda event: scan_system_path_click())
     root.bind('<Command-Shift-P>', lambda event: scan_system_path_click())
+    root.bind('<Control-Shift-K>', lambda event: scan_running_processes_click())
+    root.bind('<Command-Shift-K>', lambda event: scan_running_processes_click())
     root.bind('<Control-e>', export_results)
     root.bind('<Command-e>', export_results)
     root.bind('<Control-t>', check_virustotal)
@@ -6238,6 +6289,11 @@ def main():
         '--system-path',
         action='store_true',
         help='Scan all directories in the system PATH.'
+    )
+    scan_group.add_argument(
+        '--running-processes',
+        action='store_true',
+        help='Scan command lines of all running processes.'
     )
     scan_group.add_argument(
         '--import-results', '--import',
@@ -6433,6 +6489,13 @@ def main():
                 scan_targets.extend(path_dirs)
             else:
                 print("No valid directories found in the system PATH.", file=sys.stderr)
+
+        if args.running_processes:
+            processes = get_running_process_commands()
+            if processes:
+                extra_snippets.extend(processes)
+            else:
+                print("No running processes with command lines were found.", file=sys.stderr)
 
         threats = run_cli(
             scan_targets,

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for malicious one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
+*   **Scan Running Processes:** Scan command lines of all running processes to find potentially malicious execution strings (Ctrl+Shift+K).
 
 ### Using the Terminal (CLI)
 To run the scanner in your terminal, use the `--cli` flag:
@@ -73,6 +74,11 @@ python3 gptscan.py --shell-history --cli
 To scan all directories in your system PATH:
 ```bash
 python3 gptscan.py --system-path --cli
+```
+
+To scan all running processes:
+```bash
+python3 gptscan.py --running-processes --cli
 ```
 
 You can also scan multiple files, folders, or web links:

--- a/tests/test_running_processes.py
+++ b/tests/test_running_processes.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import subprocess
+import json
+import sys
+import os
+from gptscan import get_running_process_commands, scan_running_processes_click
+
+def test_get_running_process_commands_linux():
+    mock_output = "ARGS\n/usr/bin/python3 gptscan.py\n[kthreadd]\n/usr/lib/systemd/systemd --user\n"
+    with patch("sys.platform", "linux"):
+        with patch("subprocess.check_output", return_value=mock_output):
+            processes = get_running_process_commands()
+
+            # Should have python3 and systemd, but not kthreadd (kernel thread) or header
+            assert len(processes) == 2
+            assert processes[0][0] == "[Process] python3"
+            assert processes[0][1] == b"/usr/bin/python3 gptscan.py"
+            assert processes[1][0] == "[Process] systemd"
+            assert processes[1][1] == b"/usr/lib/systemd/systemd --user"
+
+def test_get_running_process_commands_windows():
+    mock_json = json.dumps([
+        {"Name": "python.exe", "CommandLine": "python gptscan.py"},
+        {"Name": "svchost.exe", "CommandLine": None},
+        {"Name": "cmd.exe", "CommandLine": "cmd /c dir"}
+    ])
+    with patch("sys.platform", "win32"):
+        with patch("subprocess.check_output", return_value=mock_json):
+            processes = get_running_process_commands()
+
+            # Should have python.exe and cmd.exe, but not svchost.exe (no command line)
+            assert len(processes) == 2
+            assert processes[0][0] == "[Process] python.exe"
+            assert processes[0][1] == b"python gptscan.py"
+            assert processes[1][0] == "[Process] cmd.exe"
+            assert processes[1][1] == b"cmd /c dir"
+
+def test_get_running_process_commands_error():
+    with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "ps")):
+        processes = get_running_process_commands()
+        assert processes == []
+
+@patch("gptscan.get_running_process_commands")
+@patch("gptscan.button_click")
+def test_scan_running_processes_click_success(mock_button_click, mock_get_cmds):
+    mock_get_cmds.return_value = [("[Process] test", b"test command")]
+
+    scan_running_processes_click()
+
+    mock_button_click.assert_called_once_with(extra_snippets=mock_get_cmds.return_value)
+
+@patch("gptscan.get_running_process_commands")
+@patch("gptscan.messagebox.showinfo")
+def test_scan_running_processes_click_empty(mock_showinfo, mock_get_cmds):
+    mock_get_cmds.return_value = []
+
+    scan_running_processes_click()
+
+    mock_showinfo.assert_called_once()


### PR DESCRIPTION
Implemented "Scan Running Processes" to complement existing static history and system path scanning. This feature collects command lines from active processes on Windows, Linux, and macOS and feeds them into the scanner as virtual snippets. It includes full GUI and CLI integration, updated documentation, and unit tests.

---
*PR created automatically by Jules for task [11165155975307840269](https://jules.google.com/task/11165155975307840269) started by @RainRat*