### PR TITLE
[TEST] Add coverage and fix for YAML list multi-line block extraction

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3151,7 +3151,26 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                             list_match = re.match(r'^\s*-\s*(.*)', lines[j])
                             if list_match:
                                 cmd = list_match.group(1).strip()
-                                if cmd:
+                                if cmd in ('|', '>', '|-', '|+', '>-', '>+'):
+                                    # Multi-line block within list
+                                    block_lines = []
+                                    list_indent = len(lines[j]) - len(lines[j].lstrip())
+                                    j += 1
+                                    while j < len(lines):
+                                        if not lines[j].strip():
+                                            block_lines.append("")
+                                            j += 1
+                                            continue
+                                        inner_indent = len(lines[j]) - len(lines[j].lstrip())
+                                        if inner_indent <= list_indent:
+                                            break
+                                        # Strip indentation from block lines
+                                        block_lines.append(lines[j][list_indent+2:])
+                                        j += 1
+                                    if block_lines:
+                                        list_items.append("\n".join(block_lines))
+                                    continue
+                                elif cmd:
                                     list_items.append(cmd)
                                 j += 1
                             else:

--- a/tests/test_yaml_multiline_list.py
+++ b/tests/test_yaml_multiline_list.py
@@ -1,0 +1,61 @@
+import pytest
+from gptscan import unpack_content
+
+def test_yaml_multiline_block_in_list():
+    """Verify that multi-line blocks using '|' inside a YAML list are correctly extracted."""
+    yaml_content = b"""
+steps:
+  - name: Build
+    run:
+      - |
+        npm install
+        npm run build
+      - echo "Done"
+"""
+    results = list(unpack_content("workflow.yml", yaml_content))
+
+    # We expect 2 scripts extracted from the list under 'run'
+    # Actually, current logic joins list items with \n if they are strings.
+    # But if they are blocks, it might be different.
+
+    scripts = [r[1].decode('utf-8') for r in results]
+
+    # After my proposed fix, it should contain both
+    assert any('npm install\nnpm run build' in s for s in scripts)
+    assert any('echo "Done"' in s for s in scripts)
+
+def test_yaml_folded_block_in_list():
+    """Verify that folded blocks using '>' inside a YAML list are correctly extracted."""
+    yaml_content = b"""
+script:
+  - >
+    echo "This is a
+    long command"
+  - ls -la
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    scripts = [r[1].decode('utf-8') for r in results]
+
+    assert any('echo "This is a\nlong command"' in s for s in scripts)
+    assert any('ls -la' in s for s in scripts)
+
+def test_yaml_mixed_list_content():
+    """Verify a list with mixed single-line and multi-line items."""
+    yaml_content = b"""
+run:
+  - echo "start"
+  - |
+    line 1
+    line 2
+  - echo "end"
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    scripts = [r[1].decode('utf-8') for r in results]
+
+    assert 'echo "start"\nline 1\nline 2\necho "end"' in scripts or \
+           (any('echo "start"' in s for s in scripts) and \
+            any('line 1\nline 2' in s for s in scripts) and \
+            any('echo "end"' in s for s in scripts))
+    # Note: current implementation of list parsing in gptscan.py:
+    # it accumulates list items and joins them with \n.
+    # So we expect one snippet: 'echo "start"\nline 1\nline 2\necho "end"'


### PR DESCRIPTION
### PR Description

**Type:** New Coverage / Bug Fix

**What:**
This PR improves the robustness of the custom YAML parsing logic in `gptscan.py`. It specifically addresses a gap where multi-line blocks (using the `|` or `>` indicators) were not correctly extracted when they were items in a YAML list. 

Key changes:
1.  **Source Code (`gptscan.py`):** Updated the YAML list parsing loop in `unpack_content` to detect block indicators and consume the subsequent indented lines, stripping the appropriate level of indentation to maintain the script's integrity.
2.  **Test Suite (`tests/test_yaml_multiline_list.py`):** Introduced a new test file containing scenarios for literal blocks, folded blocks, and mixed list content (single-line and multi-line items) to verify the fix and prevent regressions.

**Why:**
Many CI/CD workflows (like GitHub Actions) use multi-line blocks within list items for the `run` or `script` keys. The previous implementation would either stop at the block indicator or fail to capture the indented content, resulting in incomplete security scans for these critical files. This fix ensures that such scripts are fully extracted and analyzed.

---
*PR created automatically by Jules for task [9639036719769982](https://jules.google.com/task/9639036719769982) started by @RainRat*