### PR TITLE
[FEAT] Global Node.js package scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1256,6 +1256,41 @@ def get_python_package_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_nodejs_package_paths() -> List[str]:
+    """Identify all directories containing global Node.js packages."""
+    paths = []
+    # 1. Ask npm for the global root
+    try:
+        # Use shell=True on Windows to find npm command properly
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['npm', 'root', '-g'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            paths.append(output)
+    except Exception:
+        pass
+
+    # 2. Common system paths (Unix-like)
+    if sys.platform != "win32":
+        paths.extend([
+            "/usr/local/lib/node_modules",
+            "/usr/lib/node_modules"
+        ])
+    else:
+        # Windows common paths
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            paths.append(os.path.join(appdata, "npm", "node_modules"))
+
+        program_files = os.environ.get("ProgramFiles")
+        if program_files:
+            paths.append(os.path.join(program_files, "nodejs", "node_modules"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
 def get_system_service_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all system services (Windows Service PathName)."""
     items = []
@@ -2463,6 +2498,19 @@ def scan_env_vars_click():
         messagebox.showwarning("Environment Variables Error", f"Could not scan environment variables: {e}")
 
 
+def scan_nodejs_packages_click():
+    """Scan all directories containing global Node.js packages."""
+    try:
+        package_paths = get_nodejs_package_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Node.js Packages", "No global Node.js package directories were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Node.js Packages Error", f"Could not scan Node.js packages: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2473,6 +2521,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_system_service_paths())
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
+    all_paths.extend(get_nodejs_package_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6644,7 +6693,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y/M).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6685,6 +6734,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     browse_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
     browse_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
+    browse_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
     browse_button["menu"] = browse_menu
 
     # --- Settings Container ---
@@ -7062,6 +7112,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-S>', lambda event: scan_system_services_click())
     root.bind('<Control-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
+    root.bind('<Control-Shift-M>', lambda event: scan_nodejs_packages_click())
+    root.bind('<Command-Shift-M>', lambda event: scan_nodejs_packages_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7249,6 +7301,11 @@ def main():
         '--python-packages',
         action='store_true',
         help='Scan all directories containing installed Python packages (site-packages).'
+    )
+    scan_group.add_argument(
+        '--nodejs-packages',
+        action='store_true',
+        help='Scan all directories containing global Node.js packages.'
     )
     scan_group.add_argument(
         '--env-vars',
@@ -7519,6 +7576,13 @@ def main():
                 scan_targets.extend(package_paths)
             else:
                 print("No Python site-packages directories were found.", file=sys.stderr)
+
+        if args.nodejs_packages:
+            node_paths = get_nodejs_package_paths()
+            if node_paths:
+                scan_targets.extend(node_paths)
+            else:
+                print("No global Node.js package directories were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/tests/test_nodejs_packages_scan.py
+++ b/tests/test_nodejs_packages_scan.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import subprocess
+from unittest.mock import patch, MagicMock
+import pytest
+import gptscan
+
+def test_get_nodejs_package_paths_unix(monkeypatch):
+    """Test Node.js package path detection on Unix-like systems."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Mock npm root -g
+    def mock_check_output(cmd, **kwargs):
+        if cmd[:3] == ['npm', 'root', '-g']:
+            return "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules\n"
+        raise subprocess.CalledProcessError(1, cmd)
+
+    # Mock os.path.isdir to return True for our expected paths
+    def mock_isdir(path):
+        return path in [
+            "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules",
+            "/usr/local/lib/node_modules",
+            "/usr/lib/node_modules"
+        ]
+
+    with patch("subprocess.check_output", side_effect=mock_check_output), \
+         patch("os.path.isdir", side_effect=mock_isdir):
+        paths = gptscan.get_nodejs_package_paths()
+
+        assert "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules" in paths
+        assert "/usr/local/lib/node_modules" in paths
+        assert "/usr/lib/node_modules" in paths
+
+def test_get_nodejs_package_paths_windows(monkeypatch):
+    """Test Node.js package path detection on Windows."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    # Mock npm root -g
+    def mock_check_output(cmd, **kwargs):
+        if cmd[:3] == ['npm', 'root', '-g']:
+            return "C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\r\n"
+        raise subprocess.CalledProcessError(1, cmd)
+
+    # Mock environment variables
+    monkeypatch.setenv("APPDATA", "C:\\Users\\User\\AppData\\Roaming")
+    monkeypatch.setenv("ProgramFiles", "C:\\Program Files")
+
+    # Mock os.path.isdir
+    def mock_isdir(path):
+            return True
+
+    with patch("subprocess.check_output", side_effect=mock_check_output), \
+         patch("os.path.isdir", side_effect=mock_isdir):
+        # We need to mock abspath and join to be platform-agnostic for Windows paths on Linux
+        monkeypatch.setattr(os.path, "abspath", lambda x: x)
+        monkeypatch.setattr(os.path, "join", lambda *args: "\\".join(args))
+
+        paths = gptscan.get_nodejs_package_paths()
+
+        assert "C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules" in paths
+        assert "C:\\Program Files\\nodejs\\node_modules" in paths
+
+def test_get_nodejs_package_paths_no_npm(monkeypatch):
+    """Test behavior when npm is not found."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    with patch("subprocess.check_output", side_effect=FileNotFoundError), \
+         patch("os.path.isdir", return_value=True):
+        paths = gptscan.get_nodejs_package_paths()
+        # Should still contain common system paths
+        assert "/usr/local/lib/node_modules" in paths
+        assert "/usr/lib/node_modules" in paths
+
+def test_system_audit_includes_nodejs(monkeypatch):
+    """Verify that System Audit includes Node.js package paths."""
+    with patch("gptscan.get_nodejs_package_paths", return_value=["/mock/node_modules"]), \
+         patch("gptscan.get_shell_profile_paths", return_value=[]), \
+         patch("gptscan.get_shell_history_paths", return_value=[]), \
+         patch("gptscan.get_system_path_directories", return_value=[]), \
+         patch("gptscan.get_ssh_config_paths", return_value=[]), \
+         patch("gptscan.get_system_service_paths", return_value=[]), \
+         patch("gptscan.get_git_hooks_paths", return_value=[]), \
+         patch("gptscan.get_python_package_paths", return_value=[]):
+
+        all_paths, _ = gptscan.get_system_audit_data()
+        assert "/mock/node_modules" in all_paths


### PR DESCRIPTION
Implemented global Node.js package scanning to complement existing Python package scanning. The feature includes CLI support via `--nodejs-packages`, GUI support with a dedicated menu item and shortcut (`Ctrl+Shift+M`), and automatic inclusion in system audits. Path detection is robust, using `npm root -g` where available and falling back to standard platform-specific directories.

---
*PR created automatically by Jules for task [4316341705914674213](https://jules.google.com/task/4316341705914674213) started by @RainRat*