### PR TITLE
[DOCS] Expand README with missing features and CLI examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Hooks:** Scan local and global Git hooks for dangerous scripts (Ctrl+Shift+G).
 *   **Scan Git Configuration:** Scan potentially dangerous Git configuration settings (aliases, editors, etc.).
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
-*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, system services, and Git configuration (Ctrl+Shift+I).
+*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, system services, Git configuration, Git hooks, and installed Python packages (Ctrl+Shift+I).
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for dangerous one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially dangerous execution strings (Ctrl+Shift+K).
@@ -72,6 +72,7 @@ Access these options from the **Browse** menu:
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous persistence (Ctrl+Shift+T).
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
+*   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages).
 
 ### Keyboard Shortcuts
 The scanner includes shortcuts for faster navigation:
@@ -177,9 +178,34 @@ To scan potentially dangerous Git configuration settings:
 python3 gptscan.py --git-config --cli
 ```
 
+To scan all local and global Git hooks:
+```bash
+python3 gptscan.py --git-hooks --cli
+```
+
+To scan current Git changes as a diff:
+```bash
+python3 gptscan.py --git-diff --cli
+```
+
+To scan all installed Python packages:
+```bash
+python3 gptscan.py --python-packages --cli
+```
+
 To scan all shell profiles and RC files:
 ```bash
 python3 gptscan.py --shell-profiles --cli
+```
+
+To perform a comprehensive system audit:
+```bash
+python3 gptscan.py --audit --cli
+```
+
+To scan code sent from another command (piping):
+```bash
+cat script.py | python3 gptscan.py --stdin --cli
 ```
 
 To scan files modified in the last 24 hours:

--- a/tests/test_git_hooks_scanning.py
+++ b/tests/test_git_hooks_scanning.py
@@ -20,7 +20,7 @@ def test_get_git_hooks_paths(tmp_path):
     assert any(str(pre_commit) == p for p in paths)
     assert not any(str(sample) == p for p in paths)
 
-def test_cli_git_hooks(tmp_path, mocker):
+def test_cli_git_hooks(tmp_path, monkeypatch):
     # Setup test repo
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -31,7 +31,7 @@ def test_cli_git_hooks(tmp_path, mocker):
     pre_commit.write_text("#!/bin/sh\necho 'hello'")
 
     # Mocking get_git_hooks_paths to ensure it returns our test hook
-    mocker.patch("gptscan.get_git_hooks_paths", return_value=[str(pre_commit)])
+    monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda x: [str(pre_commit)])
 
     # Simulate CLI logic for --git-hooks
     paths = [str(repo)]


### PR DESCRIPTION
This PR improves the project documentation by filling gaps in the README.

**Changes:**
- **GUI Documentation:** Added "Scan Python Packages" to the list of available scan options in the "Using the Window (GUI)" section.
- **System Audit:** Updated the description of the "System Audit" feature to explicitly mention that it scans Git hooks and installed Python packages, providing a more accurate overview of its capabilities.
- **CLI Examples:** Added several new examples to the "Using the Terminal (CLI)" section, covering:
    - Scanning local and global Git hooks (`--git-hooks`).
    - Scanning current Git changes as a diff (`--git-diff`).
    - Scanning installed Python packages (`--python-packages`).
    - Performing a comprehensive system audit (`--audit`).
    - Scanning piped input from the terminal (`--stdin`).

**Maintenance:**
- Fixed an error in `tests/test_git_hooks_scanning.py` where the `mocker` fixture was used but not available (replaced with `monkeypatch`). This was necessary to verify the accuracy of the documented `--git-hooks` feature.

These improvements ensure that both GUI and CLI users can discover and use the full range of features offered by the GPT Virus Scanner.

---
*PR created automatically by Jules for task [1035056382491692140](https://jules.google.com/task/1035056382491692140) started by @RainRat*