### PR TITLE
Consolidate core scanning logic and improve threat precision

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3757,7 +3757,7 @@ def scan_files(
 
     def handle_scan_result(path: str, maxconf: float, max_window_bytes: bytes, line_num: Union[int, str], full_content: Optional[str] = None, force: bool = False) -> Generator[Tuple[str, Any], None, None]:
         if maxconf >= 0:
-            percent = format_percent(int(maxconf * 100))
+            percent = format_percent(maxconf * 100.0)
             snippet = ''.join(map(chr, max_window_bytes)).strip()
             cleaned_snippet = _clean_snippet_for_ai(snippet)
 
@@ -3788,6 +3788,55 @@ def scan_files(
                         line_num,
                     )
                 )
+
+    def _scan_fh(fh, name: str, size: int, is_virtual: bool = False) -> Generator[Tuple[str, Any], None, None]:
+        maxconf = -1.0
+        max_window_bytes = b""
+        max_offset = 0
+        hits_found = 0
+        full_bytes = None
+        decoded_content = None
+
+        if is_virtual:
+            curr_pos = fh.tell()
+            fh.seek(0)
+            full_bytes = fh.read()
+            fh.seek(curr_pos)
+            decoded_content = full_bytes.decode('utf-8', errors='ignore')
+
+        for offset, window in iter_windows(fh, size, deep_scan):
+            if cancel_event.is_set():
+                break
+            result, padded_bytes = predict_window(window)
+            if result > maxconf:
+                maxconf = result
+                max_window_bytes = padded_bytes
+                max_offset = offset
+
+            if result >= threshold_val:
+                hits_found += 1
+                if not is_virtual and full_bytes is None:
+                    curr_pos = fh.tell()
+                    fh.seek(0)
+                    full_bytes = fh.read()
+                    fh.seek(curr_pos)
+
+                line_num = full_bytes[:offset].count(b'\n') + 1
+                yield from handle_scan_result(name, result, padded_bytes, line_num, full_content=decoded_content)
+
+        if not cancel_event.is_set() and hits_found == 0:
+            if is_virtual:
+                line_num = full_bytes[:max_offset].count(b'\n') + 1
+            else:
+                line_num = 1
+                try:
+                    curr_pos = fh.tell()
+                    fh.seek(0)
+                    line_num = fh.read(max_offset).count(b'\n') + 1
+                    fh.seek(curr_pos)
+                except Exception:
+                    pass
+            yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content, force=True)
 
     for file_path in file_list:
         if cancel_event.is_set():
@@ -3848,62 +3897,23 @@ def scan_files(
                     '-',
                 )
             )
-        else:
-            print(file_path, file=sys.stderr)
-            if file_size is not None:
-                maxconf = -1.0
-                max_window_bytes = b""
-                max_offset = 0
-                hits_found = 0
-                file_content_for_lines = None
-                error_message: Optional[str] = None
-
-                try:
-                    with open(file_path, 'rb') as f:
-                        for offset, window in iter_windows(f, file_size, deep_scan):
-                            if cancel_event.is_set():
-                                break
-                            print("Scanning at:", offset if offset > 0 else 0, file=sys.stderr)
-                            result, padded_bytes = predict_window(window)
-                            if result > maxconf:
-                                maxconf = result
-                                max_window_bytes = padded_bytes
-                                max_offset = offset
-
-                            if result >= threshold_val:
-                                hits_found += 1
-                                if file_content_for_lines is None:
-                                    curr_pos = f.tell()
-                                    f.seek(0)
-                                    file_content_for_lines = f.read()
-                                    f.seek(curr_pos)
-                                line_num = file_content_for_lines[:offset].count(b'\n') + 1
-                                yield from handle_scan_result(str(file_path), result, padded_bytes, line_num)
-                except OSError as err:
-                    error_message = f"Error reading file: {err}"
-
-                if error_message is not None:
-                    yield (
-                        'result',
-                        (
-                            str(file_path),
-                            'Error',
-                            '',
-                            '',
-                            '',
-                            error_message,
-                            '-',
-                        )
+        elif file_size is not None:
+            try:
+                with open(file_path, 'rb') as f:
+                    yield from _scan_fh(f, str(file_path), file_size, is_virtual=False)
+            except OSError as err:
+                yield (
+                    'result',
+                    (
+                        str(file_path),
+                        'Error',
+                        '',
+                        '',
+                        '',
+                        f"Error reading file: {err}",
+                        '-',
                     )
-                elif hits_found == 0:
-                    # Calculate line number for best hit
-                    line_num = 1
-                    try:
-                        with open(file_path, 'rb') as f:
-                            line_num = f.read(max_offset).count(b'\n') + 1
-                    except Exception:
-                        pass
-                    yield from handle_scan_result(str(file_path), maxconf, max_window_bytes, line_num, force=True)
+                )
 
     for name, content in extra_snippets:
         if cancel_event.is_set():
@@ -3930,30 +3940,8 @@ def scan_files(
                 )
             )
         else:
-            maxconf = -1.0
-            max_window_bytes = b""
-            max_offset = 0
-            hits_found = 0
-            decoded_content = content.decode('utf-8', errors='ignore')
             with io.BytesIO(content) as f:
-                for offset, window in iter_windows(f, file_size, deep_scan):
-                    if cancel_event.is_set():
-                        break
-                    result, padded_bytes = predict_window(window)
-                    if result > maxconf:
-                        maxconf = result
-                        max_window_bytes = padded_bytes
-                        max_offset = offset
-
-                    if result >= threshold_val:
-                        hits_found += 1
-                        line_num = content[:offset].count(b'\n') + 1
-                        yield from handle_scan_result(name, result, padded_bytes, line_num, full_content=decoded_content)
-
-            if hits_found == 0:
-                # Calculate line number for best hit
-                line_num = content[:max_offset].count(b'\n') + 1
-                yield from handle_scan_result(name, maxconf, max_window_bytes, line_num, full_content=decoded_content, force=True)
+                yield from _scan_fh(f, name, file_size, is_virtual=True)
 
     if cancel_event.is_set():
         return


### PR DESCRIPTION
This change addresses code duplication and minor logic bugs in `gptscan.py`.

### Changes:
- **Duplication Removal:** The logic for iterating over file windows, calling the prediction model, and handling results was duplicated for both physical files and in-memory snippets. I extracted this into a nested `_scan_fh` helper within `scan_files`.
- **Logic Bug Fix:** Updated the threat level percentage calculation to use float multiplication (`maxconf * 100.0`) instead of integer truncation, ensuring more accurate reporting in the UI and reports.
- **Code Hygiene:** Removed redundant `print` statements that were cluttering `stderr` during scans.

### Safety:
- The `_scan_fh` helper maintains memory efficiency by lazy-loading file content for local files only when a hit is detected.
- Verified that all 18 core scanning tests pass.
- No breaking changes to external CLI or GUI behavior.

---
*PR created automatically by Jules for task [17387529301266352633](https://jules.google.com/task/17387529301266352633) started by @RainRat*