### PR TITLE
[TEST] Add support and coverage for Poe the Poet tasks in pyproject.toml

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2957,13 +2957,13 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                     header_match = re.match(r'^\[\s*([^\]]+)\s*\](?:\s*#.*)?$', line)
                     if header_match:
                         section = header_match.group(1).strip()
-                        # Flat script sections: [project.scripts], [tool.pdm.scripts], etc.
-                        if re.match(r'^(?:.*?\.)?scripts$', section, re.IGNORECASE) or \
+                        # Flat script sections: [project.scripts], [tool.pdm.scripts], [tool.poe.tasks], etc.
+                        if re.match(r'^(?:.*?\.)?(?:scripts|tasks)$', section, re.IGNORECASE) or \
                            section.lower() == 'tool.pdm.dev-dependencies':
                             in_script_section = True
                             current_nested_script = None
-                        # Nested script sections: [tool.pdm.scripts.test]
-                        elif match := re.match(r'^(?:.*?\.)?scripts\.(.+)$', section, re.IGNORECASE):
+                        # Nested script sections: [tool.pdm.scripts.test], [tool.poe.tasks.test]
+                        elif match := re.match(r'^(?:.*?\.)?(?:scripts|tasks)\.(.+)$', section, re.IGNORECASE):
                             in_script_section = True
                             current_nested_script = match.group(1).strip()
                         else:
@@ -3000,15 +3000,15 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                     command_val = "\n".join(multiline_lines)
 
                             if current_nested_script:
-                                # Inside a nested section like [tool.pdm.scripts.test]
-                                if script_key.lower() in ('cmd', 'shell', 'command', 'composite'):
+                                # Inside a nested section like [tool.pdm.scripts.test] or [tool.poe.tasks.test]
+                                if script_key.lower() in ('cmd', 'shell', 'command', 'composite', 'script', 'expr'):
                                     yield from yield_pyproject_scripts(current_nested_script, command_val)
                                     in_script_section = False
                             else:
-                                # Inside a flat section like [project.scripts]
+                                # Inside a flat section like [project.scripts] or [tool.poe.tasks]
                                 if command_val.startswith('{'):
                                     # Inline table
-                                    cmd_match = re.search(r'(?:cmd|command|shell|composite)\s*=\s*("[^"]*"|\'[^\']*\'|\[[^\]]*\])', command_val)
+                                    cmd_match = re.search(r'(?:cmd|command|shell|composite|script|expr)\s*=\s*("[^"]*"|\'[^\']*\'|\[[^\]]*\])', command_val)
                                     if cmd_match:
                                         yield from yield_pyproject_scripts(script_key, cmd_match.group(1).strip())
                                 else:

--- a/tests/test_pyproject_poe.py
+++ b/tests/test_pyproject_poe.py
@@ -1,0 +1,31 @@
+import pytest
+from gptscan import unpack_content
+
+def test_pyproject_poe_tasks_support():
+    """Verify that [tool.poe.tasks] in pyproject.toml is correctly extracted."""
+    content = b"""
+[tool.poe.tasks]
+test = "pytest"
+serve = { cmd = "python manage.py runserver" }
+expr_task = { expr = "sys.platform" }
+script_task = { script = "my_module:main" }
+
+[tool.poe.tasks.deep]
+shell = "echo deep"
+"""
+    snippets = list(unpack_content("pyproject.toml", content))
+    names = [s[0] for s in snippets]
+
+    assert "pyproject.toml [Script: test]" in names
+    assert "pyproject.toml [Script: serve]" in names
+    assert "pyproject.toml [Script: expr_task]" in names
+    assert "pyproject.toml [Script: script_task]" in names
+    assert "pyproject.toml [Script: deep]" in names
+
+    # Verify content
+    scripts = {s[0]: s[1].decode() for s in snippets}
+    assert scripts["pyproject.toml [Script: test]"] == "pytest"
+    assert scripts["pyproject.toml [Script: serve]"] == "python manage.py runserver"
+    assert scripts["pyproject.toml [Script: expr_task]"] == "sys.platform"
+    assert scripts["pyproject.toml [Script: script_task]"] == "my_module:main"
+    assert scripts["pyproject.toml [Script: deep]"] == "echo deep"


### PR DESCRIPTION
This change addresses a gap in the `pyproject.toml` parsing logic where "Poe the Poet" tasks were previously ignored.

- Modified `unpack_content` in `gptscan.py` to support `tasks` in section headers and `script`/`expr` keys.
- Added `tests/test_pyproject_poe.py` with comprehensive test cases for flat and nested Poe tasks.
- Verified that the new test passes and no regressions were introduced in existing manifest or CI scanning tests.

---
*PR created automatically by Jules for task [3776571021745497199](https://jules.google.com/task/3776571021745497199) started by @RainRat*