### PR TITLE
[TEST] Fix pyproject.toml multiline script parsing with trailing comments

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2829,13 +2829,21 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                             # Handle multiline strings
                             if command_val.startswith(('"""', "'''")):
                                 quote_type = command_val[:3]
-                                if not (command_val.endswith(quote_type) and len(command_val) >= 6):
+                                # Check if it also ends with it (possibly with a comment)
+                                # Finding the second occurrence of quote_type after the first 3 chars
+                                end_pos = command_val.find(quote_type, 3)
+                                if end_pos != -1:
+                                    command_val = command_val[:end_pos + 3]
+                                else:
                                     multiline_lines = [command_val]
                                     while i < len(lines):
                                         curr_line = lines[i]
                                         multiline_lines.append(curr_line)
                                         i += 1
-                                        if quote_type in curr_line:
+                                        end_pos = curr_line.find(quote_type)
+                                        if end_pos != -1:
+                                            # Truncate at closing quotes to ignore trailing comments
+                                            multiline_lines[-1] = curr_line[:end_pos + 3]
                                             break
                                     command_val = "\n".join(multiline_lines)
 

--- a/tests/test_pyproject_multiline_gap.py
+++ b/tests/test_pyproject_multiline_gap.py
@@ -40,3 +40,34 @@ hash-in-str = "echo #not-a-comment"
 
     assert "pyproject.toml [Script: hash-in-str]" in scripts
     assert scripts["pyproject.toml [Script: hash-in-str]"] == "echo #not-a-comment"
+
+def test_pyproject_multiline_with_trailing_comment():
+    """Verify that triple-quoted strings with trailing comments are parsed correctly."""
+    content = b"""
+[tool.pdm.scripts]
+test = \"\"\"echo hello\"\"\" # trailing comment
+next = "echo next"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert scripts["pyproject.toml [Script: test]"] == "echo hello"
+    assert scripts["pyproject.toml [Script: next]"] == "echo next"
+
+def test_pyproject_multiline_block_with_trailing_comment():
+    """Verify multiline block with closing quotes and comment on separate line."""
+    content = b"""
+[tool.pdm.scripts]
+test = '''
+echo line 1
+echo line 2
+''' # comment here
+next = "echo next"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "echo line 1" in scripts["pyproject.toml [Script: test]"]
+    assert "echo line 2" in scripts["pyproject.toml [Script: test]"]
+    assert "comment here" not in scripts["pyproject.toml [Script: test]"]
+    assert scripts["pyproject.toml [Script: next]"] == "echo next"


### PR DESCRIPTION
### Type
Bug Fix / New Coverage

### What
Fixed a bug in `gptscan.py` where `pyproject.toml` multiline scripts (triple-quoted strings) followed by inline comments on the same line as the closing quotes were incorrectly parsed. The parser now correctly identifies the closing quotes and ignores subsequent content on that line. Added regression tests in `tests/test_pyproject_multiline_gap.py`.

### Why
The previous manual TOML parsing logic failed to correctly identify the end of triple-quoted strings if a comment followed them on the same line. This resulted in the comment being included in the extracted command and, in some cases, the parser failing to correctly identify subsequent script definitions. This fix ensures more robust extraction of scripts from package manifests for security scanning.

---
*PR created automatically by Jules for task [13119625092441682362](https://jules.google.com/task/13119625092441682362) started by @RainRat*