### PR TITLE
[TEST] Improve pyproject.toml parsing coverage and fix array comment bug

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3193,20 +3193,27 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                             break
                                     command_val = "\n".join(multiline_lines)
                             # Handle multiline arrays
-                            elif command_val.startswith('[') and not command_val.endswith(']'):
-                                array_lines = [command_val]
-                                while i < len(lines):
-                                    curr_line = lines[i].strip()
-                                    # Strip inline comments from array lines
-                                    comment_match = re.search(r'^(?:[^"\'#]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*(#.*)', curr_line)
-                                    if comment_match:
-                                        curr_line = curr_line[:comment_match.start(1)].strip()
+                            elif command_val.startswith('['):
+                                # Check if it actually ends on this line (ignoring comments)
+                                temp_val = command_val
+                                comment_match = re.search(r'^(?:[^"\'#]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*(#.*)', temp_val)
+                                if comment_match:
+                                    temp_val = temp_val[:comment_match.start(1)].strip()
 
-                                    array_lines.append(curr_line)
-                                    i += 1
-                                    if curr_line.endswith(']'):
-                                        break
-                                command_val = "".join(array_lines)
+                                if not temp_val.endswith(']'):
+                                    array_lines = [command_val]
+                                    while i < len(lines):
+                                        curr_line = lines[i].strip()
+                                        # Strip inline comments from array lines
+                                        comment_match = re.search(r'^(?:[^"\'#]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*(#.*)', curr_line)
+                                        if comment_match:
+                                            curr_line = curr_line[:comment_match.start(1)].strip()
+
+                                        array_lines.append(curr_line)
+                                        i += 1
+                                        if curr_line.endswith(']'):
+                                            break
+                                    command_val = "".join(array_lines)
 
                             if current_nested_script:
                                 # Inside a nested section like [tool.pdm.scripts.test] or [tool.poe.tasks.test]

--- a/tests/test_pyproject_parsing_v2.py
+++ b/tests/test_pyproject_parsing_v2.py
@@ -1,0 +1,87 @@
+import pytest
+from gptscan import unpack_content
+
+def test_pyproject_complex_multiline_array():
+    """Verify multiline arrays with internal and trailing comments."""
+    content = b"""
+[tool.pdm.scripts]
+complex = [
+    "echo 1", # internal 1
+    "echo 2", # internal 2
+] # trailing
+next = "echo next"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "pyproject.toml [Script: complex (1)]" in scripts
+    assert scripts["pyproject.toml [Script: complex (1)]"] == "echo 1"
+    assert "pyproject.toml [Script: complex (2)]" in scripts
+    assert scripts["pyproject.toml [Script: complex (2)]"] == "echo 2"
+    assert "pyproject.toml [Script: next]" in scripts
+    assert scripts["pyproject.toml [Script: next]"] == "echo next"
+
+def test_pyproject_nested_sections_mixed():
+    """Verify mixed flat and nested sections."""
+    content = b"""
+[project.scripts]
+cli = "pkg:main"
+
+[tool.pdm.scripts]
+pdm-flat = "echo flat"
+
+[tool.pdm.scripts.nested]
+cmd = "echo nested"
+
+[tool.poe.tasks]
+poe-flat = "echo poe"
+
+[tool.poe.tasks.nested-poe]
+shell = "echo nested poe"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert scripts["pyproject.toml [Script: cli]"] == "pkg:main"
+    assert scripts["pyproject.toml [Script: pdm-flat]"] == "echo flat"
+    assert scripts["pyproject.toml [Script: nested]"] == "echo nested"
+    assert scripts["pyproject.toml [Script: poe-flat]"] == "echo poe"
+    assert scripts["pyproject.toml [Script: nested-poe]"] == "echo nested poe"
+
+def test_pyproject_multiline_string_single_line():
+    """Verify triple quotes on a single line with comments."""
+    content = b"""
+[tool.pdm.scripts]
+test = '''echo hello''' # comment
+next = \"\"\"echo world\"\"\" # another
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert scripts["pyproject.toml [Script: test]"] == "echo hello"
+    assert scripts["pyproject.toml [Script: next]"] == "echo world"
+
+def test_pyproject_invalid_sections_ignored():
+    """Verify sections that are not script-related are ignored."""
+    content = b"""
+[build-system]
+requires = ["setuptools"]
+
+[tool.other]
+data = "important"
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    assert len(results) == 0
+
+def test_pyproject_inline_table_script():
+    """Verify scripts defined in inline tables."""
+    content = b"""
+[tool.pdm.scripts]
+test = { cmd = "pytest", help = "run tests" }
+shell-task = { shell = "echo hi" }
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert scripts["pyproject.toml [Script: test]"] == "pytest"
+    assert scripts["pyproject.toml [Script: shell-task]"] == "echo hi"


### PR DESCRIPTION
This PR improves the test coverage and reliability of `pyproject.toml` script parsing in `gptscan.py`.

### What
1.  **Bug Fix**: Corrected a logic error in `unpack_content` that caused single-line TOML-style arrays followed by a comment (e.g., `test = ["pytest"] # comment`) to be treated as open-ended multiline arrays. The fix now strips comments before checking for the closing bracket `]`.
2.  **New Coverage**: Added `tests/test_pyproject_parsing_v2.py` which provides exhaustive coverage for:
    *   Complex multiline arrays with internal and trailing comments.
    *   Mixed flat and nested sections (e.g., `[tool.pdm.scripts]` vs `[tool.pdm.scripts.nested]`).
    *   Single-line triple-quoted strings with trailing comments.
    *   Inline table script definitions (e.g., `test = { cmd = "pytest" }`).
    *   Validation that non-script sections are correctly ignored.

### Why
Robust parsing of `pyproject.toml` is critical for security scanning as it is a common location for malicious build scripts or tasks. The previous implementation was fragile when encountering standard TOML comments on the same line as an array definition, leading to potential mis-parsing of subsequent lines. This intervention ensures the scanner is both more accurate and better tested against edge cases.

---
*PR created automatically by Jules for task [15909270737652745962](https://jules.google.com/task/15909270737652745962) started by @RainRat*