### PR TITLE
[DOCS] Improve scanner customization guide in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,9 +223,12 @@ The scanner provides several ways to analyze and manage your results:
 
 ## Customizing the Scanner
 You can tailor the scanner to your needs:
-*   **Exclusions:** Ignore specific files or folders by using **File > Manage Exclusions...** or by adding patterns to a `.gptscanignore` file.
-*   **Extensions:** Control which file types are scanned by using **File > Manage Extensions...** or by editing the `extensions.txt` file.
-*   **File Size:** The scanner skips files larger than 10MB during folder scans. You can adjust this limit in the **Scan Options** panel or by using the `--max-size` flag in the terminal. Files selected individually are always scanned, regardless of their size.
+*   **Exclusions:** Ignore specific files or folders by using **File > Manage Exclusions...** or by adding patterns to a `.gptscanignore` file. In the terminal, use the `-e` or `--exclude` flag.
+*   **Extensions:** Control which file types are scanned by using **File > Manage Extensions...** or by editing the `extensions.txt` file. In the terminal, use the `--extensions` flag.
+*   **File Size:** The scanner skips files larger than 10MB during folder scans. You can adjust this limit in the **Scan Options** panel or by using the `--max-size` flag. Files you select individually are always scanned, regardless of their size.
+*   **Deep Scan:** Scan the entire file instead of just the beginning. This is more thorough but slower. Use the **Deep Scan** checkbox or the `-d` or `--deep` flag.
+*   **Scan All Files:** By default, the scanner only checks script-like files (like `.py` or `.js`). Use the **Scan All Files** checkbox or the `--all-files` flag to check every file.
+*   **Dry Run:** Preview which files would be scanned without actually checking them. Use the **Dry Run** checkbox or the `--dry-run` flag.
 
 ## Advanced Usage
 ### Training the Model


### PR DESCRIPTION
The "Customizing the Scanner" section in `readme.md` was improved to provide a more complete and accessible guide for users. 

Key improvements:
- Added documentation for missing features: **Deep Scan**, **Scan All Files**, and **Dry Run**.
- Included corresponding terminal flags (e.g., `-d`, `--all-files`, `--dry-run`) for all customization options to assist command-line users.
- Refined existing entries for Exclusions, Extensions, and File Size to ensure consistent formatting and clear instructions.
- Adhered to style guidelines by using short sentences, active voice, and avoiding technical jargon where possible.

These changes make the scanner's advanced options more discoverable and easier to use across different interfaces.

---
*PR created automatically by Jules for task [17358484609774824838](https://jules.google.com/task/17358484609774824838) started by @RainRat*