### PR TITLE
[FIX] Fix TypeError in _set_scan_target when using Path objects

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -724,8 +724,8 @@ def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
 
     # Handle multiple paths or a single path string
     if isinstance(path, (list, tuple)):
-        # Join multiple targets with appropriate quoting
-        formatted_path = shlex.join(path)
+        # Join multiple targets with appropriate quoting, ensuring all are strings
+        formatted_path = shlex.join(str(p) for p in path)
     else:
         # For a single path, use quote if it's not a list, for safety
         formatted_path = shlex.quote(str(path))


### PR DESCRIPTION
* **What:** Modified `_set_scan_target` to convert all items in a list/tuple to strings before passing them to `shlex.join`.
* **Why:** `shlex.join` expects an iterable of strings. Passing `pathlib.Path` objects (which are commonly used throughout the codebase) was causing a `TypeError`. This fix ensures robustness when the GUI updates the scan target field with results from file collection or system audit functions. No breaking changes were introduced as string inputs remain unaffected.

---
*PR created automatically by Jules for task [14796665582580672429](https://jules.google.com/task/14796665582580672429) started by @RainRat*