### PR TITLE
Remove redundant gpt_var declaration

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -64,7 +64,6 @@ scan_all_checkbox: Optional[ttk.Checkbutton] = None
 dry_checkbox: Optional[ttk.Checkbutton] = None
 gpt_checkbox: Optional[ttk.Checkbutton] = None
 all_checkbox: Optional[ttk.Checkbutton] = None
-gpt_var: Optional[tk.BooleanVar] = None
 threshold_spin: Optional[ttk.Spinbox] = None
 provider_var: Optional[tk.StringVar] = None
 model_var: Optional[tk.StringVar] = None


### PR DESCRIPTION
This change removes a duplicate declaration of the `gpt_var` global variable in `gptscan.py`. The variable was declared twice (lines 41 and 67) as `Optional[tk.BooleanVar] = None`. 

Removing this redundancy improves code readability and hygiene while ensuring the external behavior remains identical. The variable continues to be correctly initialized and scoped within `create_gui` and used throughout the application for AI analysis toggling. 

All 740 project tests passed successfully after this change.

---
*PR created automatically by Jules for task [3086702055796307430](https://jules.google.com/task/3086702055796307430) started by @RainRat*