### PR TITLE
[UI/UX] Add keyboard shortcut for 'Scan Python Packages'

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6647,7 +6647,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6687,7 +6687,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     browse_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     browse_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
-    browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click)
+    browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -7063,6 +7063,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-A>', lambda event: scan_startup_items_click())
     root.bind('<Control-Shift-S>', lambda event: scan_system_services_click())
     root.bind('<Command-Shift-S>', lambda event: scan_system_services_click())
+    root.bind('<Control-Shift-Y>', lambda event: scan_python_packages_click())
+    root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Access these options from the **Browse** menu:
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous persistence (Ctrl+Shift+T).
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
+*   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
 
 ### Keyboard Shortcuts
 The scanner includes shortcuts for faster navigation:
@@ -101,6 +102,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+T` | Scan Scheduled Tasks |
 | `Ctrl+Shift+A` | Scan Startup Items |
 | `Ctrl+Shift+S` | Scan System Services |
+| `Ctrl+Shift+Y` | Scan Python Packages |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |


### PR DESCRIPTION
Improved the usability and consistency of the GPT Virus Scanner GUI by adding a dedicated keyboard shortcut for the 'Scan Python Packages' feature.

**Changes:**
- **gptscan.py**:
  - Implemented `Ctrl+Shift+Y` (and `Cmd+Shift+Y` for macOS) bindings for `scan_python_packages_click`.
  - Added the `accelerator` label to the "Scan Python Packages" menu command.
  - Updated the tooltip for the "Browse" button to include the new shortcut.
- **readme.md**:
  - Added "Scan Python Packages" to the features list with its shortcut.
  - Included `Ctrl+Shift+Y` in the keyboard shortcuts reference table.

This change ensures that all integrated scan actions are equally accessible via keyboard shortcuts, improving efficiency for power users.

---
*PR created automatically by Jules for task [10214556950162229425](https://jules.google.com/task/10214556950162229425) started by @RainRat*