### PR TITLE
[TEST] Add Makefile variable extraction and tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3636,31 +3636,49 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
     if check_basename.endswith('makefile'):
         try:
             text = content.decode('utf-8', errors='ignore')
-            # Extract recipes (lines starting with a tab) with multi-line support
-            recipes = []
-            current_recipe = []
+            yielded_any = False
+            recipes_count = 0
+            vars_count = 0
 
-            def finalize_recipe():
-                if current_recipe:
-                    recipes.append(" ".join([c.rstrip('\\').strip() for c in current_recipe]))
+            lines = text.splitlines()
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                i += 1
 
-            for line in text.splitlines():
+                if not line.strip() or line.strip().startswith('#'):
+                    continue
+
                 if line.startswith('\t'):
-                    current_recipe.append(line[1:])
-                    # If line doesn't end with \, we've finished this recipe
-                    if not line.rstrip().endswith('\\'):
-                        finalize_recipe()
-                        current_recipe = []
-                elif current_recipe:
-                    finalize_recipe()
-                    current_recipe = []
+                    # Recipe
+                    content_parts = [line[1:]]
+                    while line.rstrip().endswith('\\') and i < len(lines):
+                        line = lines[i]
+                        i += 1
+                        content_parts.append(line[1:] if line.startswith('\t') else line.strip())
 
-            finalize_recipe()
+                    cmd = " ".join([c.rstrip('\\').strip() for c in content_parts])
+                    if cmd.strip():
+                        recipes_count += 1
+                        yield (f"{name} [Recipe {recipes_count}]", cmd.encode('utf-8'))
+                        yielded_any = True
+                else:
+                    # Check for variable assignment: VAR = val, VAR := val, VAR += val, VAR ?= val
+                    var_match = re.match(r'^([\w.-]+)\s*([:+?]?=)\s*(.*)', line)
+                    if var_match:
+                        content_parts = [var_match.group(3)]
+                        while line.rstrip().endswith('\\') and i < len(lines):
+                            line = lines[i]
+                            i += 1
+                            content_parts.append(line.strip())
 
-            if recipes:
-                for i, recipe in enumerate(recipes, 1):
-                    if recipe.strip():
-                        yield (f"{name} [Recipe {i}]", recipe.encode('utf-8'))
+                        val = " ".join([c.rstrip('\\').strip() for c in content_parts])
+                        if val.strip():
+                            vars_count += 1
+                            yield (f"{name} [Variable {vars_count}]", val.encode('utf-8'))
+                            yielded_any = True
+
+            if yielded_any:
                 return
         except Exception:
             pass

--- a/tests/test_makefile_gap.py
+++ b/tests/test_makefile_gap.py
@@ -1,0 +1,72 @@
+import pytest
+from gptscan import unpack_content
+
+def test_makefile_variable_extraction():
+    """Verify that Makefile variable assignments are correctly extracted."""
+    content = b"""
+MALICIOUS_VAR = rm -rf /
+IMMEDIATE := echo "immediate"
+APPEND += --flag
+DEFAULT ?= default_val
+EMPTY =
+all:
+\techo "done"
+"""
+    results = list(unpack_content("Makefile", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "Makefile [Variable 1]" in scripts
+    assert scripts["Makefile [Variable 1]"] == "rm -rf /"
+
+    assert "Makefile [Variable 2]" in scripts
+    assert scripts["Makefile [Variable 2]"] == 'echo "immediate"'
+
+    assert "Makefile [Variable 3]" in scripts
+    assert scripts["Makefile [Variable 3]"] == "--flag"
+
+    assert "Makefile [Variable 4]" in scripts
+    assert scripts["Makefile [Variable 4]"] == "default_val"
+
+    # EMPTY variable should not be yielded if val.strip() is empty
+    assert "Makefile [Variable 5]" not in scripts
+
+    assert "Makefile [Recipe 1]" in scripts
+    assert scripts["Makefile [Recipe 1]"] == 'echo "done"'
+
+def test_makefile_multiline_variable():
+    """Verify that multi-line Makefile variable assignments are correctly extracted."""
+    content = b"""
+MULTILINE = echo "part 1" \\
+            "part 2" \\
+            "part 3"
+NEXT = after
+"""
+    results = list(unpack_content("Makefile", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "Makefile [Variable 1]" in scripts
+    assert scripts["Makefile [Variable 1]"] == 'echo "part 1" "part 2" "part 3"'
+
+    assert "Makefile [Variable 2]" in scripts
+    assert scripts["Makefile [Variable 2]"] == "after"
+
+def test_makefile_mixed_variables_and_recipes():
+    """Verify mixed variables and recipes are extracted in order."""
+    content = b"""
+VAR1 = val1
+target1:
+\tcmd1
+VAR2 = val2
+target2:
+\tcmd2
+"""
+    results = list(unpack_content("Makefile", content))
+    # Order should be preserved in numbering
+    assert results[0][0] == "Makefile [Variable 1]"
+    assert results[0][1] == b"val1"
+    assert results[1][0] == "Makefile [Recipe 1]"
+    assert results[1][1] == b"cmd1"
+    assert results[2][0] == "Makefile [Variable 2]"
+    assert results[2][1] == b"val2"
+    assert results[3][0] == "Makefile [Recipe 2]"
+    assert results[3][1] == b"cmd2"


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** Improved `unpack_content` in `gptscan.py` to extract Makefile variable assignments (e.g., `VAR = val`, `VAR := val`, etc.) in addition to recipes. It also handles multi-line continuations for both variables and recipes. Added `tests/test_makefile_gap.py` for verification.
* **Why:** Makefile variables can contain dangerous commands or configuration. Previously, only recipes (lines starting with tabs) were extracted, leading to a gap in scan coverage for Makefile-based projects.

---
*PR created automatically by Jules for task [8407833211817549764](https://jules.google.com/task/8407833211817549764) started by @RainRat*