### PR TITLE
[FEAT] Scan Environment Variables

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1138,6 +1138,15 @@ def get_running_process_commands() -> List[Tuple[str, bytes]]:
     return processes
 
 
+def get_environment_variable_snippets() -> List[Tuple[str, bytes]]:
+    """Collect all non-empty environment variables as snippets."""
+    snippets = []
+    for key, value in os.environ.items():
+        if value.strip():
+            snippets.append((f"[EnvVar] {key}", value.encode('utf-8')))
+    return snippets
+
+
 def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all scheduled tasks (Cron on Linux/macOS, schtasks on Windows)."""
     tasks = []
@@ -1956,6 +1965,18 @@ def scan_scheduled_tasks_click():
             messagebox.showinfo("Scheduled Tasks", "No scheduled tasks or Cron jobs were found.")
     except Exception as e:
         messagebox.showwarning("Scheduled Tasks Error", f"Could not scan scheduled tasks: {e}")
+
+
+def scan_env_vars_click():
+    """Scan all non-empty environment variables."""
+    try:
+        snippets = get_environment_variable_snippets()
+        if snippets:
+            button_click(extra_snippets=snippets)
+        else:
+            messagebox.showinfo("Environment Variables", "No non-empty environment variables were found.")
+    except Exception as e:
+        messagebox.showwarning("Environment Variables Error", f"Could not scan environment variables: {e}")
 
 
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None) -> None:
@@ -5796,7 +5817,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K/T).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K/N/T).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5819,6 +5840,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Shell History", command=scan_shell_history_click, accelerator="Ctrl+Shift+H")
     browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
     browse_menu.add_command(label="Scan Running Processes", command=scan_running_processes_click, accelerator="Ctrl+Shift+K")
+    browse_menu.add_command(label="Scan Environment Variables", command=scan_env_vars_click, accelerator="Ctrl+Shift+N")
     browse_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     browse_button["menu"] = browse_menu
 
@@ -6205,6 +6227,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-P>', lambda event: scan_system_path_click())
     root.bind('<Control-Shift-K>', lambda event: scan_running_processes_click())
     root.bind('<Command-Shift-K>', lambda event: scan_running_processes_click())
+    root.bind('<Control-Shift-N>', lambda event: scan_env_vars_click())
+    root.bind('<Command-Shift-N>', lambda event: scan_env_vars_click())
     root.bind('<Control-Shift-T>', lambda event: scan_scheduled_tasks_click())
     root.bind('<Command-Shift-T>', lambda event: scan_scheduled_tasks_click())
     root.bind('<Control-e>', export_results)
@@ -6284,6 +6308,8 @@ def main():
                "  python gptscan.py https://github.com/user/repo/pull/123 --cli\n\n"
                "  # Scan a Pastebin paste or a Hugging Face script directly\n"
                "  python gptscan.py https://pastebin.com/abcdefgh --cli\n\n"
+               "  # Scan all environment variables\n"
+               "  python gptscan.py --env-vars --cli\n\n"
                "Note: Run the script from its own folder so it can find its data files.",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -6368,6 +6394,11 @@ def main():
         help='Scan all scheduled tasks and Cron jobs.'
     )
     scan_group.add_argument(
+        '--env-vars',
+        action='store_true',
+        help='Scan all non-empty environment variables.'
+    )
+    scan_group.add_argument(
         '--import-results', '--import',
         type=str,
         help='Import results from a previous scan. Use "-" to read from the terminal.'
@@ -6432,7 +6463,7 @@ def main():
         Config.save_cache()
         print("AI Analysis cache cleared.", file=sys.stderr)
         # If we ONLY wanted to clear cache, exit now.
-        if not any([args.target, args.path, args.stdin, args.import_results, args.files]):
+        if not any([args.target, args.path, args.stdin, args.import_results, args.files, args.env_vars]):
             sys.exit(0)
 
     Config.provider = args.provider
@@ -6575,6 +6606,13 @@ def main():
                 extra_snippets.extend(tasks)
             else:
                 print("No scheduled tasks or Cron jobs were found.", file=sys.stderr)
+
+        if args.env_vars:
+            snippets = get_environment_variable_snippets()
+            if snippets:
+                extra_snippets.extend(snippets)
+            else:
+                print("No non-empty environment variables were found.", file=sys.stderr)
 
         threats = run_cli(
             scan_targets,

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Access these options from the **Browse** menu:
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for dangerous one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially dangerous execution strings (Ctrl+Shift+K).
+*   **Scan Environment Variables:** Scan all non-empty environment variables for suspicious scripts or commands (Ctrl+Shift+N).
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous persistence (Ctrl+Shift+T).
 
 ### Using the Terminal (CLI)
@@ -85,6 +86,11 @@ python3 gptscan.py --running-processes --cli
 To scan all scheduled tasks and Cron jobs:
 ```bash
 python3 gptscan.py --scheduled-tasks --cli
+```
+
+To scan all environment variables:
+```bash
+python3 gptscan.py --env-vars --cli
 ```
 
 You can also scan multiple files, folders, or web links:

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from gptscan import get_environment_variable_snippets
+
+def test_get_environment_variable_snippets(monkeypatch):
+    # Setup mock environment variables
+    monkeypatch.setenv("TEST_VAR_1", "dangerous_command")
+    monkeypatch.setenv("TEST_VAR_2", "  ") # Should be ignored (whitespace only)
+    monkeypatch.setenv("EMPTY_VAR", "")    # Should be ignored
+
+    snippets = get_environment_variable_snippets()
+
+    # Check if TEST_VAR_1 is present
+    found_var1 = False
+    for name, content in snippets:
+        if name == "[EnvVar] TEST_VAR_1":
+            assert content == b"dangerous_command"
+            found_var1 = True
+        elif name == "[EnvVar] TEST_VAR_2":
+            pytest.fail("TEST_VAR_2 should have been ignored (whitespace only)")
+        elif name == "[EnvVar] EMPTY_VAR":
+            pytest.fail("EMPTY_VAR should have been ignored")
+
+    assert found_var1, "TEST_VAR_1 not found in snippets"
+
+def test_cli_env_vars_flag(monkeypatch):
+    import subprocess
+    import sys
+
+    # We'll use subprocess to run the CLI to ensure full integration
+    # Set a unique env var to look for
+    env = os.environ.copy()
+    env["GPT_SCAN_TEST_ENV"] = "suspicious_payload"
+
+    # Run gptscan.py with --env-vars --cli --dry-run
+    # --dry-run ensures we don't actually need the model file
+    # We use a non-existent target to only scan the environment variables
+    cmd = [sys.executable, "gptscan.py", "non_existent_target_999", "--env-vars", "--cli", "--dry-run"]
+
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+
+    # Check both stdout and stderr because it might depend on terminal vs redirection
+    combined_output = result.stdout + result.stderr
+
+    assert "GPT_SCAN_TEST_ENV" in combined_output
+    # Count should be 1 if only environment variables are scanned
+    # But get_environment_variable_snippets returns ALL env vars, so we check for many files
+    assert "Scan complete" in combined_output
+    assert "0 suspicious files found" in combined_output


### PR DESCRIPTION
This PR introduces the "Scan Environment Variables" feature to the GPT Virus Scanner.

### Changes:
- **Core Logic:** Added `get_environment_variable_snippets()` to extract non-empty environment variables as scan targets.
- **GUI:** Added "Scan Environment Variables" to the Browse menu and bound it to `Ctrl+Shift+N` (or `Cmd+Shift+N` on macOS).
- **CLI:** Added the `--env-vars` flag to the CLI to allow scanning of environment variables from the terminal.
- **Documentation:** Updated `readme.md` to include instructions for the new feature.
- **Testing:** Added `tests/test_env_vars.py` to verify the functionality and prevent regressions.

This feature complements existing capabilities like scanning running processes and scheduled tasks, providing a more comprehensive security audit of the system environment.

---
*PR created automatically by Jules for task [16728097186239145944](https://jules.google.com/task/16728097186239145944) started by @RainRat*