### PR TITLE
[UI/UX] Add presets for Scan Recently Modified in the GUI

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2396,9 +2396,10 @@ def scan_system_services_click():
         messagebox.showwarning("System Services Error", f"Could not scan system services: {e}")
 
 
-def scan_recently_modified_click():
+def scan_recently_modified_click(duration_str: Optional[str] = None):
     """Scan files modified within a user-specified duration."""
-    duration_str = simpledialog.askstring("Scan Recently Modified", "Enter duration (e.g., 24h, 1h, 7d):", initialvalue="24h")
+    if duration_str is None:
+        duration_str = simpledialog.askstring("Scan Recently Modified", "Enter duration (e.g., 24h, 1h, 7d):", initialvalue="24h")
     if duration_str:
         duration = parse_duration(duration_str)
         if duration is None:
@@ -6515,7 +6516,15 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")
     browse_menu.add_command(label="Scan Folder...", command=browse_dir_click)
-    browse_menu.add_command(label="Scan Recently Modified...", command=scan_recently_modified_click)
+
+    recent_menu = tk.Menu(browse_menu, tearoff=0)
+    recent_menu.add_command(label="Last Hour", command=lambda: scan_recently_modified_click("1h"))
+    recent_menu.add_command(label="Last 24 Hours", command=lambda: scan_recently_modified_click("24h"))
+    recent_menu.add_command(label="Last 7 Days", command=lambda: scan_recently_modified_click("7d"))
+    recent_menu.add_separator()
+    recent_menu.add_command(label="Custom...", command=scan_recently_modified_click)
+    browse_menu.add_cascade(label="Scan Recently Modified", menu=recent_menu)
+
     browse_menu.add_separator()
     browse_menu.add_command(label="Scan URL...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)

--- a/tests/test_scan_recently_modified_logic.py
+++ b/tests/test_scan_recently_modified_logic.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from gptscan import scan_recently_modified_click
+
+def test_scan_recently_modified_click_no_arg(monkeypatch):
+    # Mock simpledialog.askstring to return '1h'
+    mock_askstring = MagicMock(return_value='1h')
+    monkeypatch.setattr('gptscan.simpledialog.askstring', mock_askstring)
+
+    # Mock button_click to verify it's called
+    mock_button_click = MagicMock()
+    monkeypatch.setattr('gptscan.button_click', mock_button_click)
+
+    # Mock time.time
+    mock_time = MagicMock(return_value=1000000.0)
+    monkeypatch.setattr('time.time', mock_time)
+
+    scan_recently_modified_click()
+
+    mock_askstring.assert_called_once()
+    mock_button_click.assert_called_once()
+    # 1h = 3600s. 1000000 - 3600 = 996400
+    assert mock_button_click.call_args[1]['modified_since'] == 996400.0
+
+def test_scan_recently_modified_click_with_arg(monkeypatch):
+    # Mock simpledialog.askstring - should NOT be called
+    mock_askstring = MagicMock()
+    monkeypatch.setattr('gptscan.simpledialog.askstring', mock_askstring)
+
+    # Mock button_click
+    mock_button_click = MagicMock()
+    monkeypatch.setattr('gptscan.button_click', mock_button_click)
+
+    # Mock time.time
+    mock_time = MagicMock(return_value=1000000.0)
+    monkeypatch.setattr('time.time', mock_time)
+
+    scan_recently_modified_click("24h")
+
+    mock_askstring.assert_not_called()
+    mock_button_click.assert_called_once()
+    # 24h = 86400s. 1000000 - 86400 = 913600
+    assert mock_button_click.call_args[1]['modified_since'] == 913600.0
+
+def test_scan_recently_modified_click_invalid_duration(monkeypatch):
+    # Mock simpledialog.askstring
+    mock_askstring = MagicMock(return_value='invalid')
+    monkeypatch.setattr('gptscan.simpledialog.askstring', mock_askstring)
+
+    # Mock messagebox.showerror
+    mock_showerror = MagicMock()
+    monkeypatch.setattr('gptscan.messagebox.showerror', mock_showerror)
+
+    # Mock button_click - should NOT be called
+    mock_button_click = MagicMock()
+    monkeypatch.setattr('gptscan.button_click', mock_button_click)
+
+    scan_recently_modified_click()
+
+    mock_showerror.assert_called_once()
+    mock_button_click.assert_not_called()


### PR DESCRIPTION
This PR improves the usability of the "Scan Recently Modified" feature by introducing a cascading menu with common presets.

**Context:** GUI
**Problem:** The user previously had to manually type a duration string (e.g., "24h") every time they wanted to scan recently modified files, creating unnecessary friction for the most common use cases.
**Solution:** I transformed the "Scan Recently Modified..." command into a cascading menu that offers quick selection for "Last Hour", "Last 24 Hours", and "Last 7 Days". A "Custom..." option remains available for users who need a specific timeframe. This change significantly reduces the keystrokes required for the most frequent tasks while maintaining full flexibility.

**Changes:**
- Updated `scan_recently_modified_click` in `gptscan.py` to support programmatic duration passing.
- Updated `create_gui` in `gptscan.py` to implement the new menu structure.
- Added `tests/test_scan_recently_modified_logic.py` to verify the new logic.

---
*PR created automatically by Jules for task [11562521867068157062](https://jules.google.com/task/11562521867068157062) started by @RainRat*