### PR TITLE
Fix logic bug in argument validation for --clear-cache

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -7190,7 +7190,7 @@ def main():
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
             args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
-            args.system_services, args.audit
+            args.system_services, args.audit, args.modified
         ]):
             sys.exit(0)
 


### PR DESCRIPTION
* **What:** Updated the early-exit condition for the `--clear-cache` flag in `main()` to include `args.modified`.
* **Why:** This ensures that combining `--clear-cache` with the `--modified` scan flag correctly proceeds to execution instead of terminating prematurely. No breaking changes were introduced, and all existing tests pass.

---
*PR created automatically by Jules for task [9432596736181940365](https://jules.google.com/task/9432596736181940365) started by @RainRat*