### PR TITLE
[MAINT] Simplify redundant logic in scan_files for file collection

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3812,10 +3812,7 @@ def scan_files(
     explicit_targets = {Path(t) for t in local_targets}
     explicit_files = {f for f in explicit_targets if f.is_file()}
 
-    if modified_since is not None:
-        file_list = collect_files(local_targets, modified_since=modified_since)
-    else:
-        file_list = collect_files(local_targets)
+    file_list = collect_files(local_targets, modified_since=modified_since)
 
     if exclude_patterns:
         file_list = [

--- a/tests/test_dry_run_feature.py
+++ b/tests/test_dry_run_feature.py
@@ -19,7 +19,7 @@ def test_dry_run_skips_model_and_yields_results(monkeypatch, tmp_path):
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".py", ".js"})
 
     # Mock collect_files to return these files explicitly
-    monkeypatch.setattr(gptscan, "collect_files", lambda x: [f1, f2])
+    monkeypatch.setattr(gptscan, "collect_files", lambda x, **kwargs: [f1, f2])
 
     # Mock get_model to ensure it's NOT called
     mock_get_model = MagicMock()

--- a/tests/test_extra_snippets.py
+++ b/tests/test_extra_snippets.py
@@ -6,7 +6,7 @@ from gptscan import scan_files, Config, scan_clipboard_click
 
 def test_scan_files_extra_snippets_basic(mock_tf_env, monkeypatch):
     """Test that extra_snippets are correctly processed by scan_files."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     snippet_content = b"print('hello world')"
     extra_snippets = [("[Clipboard]", snippet_content)]
 
@@ -29,7 +29,7 @@ def test_scan_files_extra_snippets_basic(mock_tf_env, monkeypatch):
 
 def test_scan_files_boundary_threshold(mock_tf_env, monkeypatch):
     """Verify that a snippet exactly at the threshold is yielded (inclusive check)."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     mock_tf_env.predict.return_value = [[0.5]] # Exactly 50%
     Config.THRESHOLD = 50
 
@@ -50,7 +50,7 @@ def test_scan_files_boundary_threshold(mock_tf_env, monkeypatch):
 
 def test_scan_files_below_threshold_ignored(mock_tf_env, monkeypatch):
     """Verify that a snippet below the threshold is ignored when show_all=False."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     mock_tf_env.predict.return_value = [[0.49]] # 49%
     Config.THRESHOLD = 50
 
@@ -70,7 +70,7 @@ def test_scan_files_below_threshold_ignored(mock_tf_env, monkeypatch):
 
 def test_scan_files_extra_snippets_gpt_trigger(mock_tf_env, monkeypatch):
     """Test that extra_snippets can trigger GPT analysis."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     mock_tf_env.predict.return_value = [[0.9]]
     Config.THRESHOLD = 50
     Config.GPT_ENABLED = True

--- a/tests/test_gptscan.py
+++ b/tests/test_gptscan.py
@@ -94,7 +94,7 @@ def test_scan_files_uses_cached_model(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gptscan, "_tf_module", fake_tf, raising=False)
     monkeypatch.setattr(gptscan, "_model_cache", None, raising=False)
-    monkeypatch.setattr(gptscan, "collect_files", lambda _targets: [sample_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda _targets, **kwargs: [sample_file])
     gptscan.Config.set_extensions([".txt"], missing=False)
 
     list(gptscan.scan_files(str(tmp_path), deep_scan=False, show_all=True, use_gpt=False, cancel_event=None))

--- a/tests/test_multi_hit.py
+++ b/tests/test_multi_hit.py
@@ -39,7 +39,7 @@ def test_scan_files_reports_multiple_hits_in_one_file(monkeypatch, tmp_path, moc
     test_file.write_bytes(content)
 
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
 
     # Run scan with deep_scan=True to find both windows
     results = list(gptscan.scan_files(
@@ -108,7 +108,7 @@ def test_scan_files_fallback_if_no_multi_hits(monkeypatch, tmp_path, mock_multi_
     test_file.write_bytes(content)
 
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
 
     # Run scan with show_all=True
     results = list(gptscan.scan_files(

--- a/tests/test_package_json_scan.py
+++ b/tests/test_package_json_scan.py
@@ -54,7 +54,7 @@ def test_is_supported_file_package_json():
 def test_scan_files_package_json_expansion(mock_tf_env, monkeypatch):
     """Test that a package.json is expanded and scanned."""
     # mock_tf_env is a fixture from conftest.py (hopefully)
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
 
     pkg_data = {
         "scripts": {

--- a/tests/test_repro_threshold_fallback.py
+++ b/tests/test_repro_threshold_fallback.py
@@ -25,7 +25,7 @@ def test_scan_files_fallback_when_below_threshold(monkeypatch, tmp_path, mock_sc
     test_file.write_bytes(b"print('hello')")
 
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".py"})
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
     monkeypatch.setattr(gptscan.Config, "THRESHOLD", 50)
 
     # Run scan with show_all=False

--- a/tests/test_scan_cancellation_logic.py
+++ b/tests/test_scan_cancellation_logic.py
@@ -23,7 +23,7 @@ def test_scan_files_cancellation_at_file_start(monkeypatch, tmp_path, mock_scan_
     (tmp_path / "file1.py").write_text("content1")
     (tmp_path / "file2.py").write_text("content2")
 
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [tmp_path / "file1.py", tmp_path / "file2.py"])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [tmp_path / "file1.py", tmp_path / "file2.py"])
 
     cancel_event = threading.Event()
 
@@ -47,7 +47,7 @@ def test_scan_files_cancellation_during_windows(monkeypatch, tmp_path, mock_scan
     test_file = tmp_path / "large.py"
     test_file.write_bytes(b"a" * file_size)
 
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
 
     cancel_event = threading.Event()
 

--- a/tests/test_scan_gpt_integration_extended.py
+++ b/tests/test_scan_gpt_integration_extended.py
@@ -25,7 +25,7 @@ def mock_gpt_env(monkeypatch, tmp_path):
     file1.write_text("print('hello')")
     file2 = tmp_path / "test2.py"
     file2.write_text("print('world')")
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [file1, file2])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [file1, file2])
 
     return file1, file2
 

--- a/tests/test_scan_logic.py
+++ b/tests/test_scan_logic.py
@@ -52,7 +52,7 @@ def test_scan_files_deep_scan_coverage(monkeypatch, tmp_path, mock_scan_dependen
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".bin"})
 
     # Mock collect_files to return only our test file
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
 
     # Execute scan with deep_scan=True
     # Convert generator to list to ensure execution
@@ -73,7 +73,7 @@ def test_scan_files_handles_permission_error(monkeypatch, tmp_path, mock_scan_de
     test_file.write_bytes(b"secret")
 
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".bin"})
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [test_file])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [test_file])
 
     # Mock open to raise PermissionError
     def mock_open(*args, **kwargs):
@@ -104,7 +104,7 @@ def test_scan_files_metadata_error(monkeypatch, tmp_path, mock_scan_dependencies
     monkeypatch.setattr(gptscan.Config, "extensions_set", {".bin"})
 
     # Mock collect_files to return our mock path
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [mock_path])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [mock_path])
 
     # Execute scan
     results = list(gptscan.scan_files(

--- a/tests/test_universal_parsing.py
+++ b/tests/test_universal_parsing.py
@@ -127,7 +127,7 @@ def test_unpack_nested_archives():
 
 def test_scan_files_url_zip_expansion(mock_tf_env, monkeypatch):
     """Test that a ZIP fetched via URL is expanded and scanned."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     url = "https://example.com/scripts.zip"
 
     zip_buffer = io.BytesIO()
@@ -155,7 +155,7 @@ def test_scan_files_url_zip_expansion(mock_tf_env, monkeypatch):
 
 def test_scan_files_clipboard_ipynb_expansion(mock_tf_env, monkeypatch):
     """Test that a Notebook in extra_snippets (clipboard) is expanded."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     nb_data = {
         "cells": [{"cell_type": "code", "source": ["print('clipboard cell')"]}]
     }

--- a/tests/test_url_scan.py
+++ b/tests/test_url_scan.py
@@ -28,7 +28,7 @@ def test_fetch_url_content_too_large():
 
 def test_scan_files_with_url_target(mock_tf_env, monkeypatch):
     """Test that URLs in scan_targets are fetched and scanned."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     url = "https://example.com/malicious.py"
     mock_content = b"print('malicious')"
 
@@ -56,7 +56,7 @@ def test_scan_files_with_url_target(mock_tf_env, monkeypatch):
 
 def test_scan_files_url_fetch_error(mock_tf_env, monkeypatch):
     """Test handling of URL fetch errors during scan."""
-    monkeypatch.setattr(gptscan, "collect_files", lambda targets: [])
+    monkeypatch.setattr(gptscan, "collect_files", lambda targets, **kwargs: [])
     url = "https://example.com/missing.sh"
 
     with patch("urllib.request.urlopen", side_effect=Exception("404 Not Found")):


### PR DESCRIPTION
This change improves code quality by removing a redundant conditional block in the core scanning logic and enhancing the robustness of associated unit tests.

- **What:** Refactored `scan_files` in `gptscan.py` to simplify the `collect_files` call and updated test mocks in the `tests/` directory to handle optional keyword arguments.
- **Why:** Simplifies the codebase by leveraging existing function default behaviors and improves test maintainability by fixing brittle mock implementations. External behavior remains identical, confirmed by 806 passing tests.

---
*PR created automatically by Jules for task [9252129765632362345](https://jules.google.com/task/9252129765632362345) started by @RainRat*