### PR TITLE
[DOCS] Clarify scanning strategy and model constraints in iter_windows

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3547,10 +3547,15 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
 
 
 def iter_windows(fh, size: int, deep_scan: bool, maxlen: Optional[int] = None) -> Generator[Tuple[int, bytes], None, None]:
-    """Yield file chunks for scanning.
+    """Yield file chunks for the local scanner.
 
-    Balance speed and thoroughness by checking the beginning and end of files
-    where script headers and dangerous payloads are usually found.
+    By default, this function only reads the beginning and end of a file.
+    This approach is fast and effective because most dangerous payloads and
+    script headers are found in these locations. If deep_scan is True, the
+    function reads the entire file instead.
+
+    The window size defaults to 1024 bytes (maxlen) to match the input
+    requirements of the pre-trained scripts.h5 model.
     """
     if maxlen is None:
         maxlen = Config.MAXLEN


### PR DESCRIPTION
**PR Title:** [DOCS] Clarify scanning strategy and model constraints in iter_windows 
**Description:** 
* **Type:** Code Comments 
* **What:** Updated the `iter_windows` function's docstring in `gptscan.py`. 
* **Why:** Explained why the scanner defaults to checking only the start and end of files (speed/relevance) and documented the 1024-byte window size as a requirement of the pre-trained AI model.

---
*PR created automatically by Jules for task [3727045725442823968](https://jules.google.com/task/3727045725442823968) started by @RainRat*