### PR TITLE
[Logic Bug] Improve threat level precision in scan results

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3757,7 +3757,7 @@ def scan_files(
 
     def handle_scan_result(path: str, maxconf: float, max_window_bytes: bytes, line_num: Union[int, str], full_content: Optional[str] = None, force: bool = False) -> Generator[Tuple[str, Any], None, None]:
         if maxconf >= 0:
-            percent = format_percent(int(maxconf * 100))
+            percent = format_percent(maxconf * 100.0)
             snippet = ''.join(map(chr, max_window_bytes)).strip()
             cleaned_snippet = _clean_snippet_for_ai(snippet)
 


### PR DESCRIPTION
* **What:** Removed the `int()` truncation when calculating the confidence percentage in the `handle_scan_result` function.
* **Why:** This ensures that the raw float value from the model is passed to `format_percent`, allowing for more precise threat level reporting (e.g., 85.5% instead of being truncated to 85%). This is a non-breaking change that improves data fidelity.

---
*PR created automatically by Jules for task [7315917781923190535](https://jules.google.com/task/7315917781923190535) started by @RainRat*