### PR TITLE
[FEAT] Scan Editor Extensions

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1256,6 +1256,46 @@ def get_python_package_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_editor_extensions_paths() -> List[str]:
+    """Identify common editor extension directories (VS Code, Sublime Text, Vim/Neovim)."""
+    paths = []
+    home = Path.home()
+
+    # 1. VS Code / Insiders / VSCodium
+    vscode_dirs = [".vscode", ".vscode-insiders", ".vscode-oss", ".vscode-remote"]
+    for d in vscode_dirs:
+        p = home / d / "extensions"
+        if p.exists():
+            paths.append(str(p))
+
+    # 2. Sublime Text
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            paths.append(os.path.join(appdata, "Sublime Text", "Packages"))
+            paths.append(os.path.join(appdata, "Sublime Text 3", "Packages"))
+    elif sys.platform == "darwin":
+        paths.append(str(home / "Library" / "Application Support" / "Sublime Text" / "Packages"))
+        paths.append(str(home / "Library" / "Application Support" / "Sublime Text 3" / "Packages"))
+    else:
+        paths.append(str(home / ".config" / "sublime-text" / "Packages"))
+        paths.append(str(home / ".config" / "sublime-text-3" / "Packages"))
+
+    # 3. Vim / Neovim
+    # Vim 8+ native packages
+    paths.append(str(home / ".vim" / "pack"))
+    # Neovim native packages
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        if local_appdata:
+            paths.append(os.path.join(local_appdata, "nvim-data", "site", "pack"))
+    else:
+        paths.append(str(home / ".local" / "share" / "nvim" / "site" / "pack"))
+    paths.append(str(home / ".config" / "nvim" / "pack"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
 def get_nodejs_package_paths() -> List[str]:
     """Identify all directories containing global Node.js packages."""
     paths = []
@@ -2512,6 +2552,19 @@ def scan_nodejs_packages_click():
         messagebox.showwarning("Node.js Packages Error", f"Could not scan Node.js packages: {e}")
 
 
+def scan_editor_extensions_click():
+    """Scan all directories containing editor extensions (VS Code, Sublime Text, Vim)."""
+    try:
+        extension_paths = get_editor_extensions_paths()
+        if extension_paths:
+            _set_scan_target(extension_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Editor Extensions", "No editor extension directories were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Editor Extensions Error", f"Could not scan editor extensions: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2523,6 +2576,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
     all_paths.extend(get_nodejs_package_paths())
+    all_paths.extend(get_editor_extensions_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6691,7 +6745,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y/M).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y/M/X).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6737,6 +6791,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
+    system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
 
@@ -7117,6 +7172,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Control-Shift-M>', lambda event: scan_nodejs_packages_click())
     root.bind('<Command-Shift-M>', lambda event: scan_nodejs_packages_click())
+    root.bind('<Control-Shift-X>', lambda event: scan_editor_extensions_click())
+    root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7190,6 +7247,8 @@ def main():
                "  python3 gptscan.py https://github.com/user/repo --cli\n\n"
                "  # Run a full system check\n"
                "  python3 gptscan.py --audit --cli\n\n"
+               "  # Scan all installed editor extensions\n"
+               "  python3 gptscan.py --editor-extensions --cli\n\n"
                "  # Scan files changed in the last 24 hours\n"
                "  python3 gptscan.py --modified 24h --cli\n\n"
                "Note: Run the script from its own folder so it can find its data files.",
@@ -7309,6 +7368,11 @@ def main():
         '--nodejs-packages',
         action='store_true',
         help='Scan all directories containing global Node.js packages.'
+    )
+    scan_group.add_argument(
+        '--editor-extensions',
+        action='store_true',
+        help='Scan all common editor extension directories.'
     )
     scan_group.add_argument(
         '--env-vars',
@@ -7586,6 +7650,13 @@ def main():
                 scan_targets.extend(node_paths)
             else:
                 print("No global Node.js package directories were found.", file=sys.stderr)
+
+        if args.editor_extensions:
+            extension_paths = get_editor_extensions_paths()
+            if extension_paths:
+                scan_targets.extend(extension_paths)
+            else:
+                print("No editor extension directories were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Access these options from the **Browse** menu:
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
 *   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
+*   **Scan Editor Extensions:** Scan all directories containing editor extensions (VS Code, Sublime Text, Vim) for potentially malicious scripts (Ctrl+Shift+X).
 
 ### Keyboard Shortcuts
 The scanner includes shortcuts for faster navigation:
@@ -102,6 +103,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+A` | Scan Startup Items |
 | `Ctrl+Shift+S` | Scan System Services |
 | `Ctrl+Shift+Y` | Scan Python Packages |
+| `Ctrl+Shift+X` | Scan Editor Extensions |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -160,6 +162,11 @@ python3 gptscan.py --audit --cli
 Scan all directories containing installed Python packages:
 ```bash
 python3 gptscan.py --python-packages --cli
+```
+
+Scan all directories containing editor extensions:
+```bash
+python3 gptscan.py --editor-extensions --cli
 ```
 
 Scan all common shell profile and RC files:

--- a/tests/test_editor_extensions.py
+++ b/tests/test_editor_extensions.py
@@ -1,0 +1,67 @@
+import sys
+import os
+from pathlib import Path
+import pytest
+from gptscan import get_editor_extensions_paths, scan_editor_extensions_click
+
+def test_get_editor_extensions_paths_mocked(monkeypatch):
+    """Verify the logic of get_editor_extensions_paths with mocked inputs."""
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    fake_paths = [
+        home / ".vscode" / "extensions",
+        home / ".config" / "sublime-text" / "Packages",
+        home / ".vim" / "pack",
+        home / ".local" / "share" / "nvim" / "site" / "pack",
+    ]
+
+    def mock_exists(self):
+        return self in fake_paths
+
+    def mock_isdir(p):
+        return Path(p) in fake_paths
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    paths = get_editor_extensions_paths()
+
+    assert str(home / ".vscode" / "extensions") in paths
+    assert str(home / ".config" / "sublime-text" / "Packages") in paths
+    assert str(home / ".vim" / "pack") in paths
+    assert str(home / ".local" / "share" / "nvim" / "site" / "pack") in paths
+
+def test_scan_editor_extensions_click(monkeypatch):
+    """Verify the GUI callback for scanning editor extensions."""
+    target_paths = []
+    def mock_set_scan_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+
+    def mock_button_click():
+        pass
+
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_scan_target)
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+    monkeypatch.setattr("gptscan.get_editor_extensions_paths", lambda: ["/mock/vscode/extensions"])
+
+    scan_editor_extensions_click()
+    assert target_paths == ["/mock/vscode/extensions"]
+
+def test_scan_editor_extensions_click_no_paths(monkeypatch):
+    """Verify the GUI callback when no paths are found."""
+    monkeypatch.setattr("gptscan.get_editor_extensions_paths", lambda: [])
+
+    message_box_shown = False
+    def mock_showinfo(title, message):
+        nonlocal message_box_shown
+        message_box_shown = True
+        assert "No editor extension directories" in message
+
+    import gptscan
+    monkeypatch.setattr(gptscan.messagebox, "showinfo", mock_showinfo)
+
+    scan_editor_extensions_click()
+    assert message_box_shown


### PR DESCRIPTION
* **What:** Implemented a new "Scan Editor Extensions" feature that automatically identifies and scans extension directories for popular code editors, including VS Code (Insiders, VSCodium, Remote), Sublime Text (2/3), and Vim/Neovim (native packages). The feature is integrated into the GUI (Browse > System Scans), CLI (`--editor-extensions`), and the comprehensive System Audit (`--audit`).
* **Why:** I noticed the codebase already provides specialized scans for system-level vectors like Python packages, Node.js packages, and shell profiles. Editor extensions are a significant similar vector for potentially malicious third-party scripts or persistence mechanisms, making this a logical and highly useful addition for security auditing.

---
*PR created automatically by Jules for task [8644615232453581089](https://jules.google.com/task/8644615232453581089) started by @RainRat*