### PR TITLE
[UI/UX] Stabilize Result Details layout and improve typography consistency

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5297,7 +5297,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     header_frame.columnconfigure(1, weight=1)
 
     conf_frame = ttk.Frame(header_frame)
-    conf_frame.grid(row=2, column=0, columnspan=5, sticky="w", pady=(5, 0))
+    conf_frame.grid(row=2, column=0, columnspan=5, sticky="ew", pady=(5, 0))
+    conf_frame.columnconfigure(4, weight=1)
 
     ttk.Label(conf_frame, text="Local Threat:").grid(row=0, column=0, sticky="w")
     own_conf_label = ttk.Label(conf_frame, font=('TkDefaultFont', 9, 'bold'))
@@ -5329,7 +5330,7 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     snippet_frame = ttk.LabelFrame(paned_window, text="Code Snippet", padding=5)
     paned_window.add(snippet_frame, weight=1)
 
-    snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font=('Courier', 10), wrap=tk.NONE)
+    snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font='TkFixedFont', wrap=tk.NONE)
     snippet_text.pack(fill=tk.BOTH, expand=True)
     snippet_text.tag_configure("highlight", background="yellow", foreground="black")
 


### PR DESCRIPTION
### Context
GUI

### Problem
The "Result Details" metrics row (Local Threat, AI Threat, Detected Line) shifted horizontally whenever AI analysis data was missing or added, causing a distracting layout jump. Additionally, the code snippet used a hardcoded 'Courier' font, which is not optimal for all platforms.

### Solution
1. **Layout Stability:** Refactored the `conf_frame` grid in `view_details` to use `sticky="ew"` and added a weighted spacer (`columnconfigure(4, weight=1)`). This keeps the threat levels on the left and pins the "Detected Line" and "Risk Badge" to the right, maintaining a stable layout even when AI metrics are hidden.
2. **Typography Polish:** Updated the code snippet view to use the symbolic `'TkFixedFont'`, which automatically selects the best available monospaced font on the host operating system (e.g., Consolas, Menlo), improving readability and native feel.

---
*PR created automatically by Jules for task [17636758139890556757](https://jules.google.com/task/17636758139890556757) started by @RainRat*