### PR TITLE
[TEST] Add coverage for _normalize_and_filter_dirs utility

### DIFF
--- a/tests/test_normalize_and_filter_dirs.py
+++ b/tests/test_normalize_and_filter_dirs.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+from gptscan import _normalize_and_filter_dirs
+
+def test_normalize_and_filter_dirs_basic(tmp_path):
+    d1 = tmp_path / "dir1"
+    d1.mkdir()
+    d2 = tmp_path / "dir2"
+    d2.mkdir()
+
+    paths = [str(d1), str(d2)]
+    result = _normalize_and_filter_dirs(paths)
+    assert len(result) == 2
+    assert os.path.abspath(str(d1)) in result
+    assert os.path.abspath(str(d2)) in result
+
+def test_normalize_and_filter_dirs_none_empty():
+    paths = [None, ""]
+    result = _normalize_and_filter_dirs(paths)
+    assert result == []
+
+def test_normalize_and_filter_dirs_deduplication(tmp_path):
+    d1 = tmp_path / "dir1"
+    d1.mkdir()
+
+    abs_d1 = os.path.abspath(str(d1))
+
+    # Using relative path to the same directory
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        rel_d1 = "dir1"
+        paths = [abs_d1, rel_d1, abs_d1]
+        result = _normalize_and_filter_dirs(paths)
+        assert result == [abs_d1]
+    finally:
+        os.chdir(cwd)
+
+def test_normalize_and_filter_dirs_non_existent(tmp_path):
+    d1 = tmp_path / "non_existent"
+
+    result = _normalize_and_filter_dirs([str(d1)])
+    assert result == []
+
+def test_normalize_and_filter_dirs_files(tmp_path):
+    f1 = tmp_path / "file.txt"
+    f1.write_text("hello")
+
+    result = _normalize_and_filter_dirs([str(f1)])
+    assert result == []
+
+def test_normalize_and_filter_dirs_order(tmp_path):
+    d1 = tmp_path / "dir1"
+    d1.mkdir()
+    d2 = tmp_path / "dir2"
+    d2.mkdir()
+
+    abs_d1 = os.path.abspath(str(d1))
+    abs_d2 = os.path.abspath(str(d2))
+
+    paths = [str(d2), str(d1), str(d2)]
+    result = _normalize_and_filter_dirs(paths)
+    assert result == [abs_d2, abs_d1]


### PR DESCRIPTION
### Type: New Coverage

### What:
Added a new unit test suite `tests/test_normalize_and_filter_dirs.py` specifically targeting the `_normalize_and_filter_dirs` internal helper function in `gptscan.py`.

### Why:
The `_normalize_and_filter_dirs` function is a critical utility used by multiple system-level scan features (such as scanning the system PATH, Python packages, Node.js packages, and editor extensions) to ensure that scan targets are valid, absolute, and deduplicated directories. Previously, this function lacked direct unit test coverage, making it a priority for gap analysis. The new tests ensure that the core logic for path normalization and filtering remains robust as the application grows.

---
*PR created automatically by Jules for task [12704811612629955126](https://jules.google.com/task/12704811612629955126) started by @RainRat*