### PR TITLE
[UI/UX] Standardize filter bar clear button and improve focus workflow

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6696,9 +6696,10 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     def clear_filter():
         filter_var.set("")
         _apply_filter()
+        filter_entry.focus_set()
 
-    clear_filter_btn = ttk.Button(filter_frame, text="Clear", width=8, command=clear_filter)
-    clear_filter_btn.grid(row=0, column=2, padx=(5, 10), ipady=5)
+    clear_filter_btn = ttk.Button(filter_frame, text="×", width=3, command=clear_filter)
+    clear_filter_btn.grid(row=0, column=2, padx=(0, 5))
     bind_hover_message(clear_filter_btn, "Clear the filter.")
 
     ttk.Separator(filter_frame, orient=tk.VERTICAL).grid(row=0, column=3, sticky="ns", padx=10)


### PR DESCRIPTION
This improvement standardizes the Filter Bar's "Clear" button in the GUI to match the primary Scan Target's "Clear" button.

Key changes:
1.  **Friction Reduction:** Updated the `clear_filter` function to automatically return focus to the `filter_entry` field. This allows users to immediately type a new filter after clearing the previous one without needing an extra click.
2.  **Consistency & Clarity:** Changed the button label from "Clear" to the symbolic "×" and reduced its width to 3. This matches the established pattern used for the scan target path input, creating a more cohesive and professional "stock" look.
3.  **Alignment:** Adjusted the grid padding to ensure the new compact button aligns perfectly with the filter entry and surrounding elements.

These changes adhere to the "Invisible Design" principle by making common actions more efficient and the interface more consistent without adding unnecessary decoration.

---
*PR created automatically by Jules for task [10065477348378910316](https://jules.google.com/task/10065477348378910316) started by @RainRat*