### PR TITLE
[FEAT] Scan Installed Python Packages

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1200,6 +1200,28 @@ def get_running_process_commands() -> List[Tuple[str, bytes]]:
     return processes
 
 
+def get_python_package_paths() -> List[str]:
+    """Identify site-packages directories for the current Python environment."""
+    import site
+    paths = []
+
+    try:
+        # Global site-packages
+        if hasattr(site, 'getsitepackages'):
+            for p in site.getsitepackages():
+                if os.path.exists(p):
+                    paths.append(p)
+
+        # User site-packages
+        user_site = site.getusersitepackages()
+        if user_site and os.path.exists(user_site):
+            paths.append(user_site)
+    except Exception:
+        pass
+
+    return sorted(list(set(paths)))
+
+
 def get_system_service_paths() -> List[str]:
     """Identify common systemd service and user service configuration files."""
     paths = []
@@ -2369,6 +2391,19 @@ def scan_scheduled_tasks_click():
         messagebox.showwarning("Scheduled Tasks Error", f"Could not scan scheduled tasks: {e}")
 
 
+def scan_python_packages_click():
+    """Scan all installed Python packages in site-packages."""
+    try:
+        paths = get_python_package_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Python Packages", "No site-packages directories were found.")
+    except Exception as e:
+        messagebox.showwarning("Python Packages Error", f"Could not scan Python packages: {e}")
+
+
 def scan_startup_items_click():
     """Scan all system startup items and LaunchAgents."""
     try:
@@ -2429,6 +2464,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_ssh_config_paths())
     all_paths.extend(get_system_service_paths())
     all_paths.extend(get_git_hooks_paths())
+    all_paths.extend(get_python_package_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6502,7 +6538,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6531,6 +6567,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan System PATH", command=scan_system_path_click, accelerator="Ctrl+Shift+P")
     browse_menu.add_command(label="Scan Running Processes", command=scan_running_processes_click, accelerator="Ctrl+Shift+K")
     browse_menu.add_command(label="Scan Environment Variables", command=scan_env_vars_click, accelerator="Ctrl+Shift+N")
+    browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click)
     browse_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     browse_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     browse_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
@@ -7111,6 +7148,11 @@ def main():
         help='Scan all non-empty environment variables.'
     )
     scan_group.add_argument(
+        '--python-packages',
+        action='store_true',
+        help='Scan all installed Python packages in site-packages.'
+    )
+    scan_group.add_argument(
         '--audit',
         action='store_true',
         help='Perform a comprehensive system audit scan.'
@@ -7374,6 +7416,13 @@ def main():
                 extra_snippets.extend(snippets)
             else:
                 print("No non-empty environment variables were found.", file=sys.stderr)
+
+        if args.python_packages:
+            package_paths = get_python_package_paths()
+            if package_paths:
+                scan_targets.extend(package_paths)
+            else:
+                print("No site-packages directories were found.", file=sys.stderr)
 
         if args.audit:
             paths, snippets = get_system_audit_data()

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Access these options from the **Browse** menu:
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially dangerous execution strings (Ctrl+Shift+K).
 *   **Scan Environment Variables:** Scan all non-empty environment variables for suspicious scripts or commands (Ctrl+Shift+N).
+*   **Scan Python Packages:** Scan all installed Python packages in your site-packages directories for malicious code.
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous persistence (Ctrl+Shift+T).
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
@@ -170,6 +171,11 @@ python3 gptscan.py --system-services --cli
 To scan all environment variables:
 ```bash
 python3 gptscan.py --env-vars --cli
+```
+
+To scan all installed Python packages:
+```bash
+python3 gptscan.py --python-packages --cli
 ```
 
 To scan potentially dangerous Git configuration settings:

--- a/tests/test_python_packages_scan.py
+++ b/tests/test_python_packages_scan.py
@@ -1,0 +1,44 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mocking modules that might not be available or are not needed for this unit test
+sys.modules['tensorflow'] = MagicMock()
+sys.modules['keras'] = MagicMock()
+sys.modules['keras.models'] = MagicMock()
+
+import gptscan
+
+def test_get_python_package_paths():
+    with patch('site.getsitepackages') as mock_getsite:
+        with patch('site.getusersitepackages') as mock_getuser:
+            with patch('os.path.exists') as mock_exists:
+                mock_getsite.return_value = ['/global/site-packages']
+                mock_getuser.return_value = '/user/site-packages'
+                mock_exists.side_effect = lambda p: p in ['/global/site-packages', '/user/site-packages']
+
+                paths = gptscan.get_python_package_paths()
+                assert '/global/site-packages' in paths
+                assert '/user/site-packages' in paths
+
+def test_system_audit_integration():
+    with patch('gptscan.get_python_package_paths') as mock_get_pkg:
+        mock_get_pkg.return_value = ['/fake/site-packages']
+        paths, snippets = gptscan.get_system_audit_data()
+        assert '/fake/site-packages' in paths
+
+def test_cli_python_packages_flag():
+    with patch('gptscan.get_python_package_paths') as mock_get_pkg:
+        with patch('gptscan.run_cli') as mock_run_cli:
+            mock_get_pkg.return_value = ['/fake/site-packages']
+
+            # Simulate CLI call
+            test_args = ['gptscan.py', '--python-packages', '--cli']
+            with patch.object(sys, 'argv', test_args):
+                 gptscan.main()
+
+            assert mock_get_pkg.called
+            # Verify that the package path was added to scan_targets passed to run_cli
+            args, kwargs = mock_run_cli.call_args
+            assert '/fake/site-packages' in args[0]


### PR DESCRIPTION
This PR adds a new feature to the GPT Virus Scanner: **Scan Installed Python Packages**.

### Technical Description
- **Backend:** Added `get_python_package_paths()` which uses the standard `site` module to reliably find global and user-level `site-packages` directories.
- **System Audit:** The existing `System Audit` feature (and `--audit` flag) now automatically includes all identified Python package directories in its comprehensive check.
- **CLI:** Introduced a new `--python-packages` flag to allow targeted scanning of the Python environment's dependencies from the terminal.
- **GUI:** Added a new "Scan Python Packages" command to the "Browse" menu. It follows the existing UX pattern of immediate scan execution upon selection.
- **Documentation:** Updated the `readme.md` with descriptions and usage examples for both CLI and GUI.
- **Testing:** Added `tests/test_python_packages_scan.py` to ensure core logic and CLI integration work as expected.

### Rationale
While the tool was already adept at scanning local scripts and system-level configurations, it lacked a direct utility for auditing the current Python environment's dependencies. With the increasing prevalence of supply-chain attacks targeting package repositories (e.g., PyPI typosquatting), being able to quickly scan `site-packages` for suspicious code is a logical and highly valuable extension of a security scanning tool designed for developers.

This feature is zero-configuration and follows the existing design patterns of the codebase.

---
*PR created automatically by Jules for task [17332069452797532076](https://jules.google.com/task/17332069452797532076) started by @RainRat*