### PR TITLE
Fix premature exit when --clear-cache is used with scan targets

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6738,7 +6738,13 @@ def main():
         Config.save_cache()
         print("AI Analysis cache cleared.", file=sys.stderr)
         # If we ONLY wanted to clear cache, exit now.
-        if not any([args.target, args.path, args.stdin, args.import_results, args.files, args.env_vars]):
+        if not any([
+            args.target, args.path, args.stdin, args.import_results, args.files,
+            args.env_vars, args.file_list, args.git_changes, args.git_diff,
+            args.shell_profiles, args.shell_history, args.system_path,
+            args.running_processes, args.scheduled_tasks, args.startup_items,
+            args.audit
+        ]):
             sys.exit(0)
 
     Config.provider = args.provider


### PR DESCRIPTION
This PR fixes a logic bug in the `main()` function of `gptscan.py`. Previously, when the `--clear-cache` flag was used, the application would check a limited set of arguments to decide whether to exit early. This meant that if a user provided scan targets via flags like `--audit`, `--git-changes`, or `--shell-profiles`, the application would clear the cache and then exit without performing the requested scan.

The fix involves expanding the `any()` check to include all valid scan-triggering arguments, ensuring consistent behavior across all scanning modes when used in conjunction with `--clear-cache`.

**Changes:**
- Updated the early-exit condition in `main()` to include:
    - `args.file_list`
    - `args.git_changes`
    - `args.git_diff`
    - `args.shell_profiles`
    - `args.shell_history`
    - `args.system_path`
    - `args.running_processes`
    - `args.scheduled_tasks`
    - `args.startup_items`
    - `args.audit`

**Verification:**
- Created a reproduction script that runs `python gptscan.py --clear-cache --audit --cli --dry-run` and verified it proceeds to the scan.
- Ran the full test suite (`pytest`), and all 744 tests passed.

---
*PR created automatically by Jules for task [8395155697195761290](https://jules.google.com/task/8395155697195761290) started by @RainRat*