### PR TITLE
[DOCS] Clarify Deep Scan and default scan behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,7 @@ You can tailor the scanner to your needs:
 *   **Exclusions:** Ignore specific files or folders by using **File > Manage Exclusions...** or by adding patterns to a `.gptscanignore` file. In the terminal, use the `-e` or `--exclude` flag.
 *   **Extensions:** Control which file types are scanned by using **File > Manage Extensions...** or by editing the `extensions.txt` file. In the terminal, use the `--extensions` flag.
 *   **File Size:** The scanner skips files larger than 10MB during folder scans. You can adjust this limit in the **Scan Options** panel or by using the `--max-size` flag. Files you select individually are always scanned, regardless of their size.
-*   **Deep Scan:** Scan the entire file instead of just the beginning. This is more thorough but slower. Use the **Deep Scan** checkbox or the `-d` or `--deep` flag.
+*   **Deep Scan:** Scan the entire file instead of just the beginning and end. This is more thorough but slower. Use the **Deep Scan** checkbox or the `-d` or `--deep` flag.
 *   **Scan All Files:** By default, the scanner only checks script-like files (like `.py` or `.js`). Use the **Scan All Files** checkbox or the `--all-files` flag to check every file.
 *   **Dry Run:** Preview which files would be scanned without actually checking them. Use the **Dry Run** checkbox or the `--dry-run` flag.
 


### PR DESCRIPTION
**PR Title:** [DOCS] Clarify Deep Scan and default scan behavior
**Description:**
* **Type:** Documentation
* **What:** Updated the "Deep Scan" entry in the "Customizing the Scanner" section of `readme.md`.
* **Why:** The previous description implied that the default scan only checked the beginning of files. Clarifying that it checks both the beginning and end provides a more accurate representation of the tool's efficiency and coverage.

---
*PR created automatically by Jules for task [2067544160949093849](https://jules.google.com/task/2067544160949093849) started by @RainRat*