### PR TITLE
Fix cross-platform path quoting logic bug

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -715,6 +715,21 @@ def bind_hover_message(widget: tk.Widget, message: str, label: Optional[ttk.Labe
     widget.bind("<Leave>", on_leave)
 
 
+def _quote_for_ui(path: str) -> str:
+    """Quote a path for the UI textbox based on the platform.
+
+    On Windows, it uses double quotes if the path contains spaces.
+    On other platforms, it uses shlex.quote.
+    """
+    if not path:
+        return ""
+    if sys.platform == "win32":
+        if ' ' in path:
+            return '"' + path.replace('"', '""') + '"'
+        return path
+    return shlex.quote(path)
+
+
 def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
     """Update the scan target textbox and set focus to the scan button.
 
@@ -727,10 +742,10 @@ def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
     # Handle multiple paths or a single path string
     if isinstance(path, (list, tuple)):
         # Join multiple targets with appropriate quoting, ensuring all are strings
-        formatted_path = shlex.join(str(p) for p in path)
+        formatted_path = " ".join(_quote_for_ui(str(p)) for p in path)
     else:
         # For a single path, use quote if it's not a list, for safety
-        formatted_path = shlex.quote(str(path))
+        formatted_path = _quote_for_ui(str(path))
 
     textbox.delete(0, tk.END)
     textbox.insert(0, formatted_path)
@@ -6470,10 +6485,10 @@ def copy_cli_command(event: Optional[tk.Event] = None) -> None:
             # Parse possible multiple targets from the GUI textbox
             targets = shlex.split(raw_target, posix=(sys.platform != "win32"))
             for t in targets:
-                cmd_parts.append(shlex.quote(t))
+                cmd_parts.append(_quote_for_ui(t))
         except ValueError:
             # Fallback to quoting the raw string if parsing fails
-            cmd_parts.append(shlex.quote(raw_target))
+            cmd_parts.append(_quote_for_ui(raw_target))
 
     cmd_parts.append("--cli")
 


### PR DESCRIPTION
* **What:** Introduced a `_quote_for_ui` helper function to handle platform-specific path quoting. On Windows, it uses double quotes for paths with spaces (compatible with `shlex.split(posix=False)`), while on other platforms it continues to use `shlex.quote`. Updated `_set_scan_target` and `copy_cli_command` to use this helper.
* **Why:** Resolves a logic bug where single-quoted paths from `shlex.quote` were incorrectly parsed on Windows, causing file paths with spaces to be mangled. This ensures generated CLI commands and UI scan targets work correctly across all supported operating systems. No breaking changes were introduced as POSIX behavior remains unchanged.

---
*PR created automatically by Jules for task [328467489387960527](https://jules.google.com/task/328467489387960527) started by @RainRat*