### PR TITLE
[TEST] Add unit tests for get_system_service_commands

### DIFF
--- a/tests/test_system_service_commands.py
+++ b/tests/test_system_service_commands.py
@@ -1,0 +1,56 @@
+import pytest
+import sys
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+import gptscan
+
+def test_get_system_service_commands_windows_multiple():
+    mock_json = [
+        {"Name": "Service1", "PathName": "C:\\Windows\\System32\\service1.exe"},
+        {"Name": "Service2", "PathName": "\"C:\\Program Files\\App\\service2.exe\" --run"}
+    ]
+
+    with patch("sys.platform", "win32"), \
+         patch("subprocess.check_output") as mock_run:
+        mock_run.return_value = json.dumps(mock_json)
+
+        results = gptscan.get_system_service_commands()
+
+        assert len(results) == 2
+        assert results[0] == ("[Service] Service1", b"C:\\Windows\\System32\\service1.exe")
+        assert results[1] == ("[Service] Service2", b"\"C:\\Program Files\\App\\service2.exe\" --run")
+
+def test_get_system_service_commands_windows_single():
+    mock_json = {"Name": "SoloService", "PathName": "C:\\solo.exe"}
+
+    with patch("sys.platform", "win32"), \
+         patch("subprocess.check_output") as mock_run:
+        mock_run.return_value = json.dumps(mock_json)
+
+        results = gptscan.get_system_service_commands()
+
+        assert len(results) == 1
+        assert results[0] == ("[Service] SoloService", b"C:\\solo.exe")
+
+def test_get_system_service_commands_windows_empty():
+    with patch("sys.platform", "win32"), \
+         patch("subprocess.check_output") as mock_run:
+        mock_run.return_value = ""
+
+        results = gptscan.get_system_service_commands()
+        assert results == []
+
+def test_get_system_service_commands_windows_error():
+    with patch("sys.platform", "win32"), \
+         patch("subprocess.check_output") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "cmd")
+
+        # Should catch exception and return empty list
+        results = gptscan.get_system_service_commands()
+        assert results == []
+
+def test_get_system_service_commands_non_windows():
+    with patch("sys.platform", "linux"):
+        results = gptscan.get_system_service_commands()
+        assert results == []


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added comprehensive unit tests for the `get_system_service_commands` function in `gptscan.py`.
* **Why:** This function, which discovers system service command lines on Windows via PowerShell, lacked direct unit test coverage. The new tests verify:
    - Extraction of multiple services from PowerShell JSON output.
    - Robust handling of single service objects (addressing common PowerShell JSON inconsistencies).
    - Graceful handling of empty output and subprocess errors.
    - Correct behavior on non-Windows platforms (returning an empty list).

---
*PR created automatically by Jules for task [4049178069345409962](https://jules.google.com/task/4049178069345409962) started by @RainRat*