### PR TITLE
[UI/UX] Add presets for "Scan Recently Modified" feature

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2396,9 +2396,11 @@ def scan_system_services_click():
         messagebox.showwarning("System Services Error", f"Could not scan system services: {e}")
 
 
-def scan_recently_modified_click():
+def scan_recently_modified_click(duration_str: Optional[str] = None):
     """Scan files modified within a user-specified duration."""
-    duration_str = simpledialog.askstring("Scan Recently Modified", "Enter duration (e.g., 24h, 1h, 7d):", initialvalue="24h")
+    if duration_str is None:
+        duration_str = simpledialog.askstring("Scan Recently Modified", "Enter duration (e.g., 24h, 1h, 7d):", initialvalue="24h")
+
     if duration_str:
         duration = parse_duration(duration_str)
         if duration is None:
@@ -6515,7 +6517,13 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")
     browse_menu.add_command(label="Scan Folder...", command=browse_dir_click)
-    browse_menu.add_command(label="Scan Recently Modified...", command=scan_recently_modified_click)
+    recent_menu = tk.Menu(browse_menu, tearoff=0)
+    recent_menu.add_command(label="Last Hour", command=lambda: scan_recently_modified_click("1h"))
+    recent_menu.add_command(label="Last 24 Hours", command=lambda: scan_recently_modified_click("24h"))
+    recent_menu.add_command(label="Last 7 Days", command=lambda: scan_recently_modified_click("7d"))
+    recent_menu.add_separator()
+    recent_menu.add_command(label="Custom...", command=lambda: scan_recently_modified_click())
+    browse_menu.add_cascade(label="Scan Recently Modified", menu=recent_menu)
     browse_menu.add_separator()
     browse_menu.add_command(label="Scan URL...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)


### PR DESCRIPTION
Improved the usability of the "Scan Recently Modified" feature by introducing common presets ('Last Hour', 'Last 24 Hours', 'Last 7 Days') in a cascading sub-menu within the 'Browse' menu. This change reduces friction for users by eliminating the need to manually type duration strings for common scan scenarios, while still allowing custom input via a 'Custom...' option.

The implementation is backward-compatible and follows the existing design patterns in the codebase. Tests were run to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [10484199362210429433](https://jules.google.com/task/10484199362210429433) started by @RainRat*