### PR TITLE
[Inline premature git metadata abstractions]

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1636,32 +1636,6 @@ def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
 
-def _get_git_remote_url(toplevel: str) -> Optional[str]:
-    """Get the remote origin URL for the Git repository."""
-    try:
-        return subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
-            cwd=toplevel,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
-
-
-def _get_git_revision(toplevel: str) -> Optional[str]:
-    """Get the current Git revision (SHA) for the repository."""
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            cwd=toplevel,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
-
-
 def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
     """Construct a web URL for a local Git-tracked file or a remote target.
 
@@ -1704,11 +1678,25 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
     if not toplevel or not rel_path:
         return None
 
-    remote = _get_git_remote_url(toplevel)
-    if not remote:
+    try:
+        remote = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
 
-    rev = _get_git_revision(toplevel) or "HEAD"
+    try:
+        rev = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        rev = "HEAD"
 
     # Normalize Remote URL (Convert SSH to HTTPS, remove .git suffix)
     # git@host:user/repo.git -> https://host/user/repo

--- a/tests/test_view_online.py
+++ b/tests/test_view_online.py
@@ -20,31 +20,36 @@ def test_get_online_url_remote_target():
     assert url == "https://bitbucket.org/user/repo/src/main/file.py#lines-10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-@patch('gptscan._get_git_revision')
-def test_get_online_url_local_file(mock_rev, mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_local_file(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "git@github.com:user/repo.git"
-    mock_rev.return_value = "abcdef"
+    # First call: git remote get-url origin
+    # Second call: git rev-parse HEAD
+    mock_check_output.side_effect = [
+        "git@github.com:user/repo.git\n",
+        "abcdef\n"
+    ]
 
     url = get_online_url("/app/src/file.py", 10)
     assert url == "https://github.com/user/repo/blob/abcdef/src/file.py#L10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-def test_get_online_url_local_file_gitlab(mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_local_file_gitlab(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "https://gitlab.com/user/repo.git"
+    mock_check_output.side_effect = [
+        "https://gitlab.com/user/repo.git\n",
+        "main\n"
+    ]
 
-    with patch('gptscan._get_git_revision', return_value="main"):
-        url = get_online_url("/app/src/file.py", 10)
-        assert url == "https://gitlab.com/user/repo/-/blob/main/src/file.py#L10"
+    url = get_online_url("/app/src/file.py", 10)
+    assert url == "https://gitlab.com/user/repo/-/blob/main/src/file.py#L10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-def test_get_online_url_unsupported_remote(mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_unsupported_remote(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "https://myserver.com/repo.git"
+    mock_check_output.return_value = "https://myserver.com/repo.git\n"
 
     url = get_online_url("/app/src/file.py", 10)
     assert url is None


### PR DESCRIPTION
* **What:** Inlined the private helper functions `_get_git_remote_url` and `_get_git_revision` directly into their sole call site, `get_online_url`, in `gptscan.py`. Associated unit tests in `tests/test_view_online.py` were updated to reflect this structural change.
* **Why:** These functions were identified as premature abstractions that added complexity without providing reusability or significant clarity. Inlining them simplifies the codebase. The refactor preserves all existing error handling (`subprocess` exceptions) and fallbacks (returning `None` or `"HEAD"`). Behavior was verified by running and updating the relevant test suite.

---
*PR created automatically by Jules for task [14881447557299805459](https://jules.google.com/task/14881447557299805459) started by @RainRat*