### PR TITLE
[DOCS] Simplify iter_windows docstring

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3747,14 +3747,14 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
 
 
 def iter_windows(fh, size: int, deep_scan: bool, maxlen: Optional[int] = None) -> Generator[Tuple[int, bytes], None, None]:
-    """Yield file chunks for the local scanner.
+    """Provide parts of the file for the local scanner to check.
 
     By default, this function only reads the beginning and end of a file.
-    This approach is fast and effective because most dangerous payloads and
-    script headers are found in these locations. If deep_scan is True, the
-    function reads the entire file instead.
+    This is fast because most dangerous code and script starts are
+    found in these parts. If deep_scan is True, the function reads the
+    entire file instead.
 
-    The window size defaults to 1024 bytes (maxlen) to match the input
+    The chunk size defaults to 1024 bytes (maxlen). This matches the
     requirements of the pre-trained scripts.h5 model.
     """
     if maxlen is None:


### PR DESCRIPTION
**PR Title:** [DOCS] Simplify iter_windows docstring
**Description:**
* **Type:** Code Comments
* **What:** Updated the `iter_windows` docstring in `gptscan.py`.
* **Why:** Simplified the language by using Plain English and removing technical jargon like "yield", "payloads", and "headers". This makes the core scanning logic easier to understand for an international audience.

---
*PR created automatically by Jules for task [16977036501101209631](https://jules.google.com/task/16977036501101209631) started by @RainRat*