### PR TITLE
[FEAT] Add 'Scan Scheduled Tasks' to identify malicious persistence

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1138,6 +1138,48 @@ def get_running_process_commands() -> List[Tuple[str, bytes]]:
     return processes
 
 
+def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
+    """Collect command lines of all scheduled tasks (Cron on Linux/macOS, schtasks on Windows)."""
+    tasks = []
+    try:
+        if sys.platform == "win32":
+            # Use schtasks to get task name and action (command) in CSV format
+            # /fo CSV /v provides verbose output including 'Task To Run'
+            cmd = ["schtasks", "/query", "/fo", "CSV", "/v"]
+            output = subprocess.check_output(cmd, stderr=subprocess.PIPE, universal_newlines=True)
+            if output.strip():
+                f = io.StringIO(output)
+                reader = csv.DictReader(f)
+                for row in reader:
+                    name = row.get("TaskName", "Unknown")
+                    command = row.get("Task To Run") or row.get("Action")
+                    if command and command.strip() and command.lower() != "n/a":
+                        tasks.append((f"[Task] {name}", command.encode('utf-8')))
+        else:
+            # Linux/macOS - Collect from user crontab
+            try:
+                output = subprocess.check_output(["crontab", "-l"], stderr=subprocess.PIPE, universal_newlines=True)
+                for line in output.splitlines():
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        # Crontab format: min hour day month dow command
+                        # Try to skip the first 5 fields
+                        parts = line.split(None, 5)
+                        if len(parts) > 5:
+                            command = parts[5]
+                            tasks.append(("[Cron] User", command.encode('utf-8')))
+                        elif line.startswith('@'):
+                            parts = line.split(None, 1)
+                            if len(parts) > 1:
+                                tasks.append(("[Cron] User", parts[1].encode('utf-8')))
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+    except Exception:
+        pass
+
+    return tasks
+
+
 def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the Git toplevel directory and the relative path of the target."""
     abs_path = os.path.abspath(path)
@@ -1901,6 +1943,18 @@ def scan_running_processes_click():
             messagebox.showinfo("Running Processes", "No running processes with command lines were found.")
     except Exception as e:
         messagebox.showwarning("Running Processes Error", f"Could not scan running processes: {e}")
+
+
+def scan_scheduled_tasks_click():
+    """Scan all scheduled tasks and Cron jobs."""
+    try:
+        tasks = get_scheduled_task_commands()
+        if tasks:
+            button_click(extra_snippets=tasks)
+        else:
+            messagebox.showinfo("Scheduled Tasks", "No scheduled tasks or Cron jobs were found.")
+    except Exception as e:
+        messagebox.showwarning("Scheduled Tasks Error", f"Could not scan scheduled tasks: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5739,7 +5793,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K/T).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5762,6 +5816,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Shell History", command=scan_shell_history_click, accelerator="Ctrl+Shift+H")
     browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
     browse_menu.add_command(label="Scan Running Processes", command=scan_running_processes_click, accelerator="Ctrl+Shift+K")
+    browse_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -6149,6 +6204,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-P>', lambda event: scan_system_path_click())
     root.bind('<Control-Shift-K>', lambda event: scan_running_processes_click())
     root.bind('<Command-Shift-K>', lambda event: scan_running_processes_click())
+    root.bind('<Control-Shift-T>', lambda event: scan_scheduled_tasks_click())
+    root.bind('<Command-Shift-T>', lambda event: scan_scheduled_tasks_click())
     root.bind('<Control-e>', export_results)
     root.bind('<Command-e>', export_results)
     root.bind('<Control-t>', check_virustotal)
@@ -6303,6 +6360,11 @@ def main():
         '--running-processes',
         action='store_true',
         help='Scan command lines of all running processes.'
+    )
+    scan_group.add_argument(
+        '--scheduled-tasks',
+        action='store_true',
+        help='Scan all scheduled tasks and Cron jobs.'
     )
     scan_group.add_argument(
         '--import-results', '--import',
@@ -6505,6 +6567,13 @@ def main():
                 extra_snippets.extend(processes)
             else:
                 print("No running processes with command lines were found.", file=sys.stderr)
+
+        if args.scheduled_tasks:
+            tasks = get_scheduled_task_commands()
+            if tasks:
+                extra_snippets.extend(tasks)
+            else:
+                print("No scheduled tasks or Cron jobs were found.", file=sys.stderr)
 
         threats = run_cli(
             scan_targets,

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Access these options from the **Browse** menu:
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for malicious one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially malicious execution strings (Ctrl+Shift+K).
+*   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify malicious persistence (Ctrl+Shift+T).
 
 ### Using the Terminal (CLI)
 To run the scanner in your terminal, use the `--cli` flag:
@@ -79,6 +80,11 @@ python3 gptscan.py --system-path --cli
 To scan all running processes:
 ```bash
 python3 gptscan.py --running-processes --cli
+```
+
+To scan all scheduled tasks and Cron jobs:
+```bash
+python3 gptscan.py --scheduled-tasks --cli
 ```
 
 You can also scan multiple files, folders, or web links:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import subprocess
+import os
+import sys
+from gptscan import get_scheduled_task_commands, scan_scheduled_tasks_click
+
+def test_get_scheduled_task_commands_linux():
+    mock_crontab = "# Some comment\n* * * * * /usr/bin/python3 /path/to/script.py\n@daily /usr/bin/cleanup.sh\n"
+    with patch("sys.platform", "linux"):
+        with patch("subprocess.check_output", return_value=mock_crontab):
+            tasks = get_scheduled_task_commands()
+
+            assert len(tasks) == 2
+            assert tasks[0][0] == "[Cron] User"
+            assert tasks[0][1] == b"/usr/bin/python3 /path/to/script.py"
+            assert tasks[1][0] == "[Cron] User"
+            assert tasks[1][1] == b"/usr/bin/cleanup.sh"
+
+def test_get_scheduled_task_commands_windows():
+    # schtasks /query /fo CSV /v output
+    mock_csv = '"HostName","TaskName","Next Run Time","Status","Last Run Time","Last Result","Creator","Schedule","Task To Run","Path","Run As User"\n' \
+               '"HOST","\\MyTask","N/A","Ready","N/A","0","User","One Time Only","C:\\Windows\\System32\\calc.exe","\\","User"\n' \
+               '"HOST","\\AnotherTask","N/A","Disabled","N/A","0","User","N/A","N/A","\\","User"\n'
+
+    with patch("sys.platform", "win32"):
+        with patch("subprocess.check_output", return_value=mock_csv):
+            tasks = get_scheduled_task_commands()
+
+            assert len(tasks) == 1
+            assert tasks[0][0] == "[Task] \\MyTask"
+            assert tasks[0][1] == b"C:\\Windows\\System32\\calc.exe"
+
+def test_get_scheduled_task_commands_error():
+    with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "crontab")):
+        tasks = get_scheduled_task_commands()
+        assert tasks == []
+
+@patch("gptscan.get_scheduled_task_commands")
+@patch("gptscan.button_click")
+def test_scan_scheduled_tasks_click_success(mock_button_click, mock_get_tasks):
+    mock_get_tasks.return_value = [("[Task] test", b"test command")]
+
+    scan_scheduled_tasks_click()
+
+    mock_button_click.assert_called_once_with(extra_snippets=mock_get_tasks.return_value)
+
+@patch("gptscan.get_scheduled_task_commands")
+@patch("gptscan.messagebox.showinfo")
+def test_scan_scheduled_tasks_click_empty(mock_showinfo, mock_get_tasks):
+    mock_get_tasks.return_value = []
+
+    scan_scheduled_tasks_click()
+
+    mock_showinfo.assert_called_once()


### PR DESCRIPTION
This PR adds a new scanning capability to GPT Virus Scanner: Scheduled Tasks and Cron Jobs.

**What:**
- A new backend function `get_scheduled_task_commands()` that extracts command lines from system scheduled tasks (Windows `schtasks`) and user cron jobs (Linux/macOS `crontab -l`).
- Integration into the CLI via a new `--scheduled-tasks` flag.
- Integration into the GUI through the 'Browse' menu, including a new keyboard shortcut `Ctrl+Shift+T` (or `Cmd+Shift+T`).
- Comprehensive unit tests in `tests/test_scheduled_tasks.py` covering both Windows and Linux logic.
- Updated `readme.md` documentation.

**Why:**
Identifying malicious code in persistent execution mechanisms is critical for security auditing. Attackers often use scheduled tasks or cron jobs to ensure their scripts run repeatedly or after a reboot. By adding this feature, GPT Virus Scanner now covers a major persistence vector alongside its existing support for running processes and shell history.

---
*PR created automatically by Jules for task [15297366484187706989](https://jules.google.com/task/15297366484187706989) started by @RainRat*