### PR TITLE
[TEST] Fix and test SHA256 copying for archive members

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6260,8 +6260,8 @@ def copy_sha256(event: Optional[tk.Event] = None) -> None:
             continue
         file_path = str(values[0])
 
-        if file_path.startswith("["):
-            # For virtual paths, hash the snippet content
+        if file_path.startswith("[") or not os.path.exists(file_path):
+            # For virtual paths or non-existent files (like archive members), hash the snippet content
             snippet = str(values[5])
             h = get_file_sha256(snippet.encode('utf-8'))
         else:

--- a/tests/test_threat_intel.py
+++ b/tests/test_threat_intel.py
@@ -110,6 +110,21 @@ def test_check_virustotal_virtual_path(mock_tree):
     expected_url = f"https://www.virustotal.com/gui/file/{expected_hash}"
     mock_open.assert_called_once_with(expected_url)
 
+def test_copy_sha256_archive_member(mock_tree):
+    """Test that copy_sha256 hashes the snippet for archive members."""
+    snippet = "print('archive')"
+    expected_hash = hashlib.sha256(snippet.encode('utf-8')).hexdigest()
+
+    mock_tree.selection.return_value = ["item1"]
+    path = "test.zip[malicious.py]"
+    raw_values = [path, "50%", "", "", "", snippet]
+    mock_tree._item_values["item1"] = (path, "50%", "", "", "", snippet, json.dumps(raw_values))
+
+    with patch('gptscan.update_status'), patch('os.path.exists', return_value=False):
+        gptscan.copy_sha256()
+
+    mock_tree.clipboard_append.assert_called_with(expected_hash)
+
 def test_check_virustotal_not_found(monkeypatch):
     mock_msgbox = MagicMock()
     monkeypatch.setattr(gptscan, 'messagebox', mock_msgbox)


### PR DESCRIPTION
* **Type:** Bug Fix / New Coverage
* **What:** Updated `copy_sha256` to fallback to hashing snippet content if the file path does not exist on disk, and added a corresponding unit test.
* **Why:** Previously, copying SHA256 hashes for archive members (e.g., `zip[file]`) failed because the code only checked for paths starting with `[` and didn't account for other virtual path formats that aren't physical files. This fix aligns it with `get_virustotal_url`'s robust behavior.

---
*PR created automatically by Jules for task [5640342785604519945](https://jules.google.com/task/5640342785604519945) started by @RainRat*