### PR TITLE
[UI/UX] Enable multi-selection for "View Online" with safety confirmation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6320,42 +6320,51 @@ def copy_as_json(event: Optional[tk.Event] = None) -> None:
 
 def view_online(event_or_path: Union[tk.Event, str, None] = None, line: Optional[Union[int, str]] = None) -> None:
     """Open the selected result in a web browser (GitHub/GitLab/Bitbucket)."""
-    # 1. Resolve path and line number
-    file_path = None
-    line_num = line
+    # List of (path, line_num)
+    targets: List[Tuple[str, Union[int, str]]] = []
 
     if isinstance(event_or_path, str):
-        file_path = event_or_path
+        targets.append((event_or_path, line if line is not None else 1))
     else:
         if not tree:
             return
         selection = tree.selection()
         if not selection:
             return
-        values = _get_item_raw_values(selection[0])
-        if not values:
-            return
-        file_path = str(values[0])
-        if line_num is None:
-            line_num = values[6] if len(values) > 6 else 1
 
-    if not file_path:
-        return
-    if line_num is None:
-        line_num = 1
+        # Avoid accidental mass tab opening
+        if len(selection) > 5:
+            if not messagebox.askyesno("View Online",
+                                        f"You have selected {len(selection)} files. Do you want to open that many browser tabs?"):
+                return
 
-    # 2. Get URL
-    url = get_online_url(file_path, line_num)
+        for item_id in selection:
+            vals = _get_item_raw_values(item_id)
+            if vals:
+                path = str(vals[0])
+                line_num = vals[6] if len(vals) > 6 and vals[6] != "-" else 1
+                targets.append((path, line_num))
 
-    if url:
-        webbrowser.open(url)
-        update_status(f"Opening online view for {os.path.basename(file_path)}...")
-    else:
+    success_count = 0
+    last_path = ""
+    for file_path, line_num in targets:
+        url = get_online_url(file_path, line_num)
+        if url:
+            webbrowser.open(url)
+            success_count += 1
+            last_path = file_path
+
+    if success_count > 0:
+        if success_count == 1:
+            update_status(f"Opening online view for {os.path.basename(last_path)}...")
+        else:
+            update_status(f"Opening online view for {success_count} files...")
+    elif not isinstance(event_or_path, str):
         messagebox.showinfo(
             "Online View Unavailable",
-            "This file could not be resolved to an online repository.\n\n"
-            "Ensure it is part of a Git project with a remote origin (GitHub, GitLab, or Bitbucket) "
-            "or is a remote URL target."
+            "The selected file(s) could not be resolved to an online repository.\n\n"
+            "Ensure they are part of a Git project with a remote origin (GitHub, GitLab, or Bitbucket) "
+            "or are remote URL targets."
         )
 
 

--- a/tests/test_view_online_multi.py
+++ b/tests/test_view_online_multi.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import os
+
+@pytest.fixture
+def mock_gui_vars(monkeypatch):
+    mock_tree = MagicMock()
+    mock_status = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'status_label', mock_status)
+    return mock_tree, mock_status
+
+def test_view_online_multi_selection(mock_gui_vars):
+    mock_tree, _ = mock_gui_vars
+    mock_tree.selection.return_value = ['item1', 'item2']
+
+    def mock_get_item_raw_values(item_id):
+        if item_id == 'item1':
+            return ["file1.py", "50%", "Admin", "User", "50%", "snippet1", "10"]
+        if item_id == 'item2':
+            return ["file2.py", "60%", "Admin", "User", "60%", "snippet2", "20"]
+        return None
+
+    with patch('gptscan._get_item_raw_values', side_effect=mock_get_item_raw_values), \
+         patch('gptscan.get_online_url', side_effect=lambda p, l: f"http://online/{p}"), \
+         patch('webbrowser.open') as mock_open, \
+         patch('gptscan.update_status') as mock_status_update:
+
+        gptscan.view_online()
+
+        assert mock_open.call_count == 2
+        mock_open.assert_any_call("http://online/file1.py")
+        mock_open.assert_any_call("http://online/file2.py")
+        mock_status_update.assert_called_with("Opening online view for 2 files...")
+
+def test_view_online_multi_selection_with_confirmation_yes(mock_gui_vars):
+    mock_tree, _ = mock_gui_vars
+    mock_tree.selection.return_value = ['item1', 'item2', 'item3', 'item4', 'item5', 'item6']
+
+    with patch('gptscan._get_item_raw_values', return_value=["file.py", "50%", "", "", "", "snippet", "1"]), \
+         patch('gptscan.messagebox.askyesno', return_value=True) as mock_ask, \
+         patch('gptscan.get_online_url', return_value="http://online"), \
+         patch('webbrowser.open') as mock_open:
+
+        gptscan.view_online()
+
+        mock_ask.assert_called_once()
+        assert mock_open.call_count == 6
+
+def test_view_online_multi_selection_with_confirmation_no(mock_gui_vars):
+    mock_tree, _ = mock_gui_vars
+    mock_tree.selection.return_value = ['item1', 'item2', 'item3', 'item4', 'item5', 'item6']
+
+    with patch('gptscan.messagebox.askyesno', return_value=False) as mock_ask, \
+         patch('webbrowser.open') as mock_open:
+
+        gptscan.view_online()
+
+        mock_ask.assert_called_once()
+        assert mock_open.call_count == 0
+
+def test_view_online_single_selection_status(mock_gui_vars):
+    mock_tree, _ = mock_gui_vars
+    mock_tree.selection.return_value = ['item1']
+
+    with patch('gptscan._get_item_raw_values', return_value=["path/to/my_file.py", "50%", "", "", "", "snippet", "1"]), \
+         patch('gptscan.get_online_url', return_value="http://online"), \
+         patch('webbrowser.open') as mock_open, \
+         patch('gptscan.update_status') as mock_status_update:
+
+        gptscan.view_online()
+
+        assert mock_open.call_count == 1
+        mock_status_update.assert_called_with("Opening online view for my_file.py...")


### PR DESCRIPTION
### Context: GUI
### Problem: 
The "View Online" action was restricted to the first selected item in the results list, causing friction for users who wanted to review multiple git-tracked findings in their browser simultaneously. Furthermore, there was no safety mechanism to prevent accidentally opening a large number of browser tabs if a user performed the action on a massive selection.

### Solution: 
Updated the `view_online` function to iterate through all currently selected items in the Treeview. 
1.  **Friction Reduction:** Users can now select multiple rows and open them all in the browser with a single click or shortcut (Ctrl+L).
2.  **Safety Mechanism:** Added a confirmation prompt (`messagebox.askyesno`) if the selection exceeds 5 items, consistent with the `check_virustotal` implementation.
3.  **Feedback & Clarity:** The status bar now provides a plural-aware summary (e.g., "Opening online view for 3 files...") instead of always referencing a single file.
4.  **Robustness:** Improved line number resolution to handle cases where no line is detected (defaulting to line 1).

### Changes:
- Modified `view_online` in `gptscan.py`.
- Created `tests/test_view_online_multi.py` for verification.

---
*PR created automatically by Jules for task [16402754594250710740](https://jules.google.com/task/16402754594250710740) started by @RainRat*