### PR TITLE
Add "Scan Shell Profiles" feature

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1070,6 +1070,42 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
             tree.item(iid, values=new_vals)
 
 
+def get_shell_profile_paths() -> List[str]:
+    """Identify common shell profile and RC files on the current system."""
+    paths = []
+    home = Path.home()
+
+    # Linux/macOS/Unix-like
+    common_files = [
+        '.bashrc', '.bash_profile', '.bash_login', '.profile',
+        '.zshrc', '.zprofile', '.zshenv', '.zlogin',
+        '.bash_logout', '.zlogout'
+    ]
+
+    for f in common_files:
+        p = home / f
+        if p.exists():
+            paths.append(str(p))
+
+    # Windows PowerShell Profiles
+    if sys.platform == "win32":
+        try:
+            cmd = ["powershell", "-NoProfile", "-Command",
+                   "$PROFILE | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | ForEach-Object { $PROFILE.$_ } | ConvertTo-Json"]
+            output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, universal_newlines=True)
+            if output.strip():
+                data = json.loads(output)
+                if isinstance(data, str):
+                    data = [data]
+                for p_str in data:
+                    if p_str and os.path.exists(p_str):
+                        paths.append(p_str)
+        except Exception:
+            pass
+
+    return sorted(list(set(paths)))
+
+
 def get_shell_history_paths() -> List[str]:
     """Identify common shell history files on the current system."""
     paths = []
@@ -1998,6 +2034,19 @@ def scan_git_revision_click():
             messagebox.showinfo("Git Revision", f"No changed files found for revision '{ref}'.")
     except Exception as e:
         messagebox.showwarning("Git Revision Error", f"Could not scan Git revision: {e}")
+
+
+def scan_shell_profiles_click():
+    """Scan common shell profile and RC files."""
+    try:
+        profile_paths = get_shell_profile_paths()
+        if profile_paths:
+            _set_scan_target(profile_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Shell Profiles", "No common shell profile files were found on this system.")
+    except Exception as e:
+        messagebox.showwarning("Shell Profiles Error", f"Could not scan shell profiles: {e}")
 
 
 def scan_shell_history_click():
@@ -5960,7 +6009,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/H/P/K/N/T/A).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/B/H/P/K/N/T/A).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -5980,6 +6029,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click, accelerator="Ctrl+Shift+V")
     browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     browse_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
+    browse_menu.add_command(label="Scan Shell Profiles", command=scan_shell_profiles_click, accelerator="Ctrl+Shift+B")
     browse_menu.add_command(label="Scan Shell History", command=scan_shell_history_click, accelerator="Ctrl+Shift+H")
     browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
     browse_menu.add_command(label="Scan Running Processes", command=scan_running_processes_click, accelerator="Ctrl+Shift+K")
@@ -6342,6 +6392,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-V>', lambda event: scan_clipboard_click())
     root.bind('<Control-Shift-D>', lambda event: scan_git_diff_click())
     root.bind('<Command-Shift-D>', lambda event: scan_git_diff_click())
+    root.bind('<Control-Shift-B>', lambda event: scan_shell_profiles_click())
+    root.bind('<Command-Shift-B>', lambda event: scan_shell_profiles_click())
     root.bind('<Control-Shift-H>', lambda event: scan_shell_history_click())
     root.bind('<Command-Shift-H>', lambda event: scan_shell_history_click())
     root.bind('<Control-Shift-P>', lambda event: scan_system_path_click())
@@ -6495,6 +6547,11 @@ def main():
         '--stdin',
         action='store_true',
         help='Scan code sent from another command in the terminal.'
+    )
+    scan_group.add_argument(
+        '--shell-profiles',
+        action='store_true',
+        help='Scan common shell profile and RC files.'
     )
     scan_group.add_argument(
         '--shell-history',
@@ -6665,7 +6722,7 @@ def main():
             if not extra_snippets:
                 print(f"No Git diff detected in provided targets (ref: {args.git_diff}).", file=sys.stderr)
 
-        if not scan_targets and not args.git_changes and not args.git_diff:
+        if not scan_targets and not args.git_changes and not args.git_diff and not extra_snippets:
             # Default to current directory if no targets provided and NOT using git-changes
             scan_targets = ["."]
 
@@ -6706,6 +6763,13 @@ def main():
                     extra_snippets.append(("[Stdin]", stdin_content))
             except Exception as e:
                 print(f"Error reading from terminal input: {e}", file=sys.stderr)
+
+        if args.shell_profiles:
+            profile_paths = get_shell_profile_paths()
+            if profile_paths:
+                scan_targets.extend(profile_paths)
+            else:
+                print("No common shell profile files were found on this system.", file=sys.stderr)
 
         if args.shell_history:
             history_paths = get_shell_history_paths()

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ Access these options from the **Browse** menu:
 *   **Scan URL...:** Scan scripts or archives directly from a web link.
 *   **Scan File List...:** Read a list of files to scan from a text file.
 *   **Scan Clipboard:** Scan code currently in your clipboard.
+*   **Scan Shell Profiles:** Scan your shell configuration files (.bashrc, .zshrc, etc.) and PowerShell profiles for dangerous aliases or functions (Ctrl+Shift+B).
 *   **Scan Git Diff:** Scan changes in your local project.
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for dangerous one-liners.
@@ -97,6 +98,11 @@ python3 gptscan.py --startup-items --cli
 To scan all environment variables:
 ```bash
 python3 gptscan.py --env-vars --cli
+```
+
+To scan all shell profiles and RC files:
+```bash
+python3 gptscan.py --shell-profiles --cli
 ```
 
 You can also scan multiple files, folders, or web links:

--- a/tests/test_shell_profiles.py
+++ b/tests/test_shell_profiles.py
@@ -1,0 +1,49 @@
+import pytest
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import gptscan
+
+def test_get_shell_profile_paths_linux(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    bashrc = home / ".bashrc"
+    bashrc.write_text("alias ls='ls --color=auto'")
+    profile = home / ".profile"
+    profile.write_text("export PATH=$PATH:~/bin")
+
+    with patch("pathlib.Path.home", return_value=home):
+        paths = gptscan.get_shell_profile_paths()
+        assert str(bashrc) in paths
+        assert str(profile) in paths
+        assert len(paths) == 2
+
+@patch("sys.platform", "win32")
+@patch("subprocess.check_output")
+@patch("os.path.exists")
+def test_get_shell_profile_paths_windows(mock_exists, mock_check_output, tmp_path):
+    mock_check_output.return_value = '"C:\\\\Users\\\\user\\\\Documents\\\\WindowsPowerShell\\\\Microsoft.PowerShell_profile.ps1"'
+    mock_exists.return_value = True
+
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        paths = gptscan.get_shell_profile_paths()
+        assert "C:\\Users\\user\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1" in paths
+
+def test_scan_shell_profiles_click_success(mocker):
+    mock_get_paths = mocker.patch("gptscan.get_shell_profile_paths", return_value=["/fake/.bashrc"])
+    mock_set_target = mocker.patch("gptscan._set_scan_target")
+    mock_button_click = mocker.patch("gptscan.button_click")
+
+    gptscan.scan_shell_profiles_click()
+
+    mock_get_paths.assert_called_once()
+    mock_set_target.assert_called_once_with(["/fake/.bashrc"])
+    mock_button_click.assert_called_once()
+
+def test_scan_shell_profiles_click_no_files(mocker):
+    mock_get_paths = mocker.patch("gptscan.get_shell_profile_paths", return_value=[])
+    mock_messagebox = mocker.patch("tkinter.messagebox.showinfo")
+
+    gptscan.scan_shell_profiles_click()
+
+    mock_messagebox.assert_called_once()


### PR DESCRIPTION
I've implemented a new "Scan Shell Profiles" feature that allows users to automatically scan their shell configuration files (like `.bashrc`, `.zshrc`, and PowerShell profiles) for dangerous code. This feature follows the established pattern of "Scan Shell History" and "Scan System PATH", providing a convenient way to check common persistence and attack vectors.

The feature is available in both the GUI (under the Browse menu and via `Ctrl+Shift+B`) and the CLI (via the `--shell-profiles` flag). I've also updated the documentation and added a full suite of unit tests to ensure cross-platform compatibility and correct behavior.

---
*PR created automatically by Jules for task [7705475251950943617](https://jules.google.com/task/7705475251950943617) started by @RainRat*