### PR TITLE
[FEAT] Add standalone SSH configuration scan feature

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2562,6 +2562,19 @@ def scan_env_vars_click():
         messagebox.showwarning("Environment Variables Error", f"Could not scan environment variables: {e}")
 
 
+def scan_ssh_config_click():
+    """Scan common SSH configuration and authorized_keys files."""
+    try:
+        ssh_paths = get_ssh_config_paths()
+        if ssh_paths:
+            _set_scan_target(ssh_paths)
+            button_click()
+        else:
+            messagebox.showinfo("SSH Configuration", "No common SSH configuration files were found on this system.")
+    except Exception as e:
+        messagebox.showwarning("SSH Configuration Error", f"Could not scan SSH configuration: {e}")
+
+
 def scan_nodejs_packages_click():
     """Scan all directories containing global Node.js packages."""
     try:
@@ -6821,6 +6834,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     system_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     system_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
+    system_menu.add_command(label="Scan SSH Configuration", command=scan_ssh_config_click)
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
@@ -7412,6 +7426,11 @@ def main():
         help='Scan all non-empty environment variables.'
     )
     scan_group.add_argument(
+        '--ssh-config',
+        action='store_true',
+        help='Scan common SSH configuration and authorized_keys files.'
+    )
+    scan_group.add_argument(
         '--audit',
         action='store_true',
         help='Run a full system audit.'
@@ -7696,6 +7715,13 @@ def main():
                 extra_snippets.extend(snippets)
             else:
                 print("No non-empty environment variables were found.", file=sys.stderr)
+
+        if args.ssh_config:
+            ssh_paths = get_ssh_config_paths()
+            if ssh_paths:
+                scan_targets.extend(ssh_paths)
+            else:
+                print("No common SSH configuration files were found.", file=sys.stderr)
 
         if args.audit:
             paths, snippets = get_system_audit_data()

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Access these options from the **Browse** menu:
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous persistence (Ctrl+Shift+T).
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
+*   **Scan SSH Configuration:** Scan common SSH configuration and authorized_keys files to identify dangerous settings.
 *   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
 *   **Scan Editor Extensions:** Scan all directories containing editor extensions (VS Code, Sublime Text, Vim) for potentially malicious scripts (Ctrl+Shift+X).
 
@@ -207,6 +208,11 @@ python3 gptscan.py --system-services --cli
 Scan all environment variables:
 ```bash
 python3 gptscan.py --env-vars --cli
+```
+
+Scan common SSH configuration and authorized_keys files:
+```bash
+python3 gptscan.py --ssh-config --cli
 ```
 
 #### Git Integration

--- a/tests/test_ssh_scan_feature.py
+++ b/tests/test_ssh_scan_feature.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import gptscan
+import sys
+import argparse
+
+def test_scan_ssh_config_click_success(monkeypatch):
+    # Mock dependencies
+    mock_get_paths = MagicMock(return_value=["/fake/ssh_config"])
+    mock_set_target = MagicMock()
+    mock_button_click = MagicMock()
+
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", mock_get_paths)
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_target)
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+
+    gptscan.scan_ssh_config_click()
+
+    mock_get_paths.assert_called_once()
+    mock_set_target.assert_called_once_with(["/fake/ssh_config"])
+    mock_button_click.assert_called_once()
+
+def test_scan_ssh_config_click_no_files(monkeypatch):
+    # Mock dependencies
+    mock_get_paths = MagicMock(return_value=[])
+    mock_showinfo = MagicMock()
+
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", mock_get_paths)
+    # messagebox is imported as from tkinter import messagebox
+    monkeypatch.setattr("gptscan.messagebox.showinfo", mock_showinfo)
+
+    gptscan.scan_ssh_config_click()
+
+    mock_get_paths.assert_called_once()
+    mock_showinfo.assert_called_once()
+    assert "No common SSH configuration files" in mock_showinfo.call_args[0][1]
+
+def test_cli_ssh_config_flag(monkeypatch):
+    # Test CLI integration
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+
+    mock_get_ssh_paths = MagicMock(return_value=["/fake/ssh_config"])
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", mock_get_ssh_paths)
+
+    # Simulate CLI arguments
+    test_args = ["gptscan.py", "--ssh-config", "--cli"]
+    monkeypatch.setattr("sys.argv", test_args)
+
+    # We need to mock sys.exit to prevent the test from exiting
+    mock_exit = MagicMock()
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    # Also mock create_gui just in case
+    monkeypatch.setattr("gptscan.create_gui", MagicMock())
+
+    gptscan.main()
+
+    # run_cli should be called with /fake/ssh_config in targets
+    assert mock_run_cli.called
+    args, kwargs = mock_run_cli.call_args
+    targets = args[0]
+    assert "/fake/ssh_config" in targets


### PR DESCRIPTION
This PR implements a new "Scan SSH Configuration" feature, providing a dedicated way to scan SSH configuration and `authorized_keys` files for potential threats or misconfigurations. 

Key changes include:
1. **GUI Integration**: A new menu item "Scan SSH Configuration" has been added to the "System Scans" menu.
2. **CLI Support**: A new `--ssh-config` flag has been added to the command-line interface.
3. **Logic**: The feature leverages the existing `get_ssh_config_paths()` utility to discover relevant files across different platforms (Linux/macOS/Windows).
4. **Documentation**: The README has been updated to include instructions for using this new scan type in both GUI and CLI modes.
5. **Testing**: New unit tests in `tests/test_ssh_scan_feature.py` verify the callback logic and CLI flag integration.

This feature adds immediate value by making it easier for users to audit critical security configuration files that are often targets for persistence or unauthorized access.

---
*PR created automatically by Jules for task [8771200489136271543](https://jules.google.com/task/8771200489136271543) started by @RainRat*