### PR TITLE
[FEAT] Scan Git Configuration for dangerous settings

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1438,6 +1438,57 @@ def get_git_hooks_paths(path: str = ".") -> List[str]:
     return sorted(list(set(paths)))
 
 
+def get_git_config_snippets() -> List[Tuple[str, bytes]]:
+    """Identify potentially dangerous Git configuration settings (aliases, editors, etc.)."""
+    snippets = []
+    configs = [("--global", "Global Git Config")]
+
+    # Check if we are in a Git repository to include local config
+    try:
+        subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"], stderr=subprocess.DEVNULL)
+        configs.append(("--local", "Local Git Config"))
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    # Keys that are known to contain executable commands or script-like content
+    dangerous_patterns = [
+        r'^core\.editor$',
+        r'^core\.sshcommand$',
+        r'^core\.pager$',
+        r'^sequence\.editor$',
+        r'^credential\.helper$',
+        r'^diff\..*?\.command$',
+        r'^merge\..*?\.driver$',
+        r'^pager\.',
+    ]
+
+    for flag, label in configs:
+        try:
+            output = subprocess.check_output(
+                ["git", "config", flag, "--list"],
+                stderr=subprocess.PIPE,
+                universal_newlines=True
+            )
+            for line in output.splitlines():
+                if '=' in line:
+                    key, value = line.split('=', 1)
+                    key = key.strip()
+                    value = value.strip()
+                    # For aliases, if it starts with !, it's a shell command
+                    if key.lower().startswith('alias.') and value.startswith('!'):
+                        snippet = value[1:].strip()
+                        if snippet:
+                            snippets.append((f"{label} [Alias: {key[6:]}]", snippet.encode('utf-8')))
+                    elif any(re.match(pattern, key, re.IGNORECASE) for pattern in dangerous_patterns):
+                        # For other dangerous keys, the whole value is the command/script
+                        if value:
+                            snippets.append((f"{label} [{key}]", value.encode('utf-8')))
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            continue
+
+    return snippets
+
+
 def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the Git toplevel directory and the relative path of the target."""
     abs_path = os.path.abspath(path)
@@ -2163,6 +2214,18 @@ def scan_git_hooks_click():
         messagebox.showwarning("Git Hooks Error", f"Could not scan Git hooks: {e}")
 
 
+def scan_git_config_click():
+    """Scan potentially dangerous Git configuration settings."""
+    try:
+        snippets = get_git_config_snippets()
+        if snippets:
+            button_click(extra_snippets=snippets)
+        else:
+            messagebox.showinfo("Git Configuration", "No potentially dangerous Git configuration settings were found.")
+    except Exception as e:
+        messagebox.showwarning("Git Configuration Error", f"Could not scan Git configuration: {e}")
+
+
 def scan_git_revision_click():
     """Scan files changed in a specific Git revision."""
     try:
@@ -2309,6 +2372,7 @@ def scan_system_audit_click():
         all_snippets.extend(get_scheduled_task_commands())
         all_snippets.extend(get_startup_item_commands())
         all_snippets.extend(get_system_service_commands())
+        all_snippets.extend(get_git_config_snippets())
 
         if all_paths or all_snippets:
             _set_scan_target(all_paths)
@@ -6339,6 +6403,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click, accelerator="Ctrl+Shift+V")
     browse_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     browse_menu.add_command(label="Scan Git Hooks", command=scan_git_hooks_click, accelerator="Ctrl+Shift+G")
+    browse_menu.add_command(label="Scan Git Configuration", command=scan_git_config_click)
     browse_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
     browse_menu.add_command(label="System Audit", command=scan_system_audit_click, accelerator="Ctrl+Shift+I")
     browse_menu.add_command(label="Scan Shell Profiles", command=scan_shell_profiles_click, accelerator="Ctrl+Shift+B")
@@ -6808,6 +6873,8 @@ def main():
                "  python gptscan.py --audit --cli\n\n"
                "  # Scan local and global Git hooks\n"
                "  python gptscan.py --git-hooks --cli\n\n"
+               "  # Scan potentially dangerous Git configuration settings\n"
+               "  python gptscan.py --git-config --cli\n\n"
                "Note: Run the script from its own folder so it can find its data files.",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -6854,6 +6921,11 @@ def main():
         '--git-hooks',
         action='store_true',
         help='Scan local and global Git hooks.'
+    )
+    scan_group.add_argument(
+        '--git-config',
+        action='store_true',
+        help='Scan potentially dangerous Git configuration settings.'
     )
     scan_group.add_argument(
         '--all-files',
@@ -6988,7 +7060,7 @@ def main():
         # If we ONLY wanted to clear cache, exit now.
         if not any([
             args.target, args.path, args.stdin, args.import_results, args.files,
-            args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks,
+            args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
             args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
             args.system_services, args.audit
@@ -7072,7 +7144,10 @@ def main():
             for root_dir in git_roots:
                 scan_targets.extend(get_git_hooks_paths(root_dir))
 
-        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not extra_snippets:
+        if args.git_config:
+            extra_snippets.extend(get_git_config_snippets())
+
+        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not extra_snippets:
             # Default to current directory if no targets provided and NOT using git-changes
             scan_targets = ["."]
 
@@ -7185,6 +7260,7 @@ def main():
             extra_snippets.extend(get_scheduled_task_commands())
             extra_snippets.extend(get_startup_item_commands())
             extra_snippets.extend(get_system_service_commands())
+            extra_snippets.extend(get_git_config_snippets())
 
         threats = run_cli(
             scan_targets,

--- a/readme.md
+++ b/readme.md
@@ -61,8 +61,9 @@ Access these options from the **Browse** menu:
 *   **Scan Shell Profiles:** Scan your shell configuration files (.bashrc, .zshrc, etc.) and PowerShell profiles for dangerous aliases or functions (Ctrl+Shift+B).
 *   **Scan Git Diff:** Scan changes in your local project.
 *   **Scan Git Hooks:** Scan local and global Git hooks for dangerous scripts (Ctrl+Shift+G).
+*   **Scan Git Configuration:** Scan potentially dangerous Git configuration settings (aliases, editors, etc.).
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
-*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, and system services (Ctrl+Shift+I).
+*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, system services, and Git configuration (Ctrl+Shift+I).
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for dangerous one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially dangerous execution strings (Ctrl+Shift+K).
@@ -155,6 +156,11 @@ python3 gptscan.py --system-services --cli
 To scan all environment variables:
 ```bash
 python3 gptscan.py --env-vars --cli
+```
+
+To scan potentially dangerous Git configuration settings:
+```bash
+python3 gptscan.py --git-config --cli
 ```
 
 To scan all shell profiles and RC files:

--- a/tests/test_git_config_scanning.py
+++ b/tests/test_git_config_scanning.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import gptscan
+import subprocess
+
+def test_get_git_config_snippets(mocker):
+    # Mock subprocess.check_output to return specific git config output
+    def mock_check_output(cmd, **kwargs):
+        if cmd == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return b"true"
+        if cmd == ["git", "config", "--global", "--list"]:
+            return "alias.co=checkout\nalias.dangerous=!rm -rf /\ncore.editor=vim\nuser.name=Test"
+        if cmd == ["git", "config", "--local", "--list"]:
+            return "core.sshcommand=ssh -i /path/to/key\nmerge.tool=kdiff3"
+        return ""
+
+    mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+
+    snippets = gptscan.get_git_config_snippets()
+
+    # We expect:
+    # 1. Global Alias: dangerous -> rm -rf /
+    # 2. Global core.editor -> vim
+    # 3. Local core.sshcommand -> ssh -i /path/to/key
+    # Note: alias.co should be ignored because it doesn't start with !
+    # Note: user.name and merge.tool should be ignored as they are not in dangerous_patterns
+
+    assert len(snippets) == 3
+
+    snippet_names = [s[0] for s in snippets]
+    assert "Global Git Config [Alias: dangerous]" in snippet_names
+    assert "Global Git Config [core.editor]" in snippet_names
+    assert "Local Git Config [core.sshcommand]" in snippet_names
+
+    snippet_contents = [s[1] for s in snippets]
+    assert b"rm -rf /" in snippet_contents
+    assert b"vim" in snippet_contents
+    assert b"ssh -i /path/to/key" in snippet_contents
+
+def test_scan_git_config_click(mocker):
+    mocker.patch("gptscan.get_git_config_snippets", return_value=[("name", b"content")])
+    mock_button_click = mocker.patch("gptscan.button_click")
+
+    gptscan.scan_git_config_click()
+
+    mock_button_click.assert_called_once_with(extra_snippets=[("name", b"content")])
+
+def test_scan_git_config_click_empty(mocker):
+    mocker.patch("gptscan.get_git_config_snippets", return_value=[])
+    mock_messagebox = mocker.patch("tkinter.messagebox.showinfo")
+
+    gptscan.scan_git_config_click()
+
+    mock_messagebox.assert_called_once()
+    assert "No potentially dangerous Git configuration settings" in mock_messagebox.call_args[0][1]
+
+def test_system_audit_includes_git_config(mocker):
+    mocker.patch("gptscan.get_shell_profile_paths", return_value=[])
+    mocker.patch("gptscan.get_shell_history_paths", return_value=[])
+    mocker.patch("gptscan.get_system_path_directories", return_value=[])
+    mocker.patch("gptscan.get_ssh_config_paths", return_value=[])
+    mocker.patch("gptscan.get_system_service_paths", return_value=[])
+    mocker.patch("gptscan.get_git_hooks_paths", return_value=[])
+
+    mocker.patch("gptscan.get_running_process_commands", return_value=[])
+    mocker.patch("gptscan.get_environment_variable_snippets", return_value=[])
+    mocker.patch("gptscan.get_scheduled_task_commands", return_value=[])
+    mocker.patch("gptscan.get_startup_item_commands", return_value=[])
+    mocker.patch("gptscan.get_system_service_commands", return_value=[])
+
+    mocker.patch("gptscan.get_git_config_snippets", return_value=[("Git Config", b"Dangerous")])
+
+    mock_set_target = mocker.patch("gptscan._set_scan_target")
+    mock_button_click = mocker.patch("gptscan.button_click")
+
+    gptscan.scan_system_audit_click()
+
+    mock_button_click.assert_called_once()
+    _, kwargs = mock_button_click.call_args
+    snippets = kwargs["extra_snippets"]
+    assert ("Git Config", b"Dangerous") in snippets


### PR DESCRIPTION
### [FEAT] Scan Git Configuration for dangerous settings

**What:**
Added a new feature to scan Git configuration settings (global and local) for potentially dangerous entries. This includes custom aliases that execute shell commands (starting with `!`), as well as sensitive configuration keys like `core.editor`, `core.sshCommand`, `credential.helper`, `pager.*`, `diff.*.command`, and `merge.*.driver`. The feature is accessible via the CLI with the `--git-config` flag, through a new "Scan Git Configuration" option in the GUI's Browse menu, and is automatically included in the "System Audit" scan.

**Why:**
I noticed the codebase already includes specialized scans for Git hooks and Git diffs to identify malicious code. However, Git's own configuration is a powerful and often overlooked vector for persistence and code execution (e.g., through malicious aliases or custom editors). Adding Git configuration scanning creates immediate security value by auditing the environment for these common attack techniques, completing the suite of Git-related security checks.

**Changes:**
- **`gptscan.py`**:
    - Implemented `get_git_config_snippets()` to identify and extract dangerous configuration keys.
    - Added `scan_git_config_click()` to handle the new GUI action.
    - Updated `scan_system_audit_click()` and the CLI audit logic to include Git configuration in the comprehensive check.
    - Registered the `--git-config` CLI flag and updated help documentation.
    - Expanded the "Browse" menu in the GUI with the new scan option.
    - Ensured `--clear-cache` respects the new flag for early-exit logic.
- **`readme.md`**:
    - Documented the "Scan Git Configuration" feature in the GUI and CLI usage sections.
    - Updated the "System Audit" description to reflect the inclusion of Git configuration.
- **`tests/test_git_config_scanning.py`**:
    - Created a new test suite to verify the extraction logic, GUI integration, and System Audit coverage.

---
*PR created automatically by Jules for task [12740247939592900882](https://jules.google.com/task/12740247939592900882) started by @RainRat*