### PR TITLE
[DOCS] Clarify Deep Scan behavior in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,7 @@ You can tailor the scanner to your needs:
 *   **Exclusions:** Ignore specific files or folders by using **File > Manage Exclusions...** or by adding patterns to a `.gptscanignore` file. In the terminal, use the `-e` or `--exclude` flag.
 *   **Extensions:** Control which file types are scanned by using **File > Manage Extensions...** or by editing the `extensions.txt` file. In the terminal, use the `--extensions` flag.
 *   **File Size:** The scanner skips files larger than 10MB during folder scans. You can adjust this limit in the **Scan Options** panel or by using the `--max-size` flag. Files you select individually are always scanned, regardless of their size.
-*   **Deep Scan:** Scan the entire file instead of just the beginning. This is more thorough but slower. Use the **Deep Scan** checkbox or the `-d` or `--deep` flag.
+*   **Deep Scan:** Scan the entire file instead of just the beginning and end. This is more thorough but slower. Use the **Deep Scan** checkbox or the `-d` or `--deep` flag.
 *   **Scan All Files:** By default, the scanner only checks script-like files (like `.py` or `.js`). Use the **Scan All Files** checkbox or the `--all-files` flag to check every file.
 *   **Dry Run:** Preview which files would be scanned without actually checking them. Use the **Dry Run** checkbox or the `--dry-run` flag.
 


### PR DESCRIPTION
* **Type:** Documentation
* **What:** The "Customizing the Scanner" section of `readme.md`.
* **Why:** To accurately describe that the default scan behavior checks both the beginning and end of the file, providing better technical clarity for the user.

---
*PR created automatically by Jules for task [15450373374179305242](https://jules.google.com/task/15450373374179305242) started by @RainRat*