### PR TITLE
[DOCS] Document default file size limit and how to adjust it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,7 @@ The scanner provides several ways to analyze and manage your results:
 You can tailor the scanner to your needs:
 *   **Exclusions:** Ignore specific files or folders by using **File > Manage Exclusions...** or by adding patterns to a `.gptscanignore` file.
 *   **Extensions:** Control which file types are scanned by using **File > Manage Extensions...** or by editing the `extensions.txt` file.
+*   **File Size:** The scanner skips files larger than 10MB during folder scans. You can adjust this limit in the **Scan Options** panel or by using the `--max-size` flag in the terminal. Files selected individually are always scanned, regardless of their size.
 
 ## Advanced Usage
 ### Training the Model


### PR DESCRIPTION
This PR adds missing information to the `readme.md` about the scanner's default file size limit.

*   **Type:** Documentation
*   **What:** Added a "**File Size**" section to the "**Customizing the Scanner**" part of the `readme.md`.
*   **Why:** Users need to know that the scanner skips files larger than 10MB during folder scans to maintain speed. The update explains how to change this limit using the GUI (**Scan Options**) or the CLI (`--max-size`) and clarifies that individually selected files are always scanned.

---
*PR created automatically by Jules for task [5987293031673734198](https://jules.google.com/task/5987293031673734198) started by @RainRat*