### PR TITLE
[FEAT] Scan Node.js Packages

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1256,6 +1256,27 @@ def get_python_package_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_node_package_paths() -> List[str]:
+    """Identify all directories containing installed Node.js packages (node_modules)."""
+    paths = []
+    # 1. Global Node.js packages via npm
+    try:
+        global_root = subprocess.check_output(
+            ["npm", "root", "-g"],
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True
+        ).strip()
+        if global_root:
+            paths.append(global_root)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    # 2. Local node_modules in current directory
+    paths.append(os.path.join(os.getcwd(), "node_modules"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
 def get_system_service_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all system services (Windows Service PathName)."""
     items = []
@@ -2425,6 +2446,19 @@ def scan_system_services_click():
         messagebox.showwarning("System Services Error", f"Could not scan system services: {e}")
 
 
+def scan_node_packages_click():
+    """Scan all directories containing installed Node.js packages (node_modules)."""
+    try:
+        package_paths = get_node_package_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Node.js Packages", "No Node.js node_modules directories were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Node.js Packages Error", f"Could not scan Node.js packages: {e}")
+
+
 def scan_python_packages_click():
     """Scan all directories containing installed Python packages (site-packages)."""
     try:
@@ -2473,6 +2507,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_system_service_paths())
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
+    all_paths.extend(get_node_package_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6685,6 +6720,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     browse_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
     browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
+    browse_menu.add_command(label="Scan Node.js Packages", command=scan_node_packages_click, accelerator="Ctrl+Shift+M")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -7062,6 +7098,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-S>', lambda event: scan_system_services_click())
     root.bind('<Control-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
+    root.bind('<Control-Shift-M>', lambda event: scan_node_packages_click())
+    root.bind('<Command-Shift-M>', lambda event: scan_node_packages_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7249,6 +7287,11 @@ def main():
         '--python-packages',
         action='store_true',
         help='Scan all directories containing installed Python packages (site-packages).'
+    )
+    scan_group.add_argument(
+        '--node-packages',
+        action='store_true',
+        help='Scan all directories containing installed Node.js packages (node_modules).'
     )
     scan_group.add_argument(
         '--env-vars',
@@ -7519,6 +7562,13 @@ def main():
                 scan_targets.extend(package_paths)
             else:
                 print("No Python site-packages directories were found.", file=sys.stderr)
+
+        if args.node_packages:
+            package_paths = get_node_package_paths()
+            if package_paths:
+                scan_targets.extend(package_paths)
+            else:
+                print("No Node.js node_modules directories were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Hooks:** Scan local and global Git hooks for dangerous scripts (Ctrl+Shift+G).
 *   **Scan Git Configuration:** Scan potentially dangerous Git configuration settings (aliases, editors, etc.).
 *   **Scan Git Revision...:** Scan files modified in a specific Git revision or commit.
-*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, system services, Git configuration, Git hooks, and installed Python packages (Ctrl+Shift+I).
+*   **System Audit:** Perform a comprehensive scan of your system including shell profiles, history, system PATH, SSH configurations, running processes, environment variables, scheduled tasks, startup items, system services, Git configuration, Git hooks, installed Python packages, and Node.js packages (Ctrl+Shift+I).
 *   **Scan Shell History:** Automatically find and scan your terminal history (Bash, Zsh, PowerShell, etc.) for dangerous one-liners.
 *   **Scan System PATH:** Scan all directories in your system PATH for suspicious executables or scripts.
 *   **Scan Running Processes:** Scan command lines of all running processes to find potentially dangerous execution strings (Ctrl+Shift+K).
@@ -73,6 +73,7 @@ Access these options from the **Browse** menu:
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
 *   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
+*   **Scan Node.js Packages:** Scan all directories containing installed Node.js packages (node_modules) for potentially malicious modules (Ctrl+Shift+M).
 
 ### Keyboard Shortcuts
 The scanner includes shortcuts for faster navigation:
@@ -103,6 +104,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+A` | Scan Startup Items |
 | `Ctrl+Shift+S` | Scan System Services |
 | `Ctrl+Shift+Y` | Scan Python Packages |
+| `Ctrl+Shift+M` | Scan Node.js Packages |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -161,6 +163,11 @@ python3 gptscan.py --audit --cli
 Scan all directories containing installed Python packages:
 ```bash
 python3 gptscan.py --python-packages --cli
+```
+
+Scan all directories containing installed Node.js packages:
+```bash
+python3 gptscan.py --node-packages --cli
 ```
 
 Scan all common shell profile and RC files:

--- a/tests/test_node_packages_scan.py
+++ b/tests/test_node_packages_scan.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+import pytest
+from gptscan import get_node_package_paths, scan_node_packages_click
+
+def test_get_node_package_paths_mocked(monkeypatch):
+    """Verify the logic of get_node_package_paths with mocked inputs."""
+
+    def mock_check_output(cmd, **kwargs):
+        if cmd == ["npm", "root", "-g"]:
+            return "/fake/global/node_modules\n"
+        return ""
+
+    monkeypatch.setattr(subprocess, "check_output", mock_check_output)
+
+    # Mock os.path.isdir to return True for our fake paths
+    def mock_isdir(p):
+        return "node_modules" in p
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
+
+    # Mock os.getcwd
+    monkeypatch.setattr(os, "getcwd", lambda: "/current/project")
+
+    paths = get_node_package_paths()
+
+    assert "/fake/global/node_modules" in paths
+    assert "/current/project/node_modules" in paths
+    assert len(paths) == 2
+
+def test_get_node_package_paths_no_npm(monkeypatch):
+    """Verify logic when npm is not found or fails."""
+
+    def mock_check_output(cmd, **kwargs):
+        raise FileNotFoundError("npm not found")
+
+    monkeypatch.setattr(subprocess, "check_output", mock_check_output)
+
+    def mock_isdir(p):
+        return "node_modules" in p
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
+    monkeypatch.setattr(os, "getcwd", lambda: "/current/project")
+
+    paths = get_node_package_paths()
+
+    assert "/current/project/node_modules" in paths
+    assert len(paths) == 1
+
+def test_scan_node_packages_click(monkeypatch):
+    """Verify the GUI callback for scanning Node.js packages."""
+    target_paths = []
+    def mock_set_scan_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+
+    def mock_button_click():
+        pass
+
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_scan_target)
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+    monkeypatch.setattr("gptscan.get_node_package_paths", lambda: ["/mock/node_modules"])
+
+    scan_node_packages_click()
+    assert target_paths == ["/mock/node_modules"]
+
+def test_scan_node_packages_click_no_paths(monkeypatch):
+    """Verify the GUI callback when no paths are found."""
+    monkeypatch.setattr("gptscan.get_node_package_paths", lambda: [])
+
+    message_box_shown = False
+    def mock_showinfo(title, message):
+        nonlocal message_box_shown
+        message_box_shown = True
+        assert "No Node.js node_modules" in message
+
+    import tkinter.messagebox
+    monkeypatch.setattr(tkinter.messagebox, "showinfo", mock_showinfo)
+
+    scan_node_packages_click()
+    assert message_box_shown


### PR DESCRIPTION
Implemented a new feature to scan Node.js package directories (`node_modules`) for malicious code. This provides symmetry with the existing Python package scanner and addresses supply chain security in the Node.js ecosystem.

Key additions:
- **Discovery Logic:** `get_node_package_paths` uses `npm root -g` for global packages and checks for local `node_modules`.
- **GUI Integration:** A new menu item "Scan Node.js Packages" in the "Browse" menu, with a dedicated keyboard shortcut `Ctrl+Shift+M`.
- **CLI Support:** A new `--node-packages` flag for terminal-based audits.
- **System Audit:** Node.js package paths are now included in the comprehensive system audit (`--audit`).
- **Tests:** Comprehensive unit tests in `tests/test_node_packages_scan.py`.
- **Documentation:** Updated `readme.md` with GUI, CLI, and shortcut details.

---
*PR created automatically by Jules for task [15280008353884540147](https://jules.google.com/task/15280008353884540147) started by @RainRat*