### PR TITLE
[TEST] Improve format_percent robustness and add unit test coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1738,7 +1738,7 @@ def parse_percent(val: str, default: float = -1.0) -> float:
 def format_percent(val: Any) -> str:
     """Format a numeric threat level (0-100) as a percentage string (e.g., 85 to "85%")."""
     try:
-        return "{:.0%}".format(int(val) / 100.)
+        return "{:.0%}".format(float(val) / 100.)
     except (ValueError, TypeError):
         return "Error"
 

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -1,7 +1,7 @@
 import tkinter.font
 import pytest
 from unittest.mock import MagicMock
-from gptscan import Config, load_file, parse_percent, get_effective_threat_level, adjust_newlines, sort_column
+from gptscan import Config, load_file, parse_percent, get_effective_threat_level, adjust_newlines, sort_column, format_percent
 
 
 # --- Config Tests ---
@@ -67,6 +67,23 @@ def test_load_file_permission_error_multi_line(tmp_path):
         assert result == []
     finally:
         f.chmod(0o644)
+
+# --- format_percent Tests ---
+
+@pytest.mark.parametrize("input_val, expected", [
+    (85, "85%"),
+    (85.5, "86%"),
+    ("85", "85%"),
+    ("85.5", "86%"),
+    (0, "0%"),
+    (100, "100%"),
+    (None, "Error"),
+    ("invalid", "Error"),
+    ("", "Error"),
+])
+def test_format_percent(input_val, expected):
+    assert format_percent(input_val) == expected
+
 
 # --- parse_percent Tests ---
 


### PR DESCRIPTION
This PR improves the robustness of the `format_percent` utility function and adds missing unit test coverage.

### Changes:
1.  **Bug Fix in `gptscan.py`**: Changed `int(val)` to `float(val)` in `format_percent`. This prevents `ValueError` when the input is a string representing a float (e.g., `"85.5"`), which is a common occurrence in AI-generated responses. It also ensures that numeric floats (e.g., `85.5`) are rounded correctly (to `"86%"`) instead of being truncated.
2.  **New Test Coverage**: Added a `test_format_percent` suite to `tests/test_config_and_utils.py` using `pytest.mark.parametrize`. These tests cover:
    *   Integer inputs (e.g., `85` -> `"85%"`)
    *   Float inputs (e.g., `85.5` -> `"86%"`)
    *   Numeric string inputs (e.g., `"85"` -> `"85%"`, `"85.5"` -> `"86%"`)
    *   Edge cases (e.g., `0`, `100`)
    *   Error cases (e.g., `None`, `"invalid"`, `""` -> `"Error"`)

### Why:
Identifying and fixing this gap improves the reliability of the AI analysis reporting, ensuring that users see accurate threat levels even when the model provides precise decimal values. The added tests ensure this core utility remains stable.

---
*PR created automatically by Jules for task [18245753890617433614](https://jules.google.com/task/18245753890617433614) started by @RainRat*