### PR TITLE
[UI/UX] Implement resizable panes in Result Details window

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5088,16 +5088,19 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
     ttk.Separator(main_frame, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=10)
 
+    paned_window = ttk.Panedwindow(main_frame, orient=tk.VERTICAL)
+    paned_window.pack(fill=tk.BOTH, expand=True, pady=5)
+
     # Analysis sections
-    analysis_frame = ttk.LabelFrame(main_frame, text="AI Analysis", padding=5)
+    analysis_frame = ttk.LabelFrame(paned_window, text="AI Analysis", padding=5)
     admin_label = ttk.Label(analysis_frame, text="Administrator Notes:", font=('TkDefaultFont', 9, 'bold'))
     admin_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
     user_label = ttk.Label(analysis_frame, text="End-User Notes:", font=('TkDefaultFont', 9, 'bold'))
     user_text = scrolledtext.ScrolledText(analysis_frame, height=5, wrap=tk.WORD)
 
     # Snippet section
-    snippet_frame = ttk.LabelFrame(main_frame, text="Code Snippet", padding=5)
-    snippet_frame.pack(fill=tk.BOTH, expand=True, pady=5)
+    snippet_frame = ttk.LabelFrame(paned_window, text="Code Snippet", padding=5)
+    paned_window.add(snippet_frame, weight=1)
 
     snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font=('Courier', 10), wrap=tk.NONE)
     snippet_text.pack(fill=tk.BOTH, expand=True)
@@ -5450,7 +5453,9 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
             gpt_conf_label.config(text="")
 
         if admin or user:
-            analysis_frame.pack(fill=tk.BOTH, expand=True, pady=5, before=snippet_frame)
+            if str(analysis_frame) not in paned_window.panes():
+                paned_window.insert(0, analysis_frame, weight=1)
+
             if admin:
                 admin_label.pack(anchor="w")
                 admin_text.config(state='normal')
@@ -5472,7 +5477,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
                 user_label.pack_forget()
                 user_text.pack_forget()
         else:
-            analysis_frame.pack_forget()
+            if str(analysis_frame) in paned_window.panes():
+                paned_window.forget(analysis_frame)
 
         load_display_code(path, line, snippet, silent_fallback=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,22 @@ class MockTk(MockFrame):
 class MockLabel(MockWidget):
     pass
 
+class MockPanedwindow(MockWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._panes = []
+    def add(self, child, **kwargs):
+        if child not in self._panes:
+            self._panes.append(child)
+    def insert(self, pos, child, **kwargs):
+        if child not in self._panes:
+            self._panes.insert(pos, child)
+    def forget(self, child):
+        if child in self._panes:
+            self._panes.remove(child)
+    def panes(self):
+        return self._panes
+
 class MockMenu(MockWidget):
     def add_command(self, *args, **kwargs): pass
     def add_separator(self, *args, **kwargs): pass
@@ -111,6 +127,7 @@ class MockTkModule:
         self.ttk.Entry = MagicMock
         self.ttk.Treeview = MagicMock
         self.ttk.Separator = MockWidget
+        self.ttk.Panedwindow = MockPanedwindow
         self.ttk.Menubutton = MockWidget
         self.ttk.Progressbar = MockWidget
         self.ttk.Spinbox = MockWidget


### PR DESCRIPTION
### Context
GUI (Tkinter)

### Problem
The "Result Details" window used fixed-size frames for "AI Analysis" and "Code Snippet". When the AI analysis was long or the code snippet was large, the user had to rely on independent scrollbars for each section. On small screens or when one section was significantly more important than the other, the static layout created friction as the user couldn't allocate more vertical space to the area they were currently focusing on.

### Solution
I replaced the static packing of the analysis and snippet frames with a vertical `ttk.Panedwindow`. This allows users to manually drag the separator between the two sections to adjust their relative sizes. The implementation also ensures that if AI data is missing for a particular result, the analysis pane is automatically removed from the paned window, giving the full space to the code snippet. This change improves flexibility and information density for power users while maintaining a clean, native look.

### Changes
- **gptscan.py**: Added `paned_window` to `view_details` and refactored `refresh_content` to manage its panes using `insert(0, ...)` and `forget()`.
- **tests/conftest.py**: Added `MockPanedwindow` class to the test environment to prevent regressions in existing UI tests.

---
*PR created automatically by Jules for task [9128783541443194682](https://jules.google.com/task/9128783541443194682) started by @RainRat*