### PR TITLE
Eliminate code duplication in directory collection logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1145,24 +1145,27 @@ def get_shell_history_paths() -> List[str]:
     return paths
 
 
-def get_system_path_directories() -> List[str]:
-    """Identify all directories listed in the system's PATH environment variable."""
-    path_env = os.environ.get("PATH", "")
-    if not path_env:
-        return []
-
-    # Split and filter out empty strings and non-existent directories
+def _normalize_and_filter_dirs(paths: Iterable[Optional[str]]) -> List[str]:
+    """Normalize paths to absolute, filter out non-directories, and deduplicate while preserving order."""
     dirs = []
     seen = set()
-    for p in path_env.split(os.pathsep):
+    for p in paths:
         if not p:
             continue
         abs_p = os.path.abspath(p)
         if abs_p not in seen and os.path.isdir(abs_p):
             dirs.append(abs_p)
             seen.add(abs_p)
-
     return dirs
+
+
+def get_system_path_directories() -> List[str]:
+    """Identify all directories listed in the system's PATH environment variable."""
+    path_env = os.environ.get("PATH", "")
+    if not path_env:
+        return []
+
+    return _normalize_and_filter_dirs(path_env.split(os.pathsep))
 
 
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
@@ -1250,18 +1253,7 @@ def get_python_package_paths() -> List[str]:
         if 'site-packages' in p:
             paths.append(p)
 
-    # Filter out non-existent directories and deduplicate
-    unique_paths = []
-    seen = set()
-    for p in paths:
-        if not p:
-            continue
-        abs_p = os.path.abspath(p)
-        if abs_p not in seen and os.path.isdir(abs_p):
-            unique_paths.append(abs_p)
-            seen.add(abs_p)
-
-    return sorted(unique_paths)
+    return sorted(_normalize_and_filter_dirs(paths))
 
 
 def get_system_service_commands() -> List[Tuple[str, bytes]]:


### PR DESCRIPTION
This PR eliminates code duplication in `gptscan.py` by extracting common directory-processing logic into a reusable private helper function.

### Changes:
- Introduced `_normalize_and_filter_dirs(paths: Iterable[Optional[str]]) -> List[str]` to handle path normalization (to absolute), filtering (checking if it's a directory), and deduplication (preserving order).
- Refactored `get_system_path_directories` to use the new helper.
- Refactored `get_python_package_paths` to use the new helper, maintaining its final sorted output.

### Benefits:
- **Reduced Duplication:** Identical logic blocks were replaced with a single source of truth.
- **Maintainability:** Future changes to how system/package directories are validated only need to be made in one place.
- **Hygiene:** Cleaner, more self-documenting code in the primary collection functions.

No breaking changes were introduced. All relevant tests (`tests/test_system_path.py` and `tests/test_python_packages_scan.py`) passed.

---
*PR created automatically by Jules for task [2761194604933010885](https://jules.google.com/task/2761194604933010885) started by @RainRat*