### PR TITLE
[DOCS] Add missing Scan Shell Profiles shortcut to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+V` | Scan Clipboard |
 | `Ctrl+Shift+D` | Scan Git Diff |
 | `Ctrl+Shift+G` | Scan Git Hooks |
+| `Ctrl+Shift+B` | Scan Shell Profiles |
 | `Ctrl+Shift+I` | System Audit |
 | `Ctrl+Shift+H` | Scan Shell History |
 | `Ctrl+Shift+P` | Scan System PATH |


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Keyboard Shortcuts section in readme.md.
* **Why:** Added the missing Ctrl+Shift+B shortcut for "Scan Shell Profiles" to the Keyboard Shortcuts table. This ensures the documentation is complete and consistent with the application's actual behavior, helping users discover and use this feature more efficiently.

---
*PR created automatically by Jules for task [14156649017865870417](https://jules.google.com/task/14156649017865870417) started by @RainRat*