### PR TITLE
[TEST] Improve pyproject.toml header parsing robustness and test coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2743,8 +2743,9 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                     if not line or line.startswith('#'):
                         continue
 
-                    if line.startswith('[') and line.endswith(']'):
-                        section = line[1:-1].strip()
+                    header_match = re.match(r'^\[\s*([^\]]+)\s*\](?:\s*#.*)?$', line)
+                    if header_match:
+                        section = header_match.group(1).strip()
                         # Flat script sections: [project.scripts], [tool.pdm.scripts], etc.
                         if re.match(r'^(?:.*?\.)?scripts$', section, re.IGNORECASE) or \
                            section.lower() == 'tool.pdm.dev-dependencies':

--- a/tests/test_pyproject_robustness.py
+++ b/tests/test_pyproject_robustness.py
@@ -76,3 +76,21 @@ CMD = "echo upper"
 
     assert "pyproject.toml [Script: UPPER]" in scripts
     assert scripts["pyproject.toml [Script: UPPER]"] == "echo upper"
+
+def test_pyproject_header_robustness():
+    """Verify that pyproject.toml sections with trailing comments and whitespace are recognized."""
+    content = b"""
+[tool.pdm.scripts] # comment
+test = "echo hello"
+
+[ tool.pdm.scripts.nested ] # another comment
+cmd = "pytest"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert len(results) == 2
+    assert "pyproject.toml [Script: test]" in scripts
+    assert scripts["pyproject.toml [Script: test]"] == "echo hello"
+    assert "pyproject.toml [Script: nested]" in scripts
+    assert scripts["pyproject.toml [Script: nested]"] == "pytest"


### PR DESCRIPTION
* **Type:** Bug Fix / New Coverage
* **What:** Updated the `pyproject.toml` parser in `gptscan.py` to correctly handle section headers with trailing comments and flexible whitespace using a robust regex. Added a new test case `test_pyproject_header_robustness` to `tests/test_pyproject_robustness.py`.
* **Why:** The previous `startswith`/`endswith` logic was fragile and failed to recognize valid TOML section headers that included comments or spaces (e.g., `[ tool.pdm.scripts ] # comment`), leading to missed scripts during scanning. This change ensures better reliability and coverage when scanning Python projects.

---
*PR created automatically by Jules for task [79376122134594732](https://jules.google.com/task/79376122134594732) started by @RainRat*