### PR TITLE
[TEST] Add Windows system SSH discovery and consolidate SSH tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1379,12 +1379,22 @@ def get_ssh_config_paths() -> List[str]:
                 paths.append(str(p))
 
     # System-level SSH files
-    system_ssh_dir = Path("/etc/ssh")
-    if system_ssh_dir.exists():
-        for f in ["sshd_config", "ssh_config"]:
-            p = system_ssh_dir / f
-            if p.exists():
-                paths.append(str(p))
+    if sys.platform == "win32":
+        program_data = os.environ.get("ProgramData")
+        if program_data:
+            win_system_ssh = Path(program_data) / "ssh"
+            if win_system_ssh.exists():
+                for f in ["sshd_config", "ssh_config"]:
+                    p = win_system_ssh / f
+                    if p.exists():
+                        paths.append(str(p))
+    else:
+        system_ssh_dir = Path("/etc/ssh")
+        if system_ssh_dir.exists():
+            for f in ["sshd_config", "ssh_config"]:
+                p = system_ssh_dir / f
+                if p.exists():
+                    paths.append(str(p))
 
     return sorted(list(set(paths)))
 

--- a/tests/test_ssh_config_scanning.py
+++ b/tests/test_ssh_config_scanning.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+def test_get_ssh_config_paths_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    # Mock Path.exists to control which files are found
+    def mock_exists(self):
+        valid_paths = [
+            "/home/user/.ssh",
+            "/home/user/.ssh/config",
+            "/home/user/.ssh/authorized_keys",
+            "/etc/ssh",
+            "/etc/ssh/sshd_config",
+            "/etc/ssh/ssh_config"
+        ]
+        return str(self).replace("\\", "/") in valid_paths
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    paths = [p.replace("\\", "/") for p in gptscan.get_ssh_config_paths()]
+
+    assert "/home/user/.ssh/config" in paths
+    assert "/home/user/.ssh/authorized_keys" in paths
+    assert "/etc/ssh/sshd_config" in paths
+    assert "/etc/ssh/ssh_config" in paths
+    assert len(paths) == 4
+
+def test_get_ssh_config_paths_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    home = Path("C:/Users/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("ProgramData", "C:/ProgramData")
+
+    def mock_exists(self):
+        valid_paths = [
+            "C:/Users/user/.ssh",
+            "C:/Users/user/.ssh/config",
+            "C:/ProgramData/ssh",
+            "C:/ProgramData/ssh/sshd_config"
+        ]
+        return str(self).replace("\\", "/") in valid_paths
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    paths = [p.replace("\\", "/") for p in gptscan.get_ssh_config_paths()]
+
+    assert "C:/Users/user/.ssh/config" in paths
+    assert "C:/ProgramData/ssh/sshd_config" in paths
+    assert "C:/Users/user/.ssh/authorized_keys" not in paths
+    assert "/etc/ssh/sshd_config" not in paths
+    assert len(paths) == 2
+
+def test_get_ssh_config_paths_empty(monkeypatch):
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    paths = gptscan.get_ssh_config_paths()
+    assert paths == []

--- a/tests/test_system_audit.py
+++ b/tests/test_system_audit.py
@@ -3,28 +3,6 @@ from unittest.mock import patch, MagicMock
 import gptscan
 from pathlib import Path
 
-def test_get_ssh_config_paths(monkeypatch):
-    home = Path("/home/user")
-    monkeypatch.setattr("pathlib.Path.home", lambda: home)
-
-    # Mock Path.exists to return True for our expected paths
-    original_exists = Path.exists
-    def mock_exists(self):
-        if str(self) in ["/home/user/.ssh/config", "/home/user/.ssh/authorized_keys", "/etc/ssh/sshd_config", "/etc/ssh/ssh_config"]:
-            return True
-        if ".ssh" in str(self) or "etc/ssh" in str(self):
-             return True
-        return False
-
-    monkeypatch.setattr(Path, "exists", mock_exists)
-    monkeypatch.setattr(Path, "is_dir", lambda self: True)
-
-    paths = gptscan.get_ssh_config_paths()
-    assert "/home/user/.ssh/config" in paths
-    assert "/home/user/.ssh/authorized_keys" in paths
-    assert "/etc/ssh/sshd_config" in paths
-    assert "/etc/ssh/ssh_config" in paths
-
 def test_scan_system_audit_click(monkeypatch):
     monkeypatch.setattr("gptscan.get_shell_profile_paths", lambda: ["/p1"])
     monkeypatch.setattr("gptscan.get_shell_history_paths", lambda: ["/h1"])


### PR DESCRIPTION
This PR addresses a platform-specific gap in the SSH configuration discovery logic and improves test suite hygiene.

### Changes:
1.  **Core Logic Update**: Modified `get_ssh_config_paths` in `gptscan.py` to identify system-level OpenSSH configuration files on Windows (located in `%ProgramData%\ssh`). Previously, only POSIX paths (`/etc/ssh`) were supported for system-level scans.
2.  **Test Consolidation**: Extracted the SSH-specific test from `tests/test_system_audit.py` into a new, dedicated test module: `tests/test_ssh_config_scanning.py`.
3.  **Enhanced Coverage**: The new test suite includes robust mocks for both POSIX and Windows environments, verifying:
    *   User-level `.ssh` config and `authorized_keys` discovery.
    *   System-level `sshd_config` and `ssh_config` discovery on Linux/macOS.
    *   System-level configuration discovery on Windows via `%ProgramData%`.
    *   Graceful handling of missing directories and files.

### Why:
*   **Gap Analysis**: Resolves a missing feature where Windows system-level SSH services were not being audited.
*   **Hygiene**: Improves test discovery and maintainability by moving domain-specific tests out of the monolithic system audit test file.
*   **Reliability**: Provides better isolation and platform-specific verification through targeted mocking.

---
*PR created automatically by Jules for task [1759083874759335413](https://jules.google.com/task/1759083874759335413) started by @RainRat*