### PR TITLE
[TEST] Expand javascript: URI attribute extraction in HTML/SVG

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2647,7 +2647,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             # Also handles leading whitespace in javascript: URLs
             attr_patterns = [
                 (r'\s+(on[a-z]+)\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)', True),
-                (r'\s+(?:href|src)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|\s*javascript:[^\s>]+)', False)
+                (r'\s+(?:href|src|action|formaction|data|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|\s*javascript:[^\s>]+)', False)
             ]
             extracted_attrs = []
             for pattern, has_name_group in attr_patterns:

--- a/tests/test_html_uri_attributes.py
+++ b/tests/test_html_uri_attributes.py
@@ -1,0 +1,45 @@
+import pytest
+from gptscan import unpack_content
+
+def test_html_uri_attributes_extraction():
+    """Verify extraction of javascript: URIs from action, formaction, data, and xlink:href."""
+    html_content = """
+    <html>
+        <body>
+            <form action="javascript:alert('action')">
+                <button formaction="javascript:alert('formaction')">Click</button>
+            </form>
+            <object data="javascript:alert('data')"></object>
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <a xlink:href="javascript:alert('xlink')">link</a>
+            </svg>
+        </body>
+    </html>
+    """
+    content_bytes = html_content.encode('utf-8')
+    snippets = list(unpack_content("test.html", content_bytes))
+
+    names = [s[0] for s in snippets]
+    assert "test.html [Attributes]" in names
+
+    attr_text = [s[1] for s in snippets if s[0] == "test.html [Attributes]"][0].decode('utf-8')
+    assert "javascript:alert('action')" in attr_text
+    assert "javascript:alert('formaction')" in attr_text
+    assert "javascript:alert('data')" in attr_text
+    assert "javascript:alert('xlink')" in attr_text
+
+def test_svg_uri_attributes_extraction():
+    """Verify extraction from SVG file specifically."""
+    svg_content = """
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <a xlink:href="javascript:alert('xlink')">link</a>
+    </svg>
+    """
+    content_bytes = svg_content.encode('utf-8')
+    snippets = list(unpack_content("test.svg", content_bytes))
+
+    names = [s[0] for s in snippets]
+    assert "test.svg [Attributes]" in names
+
+    attr_text = [s[1] for s in snippets if s[0] == "test.svg [Attributes]"][0].decode('utf-8')
+    assert "javascript:alert('xlink')" in attr_text


### PR DESCRIPTION
### **PR Title:** [TEST] Expand javascript: URI attribute extraction in HTML/SVG

**Description:**
* **Type:** New Coverage / Bug Fix
* **What:** Expanded the regex in `unpack_content` to detect `javascript:` URIs in `action`, `formaction`, `data`, and `xlink:href` attributes, and added a new test file `tests/test_html_uri_attributes.py` to verify this.
* **Why:** These attributes are valid sinks for JavaScript execution in HTML and SVG files, and were previously ignored by the scanner's extraction logic. Adding them improves the detection of potentially malicious embedded scripts.

---
*PR created automatically by Jules for task [2375887595057343714](https://jules.google.com/task/2375887595057343714) started by @RainRat*