### PR TITLE
Fix pluralization logic in scan throughput summary

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1581,7 +1581,8 @@ def format_scan_summary(total_scanned: int, threats_found: int, total_bytes: Opt
 
     if elapsed_time and elapsed_time > 0:
         files_per_sec = total_scanned / elapsed_time
-        summary += f" Time: {elapsed_time:.1f}s ({files_per_sec:.1f} {file_text}/s"
+        rate_text = "file" if files_per_sec <= 1.0 else "files"
+        summary += f" Time: {elapsed_time:.1f}s ({files_per_sec:.1f} {rate_text}/s"
         if total_bytes:
             bytes_per_sec = total_bytes / elapsed_time
             summary += f", {format_bytes(bytes_per_sec)}/s"


### PR DESCRIPTION
This PR fixes a logic bug in the `format_scan_summary` function where the throughput rate (files/s) was being pluralized incorrectly. 

### Changes:
- Modified `format_scan_summary` to use a separate `rate_text` variable for throughput pluralization.
- Throughput is now pluralized based on the actual `files_per_sec` value.
- Rates ≤ 1.0 use the singular "file/s" to ensure compatibility with existing unit tests (e.g., `0.5 file/s`).

### Benefit:
- Accurate and grammatically correct scan summaries in both CLI and GUI.
- No breaking changes to external behavior or APIs.
- Passes all existing tests.

---
*PR created automatically by Jules for task [3972898748339288974](https://jules.google.com/task/3972898748339288974) started by @RainRat*