### PR TITLE
[TEST] Fix inconsistent container detection for prefixed manifest files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2564,10 +2564,11 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
 
     # 4. Check for package manifests (package.json, composer.json, deno.json/jsonc, pyproject.toml)
     lowered_check = check_name.lower()
-    if lowered_check.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml')):
+    check_basename = os.path.basename(lowered_check)
+    if check_basename.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml')):
         try:
             text = content.decode('utf-8', errors='ignore')
-            if lowered_check.endswith('.pyproject.toml') or os.path.basename(lowered_check) == 'pyproject.toml':
+            if check_basename.endswith('pyproject.toml'):
                 # Parse pyproject.toml using regex to avoid toml dependency
                 lines = text.splitlines()
                 in_script_section = False
@@ -2756,8 +2757,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             pass
 
     # 7. Check for Dockerfile
-    lowered_check = check_name.lower()
-    if 'dockerfile' in lowered_check and (os.path.basename(lowered_check) == 'dockerfile' or lowered_check.endswith('.dockerfile')):
+    if check_basename.endswith('dockerfile'):
         try:
             text = content.decode('utf-8', errors='ignore')
             # Extract RUN, CMD, and ENTRYPOINT instructions with multi-line support
@@ -2916,7 +2916,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             pass
 
     # 10. Check for Makefile
-    if 'makefile' in lowered_check and (os.path.basename(lowered_check) == 'makefile' or lowered_check.endswith('.makefile')):
+    if check_basename.endswith('makefile'):
         try:
             text = content.decode('utf-8', errors='ignore')
             # Extract recipes (lines starting with a tab) with multi-line support

--- a/tests/test_unpack_consistency.py
+++ b/tests/test_unpack_consistency.py
@@ -1,0 +1,30 @@
+import pytest
+from gptscan import unpack_content, Config
+
+def test_repro_dockerfile_hyphen():
+    content = b"RUN echo 'hello'"
+    name = "my-dockerfile"
+    assert Config.is_container(name) is True
+
+    results = list(unpack_content(name, content))
+    assert len(results) == 1
+    # If it was unpacked as a Dockerfile, it should have [Instruction 1]
+    assert "[Instruction 1]" in results[0][0], f"Expected instruction for {name}, got {results[0][0]}"
+
+def test_repro_makefile_hyphen():
+    content = b"\techo 'hello'"
+    name = "my-makefile"
+    assert Config.is_container(name) is True
+
+    results = list(unpack_content(name, content))
+    assert len(results) == 1
+    assert "[Recipe 1]" in results[0][0], f"Expected recipe for {name}, got {results[0][0]}"
+
+def test_repro_pyproject_hyphen():
+    content = b'[project.scripts]\nspam = "spam:main"'
+    name = "my-pyproject.toml"
+    assert Config.is_container(name) is True
+
+    results = list(unpack_content(name, content))
+    assert len(results) == 1
+    assert "[Script: spam]" in results[0][0], f"Expected script for {name}, got {results[0][0]}"


### PR DESCRIPTION
This PR fixes a bug where `gptscan.py` failed to unpack certain manifest and build files (like `Dockerfile`, `Makefile`, and `pyproject.toml`) if they had custom prefixes. 

While the global configuration correctly identified these files as containers, the recursive `unpack_content` function used overly restrictive string matching that didn't account for prefixes or directories correctly in all cases. 

The fix aligns `unpack_content` with `Config.is_container` by using `os.path.basename` and `endswith` checks. 

A new test suite `tests/test_unpack_consistency.py` has been added to ensure this behavior remains consistent.

---
*PR created automatically by Jules for task [3348341017041036466](https://jules.google.com/task/3348341017041036466) started by @RainRat*