### PR TITLE
Consolidate path normalization and filtering logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1145,24 +1145,27 @@ def get_shell_history_paths() -> List[str]:
     return paths
 
 
-def get_system_path_directories() -> List[str]:
-    """Identify all directories listed in the system's PATH environment variable."""
-    path_env = os.environ.get("PATH", "")
-    if not path_env:
-        return []
-
-    # Split and filter out empty strings and non-existent directories
+def _normalize_and_filter_dirs(paths: Iterable[Optional[str]]) -> List[str]:
+    """Normalize paths to absolute form, filter out empty or non-existent directories, and deduplicate."""
     dirs = []
     seen = set()
-    for p in path_env.split(os.pathsep):
+    for p in paths:
         if not p:
             continue
         abs_p = os.path.abspath(p)
         if abs_p not in seen and os.path.isdir(abs_p):
             dirs.append(abs_p)
             seen.add(abs_p)
-
     return dirs
+
+
+def get_system_path_directories() -> List[str]:
+    """Identify all directories listed in the system's PATH environment variable."""
+    path_env = os.environ.get("PATH", "")
+    if not path_env:
+        return []
+
+    return _normalize_and_filter_dirs(path_env.split(os.pathsep))
 
 
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
@@ -1250,18 +1253,7 @@ def get_python_package_paths() -> List[str]:
         if 'site-packages' in p:
             paths.append(p)
 
-    # Filter out non-existent directories and deduplicate
-    unique_paths = []
-    seen = set()
-    for p in paths:
-        if not p:
-            continue
-        abs_p = os.path.abspath(p)
-        if abs_p not in seen and os.path.isdir(abs_p):
-            unique_paths.append(abs_p)
-            seen.add(abs_p)
-
-    return sorted(unique_paths)
+    return sorted(_normalize_and_filter_dirs(paths))
 
 
 def get_system_service_commands() -> List[Tuple[str, bytes]]:


### PR DESCRIPTION
* **What:** Extracted a shared logic block from `get_system_path_directories` and `get_python_package_paths` into a new private helper function `_normalize_and_filter_dirs`. This helper handles normalizing iterable path strings to absolute forms, filtering out non-existent or empty directories, and deduplicating while preserving original order.
* **Why:** This change eliminates code duplication, improving maintainability and readability. By centralizing the path processing logic, any future improvements to directory validation or normalization can be applied in one place. The refactor is non-breaking as it preserves the exact external behavior and contract of the modified functions, as verified by existing unit tests.

---
*PR created automatically by Jules for task [9937368956790636773](https://jules.google.com/task/9937368956790636773) started by @RainRat*