### PR TITLE
[FEAT] Scan Installed Python Packages

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6,6 +6,7 @@ import html
 import io
 import json
 import plistlib
+import site
 import os
 import queue
 import re
@@ -1227,6 +1228,42 @@ def get_system_service_paths() -> List[str]:
     return sorted(list(set(paths)))
 
 
+def get_python_package_paths() -> List[str]:
+    """Identify all directories containing installed Python packages (site-packages)."""
+    paths = []
+    # 1. Standard site-packages
+    if hasattr(site, 'getsitepackages'):
+        try:
+            paths.extend(site.getsitepackages())
+        except Exception:
+            pass
+
+    # 2. User site-packages
+    if hasattr(site, 'getusersitepackages'):
+        try:
+            paths.append(site.getusersitepackages())
+        except Exception:
+            pass
+
+    # 3. Fallback/Environment-specific paths from sys.path
+    for p in sys.path:
+        if 'site-packages' in p:
+            paths.append(p)
+
+    # Filter out non-existent directories and deduplicate
+    unique_paths = []
+    seen = set()
+    for p in paths:
+        if not p:
+            continue
+        abs_p = os.path.abspath(p)
+        if abs_p not in seen and os.path.isdir(abs_p):
+            unique_paths.append(abs_p)
+            seen.add(abs_p)
+
+    return sorted(unique_paths)
+
+
 def get_system_service_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all system services (Windows Service PathName)."""
     items = []
@@ -2396,6 +2433,19 @@ def scan_system_services_click():
         messagebox.showwarning("System Services Error", f"Could not scan system services: {e}")
 
 
+def scan_python_packages_click():
+    """Scan all directories containing installed Python packages (site-packages)."""
+    try:
+        package_paths = get_python_package_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Python Packages", "No Python site-packages directories were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Python Packages Error", f"Could not scan Python packages: {e}")
+
+
 def scan_recently_modified_click():
     """Scan files modified within a user-specified duration."""
     duration_str = simpledialog.askstring("Scan Recently Modified", "Enter duration (e.g., 24h, 1h, 7d):", initialvalue="24h")
@@ -2429,6 +2479,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_ssh_config_paths())
     all_paths.extend(get_system_service_paths())
     all_paths.extend(get_git_hooks_paths())
+    all_paths.extend(get_python_package_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6502,7 +6553,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6534,6 +6585,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     browse_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     browse_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
+    browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click)
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -7106,6 +7158,11 @@ def main():
         help='Scan all system services (systemd files on Linux, Service PathName on Windows).'
     )
     scan_group.add_argument(
+        '--python-packages',
+        action='store_true',
+        help='Scan all directories containing installed Python packages (site-packages).'
+    )
+    scan_group.add_argument(
         '--env-vars',
         action='store_true',
         help='Scan all non-empty environment variables.'
@@ -7367,6 +7424,13 @@ def main():
                 extra_snippets.extend(service_cmds)
             if not service_paths and not service_cmds:
                 print("No system services or systemd units were found.", file=sys.stderr)
+
+        if args.python_packages:
+            package_paths = get_python_package_paths()
+            if package_paths:
+                scan_targets.extend(package_paths)
+            else:
+                print("No Python site-packages directories were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/tests/test_python_packages_scan.py
+++ b/tests/test_python_packages_scan.py
@@ -1,0 +1,75 @@
+import sys
+import os
+import pytest
+from gptscan import get_python_package_paths, scan_python_packages_click, Config
+import tkinter as tk
+
+def test_get_python_package_paths():
+    """Verify that get_python_package_paths returns existing site-packages directories."""
+    paths = get_python_package_paths()
+    assert isinstance(paths, list)
+    # On most systems running tests, there should be at least one site-packages dir
+    # If not (e.g. very minimal environment), this might be empty, but usually it's not.
+    if paths:
+        for p in paths:
+            assert os.path.isdir(p)
+            assert 'site-packages' in p.lower() or 'dist-packages' in p.lower() or 'lib' in p.lower()
+            assert os.path.isabs(p)
+
+def test_get_python_package_paths_mocked(monkeypatch):
+    """Verify the logic of get_python_package_paths with mocked inputs."""
+    def mock_getsitepackages():
+        return ["/fake/site-packages", "/another/fake/path"]
+
+    def mock_getusersitepackages():
+        return "/user/fake/site-packages"
+
+    import site
+    monkeypatch.setattr(site, "getsitepackages", mock_getsitepackages, raising=False)
+    monkeypatch.setattr(site, "getusersitepackages", mock_getusersitepackages, raising=False)
+    monkeypatch.setattr(sys, "path", ["/env/site-packages", "/random/path"])
+
+    # Mock os.path.isdir to return True for our fake paths
+    def mock_isdir(p):
+        return "fake" in p or "site-packages" in p
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
+
+    paths = get_python_package_paths()
+    assert "/fake/site-packages" in paths
+    assert "/another/fake/path" in paths
+    assert "/user/fake/site-packages" in paths
+    assert "/env/site-packages" in paths
+    assert "/random/path" not in paths # Should be filtered out as it doesn't contain 'site-packages' and is not from site.get*
+
+def test_scan_python_packages_click(monkeypatch):
+    """Verify the GUI callback for scanning Python packages."""
+    target_paths = []
+    def mock_set_scan_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+
+    def mock_button_click():
+        pass
+
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_scan_target)
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: ["/mock/site-packages"])
+
+    scan_python_packages_click()
+    assert target_paths == ["/mock/site-packages"]
+
+def test_scan_python_packages_click_no_paths(monkeypatch):
+    """Verify the GUI callback when no paths are found."""
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: [])
+
+    message_box_shown = False
+    def mock_showinfo(title, message):
+        nonlocal message_box_shown
+        message_box_shown = True
+        assert "No Python site-packages" in message
+
+    import tkinter.messagebox
+    monkeypatch.setattr(tkinter.messagebox, "showinfo", mock_showinfo)
+
+    scan_python_packages_click()
+    assert message_box_shown

--- a/tests/test_system_audit.py
+++ b/tests/test_system_audit.py
@@ -3,14 +3,21 @@ from unittest.mock import patch, MagicMock
 import gptscan
 from pathlib import Path
 
-def test_get_ssh_config_paths(mocker):
+def test_get_ssh_config_paths(monkeypatch):
     home = Path("/home/user")
-    mocker.patch("pathlib.Path.home", return_value=home)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
 
-    # Mock Path object and its exists method
-    mock_exists = mocker.patch("pathlib.Path.exists")
-    # Make everything exist
-    mock_exists.return_value = True
+    # Mock Path.exists to return True for our expected paths
+    original_exists = Path.exists
+    def mock_exists(self):
+        if str(self) in ["/home/user/.ssh/config", "/home/user/.ssh/authorized_keys", "/etc/ssh/sshd_config", "/etc/ssh/ssh_config"]:
+            return True
+        if ".ssh" in str(self) or "etc/ssh" in str(self):
+             return True
+        return False
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(Path, "is_dir", lambda self: True)
 
     paths = gptscan.get_ssh_config_paths()
     assert "/home/user/.ssh/config" in paths
@@ -18,50 +25,77 @@ def test_get_ssh_config_paths(mocker):
     assert "/etc/ssh/sshd_config" in paths
     assert "/etc/ssh/ssh_config" in paths
 
-def test_scan_system_audit_click(mocker):
-    mocker.patch("gptscan.get_shell_profile_paths", return_value=["/p1"])
-    mocker.patch("gptscan.get_shell_history_paths", return_value=["/h1"])
-    mocker.patch("gptscan.get_system_path_directories", return_value=["/bin"])
-    mocker.patch("gptscan.get_ssh_config_paths", return_value=["/s1"])
-    mocker.patch("gptscan.get_running_process_commands", return_value=[("proc", b"cmd")])
-    mocker.patch("gptscan.get_environment_variable_snippets", return_value=[("env", b"val")])
-    mocker.patch("gptscan.get_scheduled_task_commands", return_value=[("task", b"run")])
-    mocker.patch("gptscan.get_startup_item_commands", return_value=[("start", b"up")])
+def test_scan_system_audit_click(monkeypatch):
+    monkeypatch.setattr("gptscan.get_shell_profile_paths", lambda: ["/p1"])
+    monkeypatch.setattr("gptscan.get_shell_history_paths", lambda: ["/h1"])
+    monkeypatch.setattr("gptscan.get_system_path_directories", lambda: ["/bin"])
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", lambda: ["/s1"])
+    monkeypatch.setattr("gptscan.get_running_process_commands", lambda: [("proc", b"cmd")])
+    monkeypatch.setattr("gptscan.get_environment_variable_snippets", lambda: [("env", b"val")])
+    monkeypatch.setattr("gptscan.get_scheduled_task_commands", lambda: [("task", b"run")])
+    monkeypatch.setattr("gptscan.get_startup_item_commands", lambda: [("start", b"up")])
+    monkeypatch.setattr("gptscan.get_system_service_paths", lambda: ["/ser1"])
+    monkeypatch.setattr("gptscan.get_system_service_commands", lambda: [("ser", b"cmd")])
+    monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: ["/hook1"])
+    monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [("git", b"conf")])
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: ["/pkg1"])
 
-    mock_set_target = mocker.patch("gptscan._set_scan_target")
-    mock_button_click = mocker.patch("gptscan.button_click")
+    target_paths = []
+    def mock_set_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_target)
+
+    clicked = False
+    snippets_count = 0
+    def mock_button_click(extra_snippets=None, **kwargs):
+        nonlocal clicked, snippets_count
+        clicked = True
+        if extra_snippets:
+            snippets_count = len(extra_snippets)
+
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
 
     gptscan.scan_system_audit_click()
 
-    mock_set_target.assert_called_once()
-    args, _ = mock_set_target.call_args
-    assert "/p1" in args[0]
-    assert "/h1" in args[0]
-    assert "/bin" in args[0]
-    assert "/s1" in args[0]
+    assert "/p1" in target_paths
+    assert "/h1" in target_paths
+    assert "/bin" in target_paths
+    assert "/s1" in target_paths
+    assert "/ser1" in target_paths
+    assert "/hook1" in target_paths
+    assert "/pkg1" in target_paths
 
-    mock_button_click.assert_called_once()
-    _, kwargs = mock_button_click.call_args
-    snippets = kwargs["extra_snippets"]
-    assert len(snippets) == 4
+    assert clicked
+    assert snippets_count == 6
 
-def test_cli_audit_flag(mocker):
-    mocker.patch("gptscan.get_shell_profile_paths", return_value=["/p1"])
-    mocker.patch("gptscan.get_shell_history_paths", return_value=[])
-    mocker.patch("gptscan.get_system_path_directories", return_value=[])
-    mocker.patch("gptscan.get_ssh_config_paths", return_value=[])
-    mocker.patch("gptscan.get_running_process_commands", return_value=[])
-    mocker.patch("gptscan.get_environment_variable_snippets", return_value=[])
-    mocker.patch("gptscan.get_scheduled_task_commands", return_value=[])
-    mocker.patch("gptscan.get_startup_item_commands", return_value=[])
+def test_cli_audit_flag(monkeypatch):
+    monkeypatch.setattr("gptscan.get_shell_profile_paths", lambda: ["/p1"])
+    monkeypatch.setattr("gptscan.get_shell_history_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_path_directories", lambda: [])
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_running_process_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_environment_variable_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_scheduled_task_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_startup_item_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: [])
 
-    mock_run_cli = mocker.patch("gptscan.run_cli", return_value=0)
+    cli_args = []
+    def mock_run_cli(targets, *args, **kwargs):
+        nonlocal cli_args
+        cli_args = targets
+        return 0
+
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
 
     import sys
     test_args = ["gptscan.py", "--audit", "--cli"]
     with patch.object(sys, 'argv', test_args):
         gptscan.main()
 
-    mock_run_cli.assert_called_once()
-    args, _ = mock_run_cli.call_args
-    assert "/p1" in args[0]
+    assert "/p1" in cli_args


### PR DESCRIPTION
* **What:** Added functionality to discover and scan all installed Python packages (site-packages and user-site-packages) from the CLI and GUI. Integrated this discovery into the comprehensive system audit feature.
* **Why:** I noticed that while the scanner supports many system components (shell profiles, history, system services), it lacked a direct way to audit the integrity of the Python environment itself. Adding site-packages scanning allows users to detect malicious code in installed dependencies, following the "Batching" and "Symmetry" heuristics (if we can scan local files, we should be able to scan the runtime environment's libraries).

---
*PR created automatically by Jules for task [5569040539287714361](https://jules.google.com/task/5569040539287714361) started by @RainRat*