### PR TITLE
[Refactor] Inline redundant Git helpers into get_online_url

### DIFF
--- a/.gptscan_cache.json
+++ b/.gptscan_cache.json
@@ -1,0 +1,7 @@
+{
+    "c961e56142c0e2771271fdc84e59ce81e0c27d0b83888a77b0a9032d554e9b26": {
+        "administrator": "Admin",
+        "end-user": "User",
+        "threat-level": 70
+    }
+}

--- a/gptscan.py
+++ b/gptscan.py
@@ -1636,32 +1636,6 @@ def _get_git_info(path: str) -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
 
-def _get_git_remote_url(toplevel: str) -> Optional[str]:
-    """Get the remote origin URL for the Git repository."""
-    try:
-        return subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
-            cwd=toplevel,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
-
-
-def _get_git_revision(toplevel: str) -> Optional[str]:
-    """Get the current Git revision (SHA) for the repository."""
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            cwd=toplevel,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
-
-
 def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
     """Construct a web URL for a local Git-tracked file or a remote target.
 
@@ -1704,11 +1678,29 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
     if not toplevel or not rel_path:
         return None
 
-    remote = _get_git_remote_url(toplevel)
-    if not remote:
+    try:
+        remote = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
+        if not remote:
+            return None
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
 
-    rev = _get_git_revision(toplevel) or "HEAD"
+    try:
+        rev = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        ).strip()
+        if not rev:
+            rev = "HEAD"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        rev = "HEAD"
 
     # Normalize Remote URL (Convert SSH to HTTPS, remove .git suffix)
     # git@host:user/repo.git -> https://host/user/repo

--- a/tests/test_view_online.py
+++ b/tests/test_view_online.py
@@ -1,6 +1,6 @@
 import pytest
 from gptscan import get_online_url
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 def test_get_online_url_remote_target():
     # GitHub blob
@@ -20,31 +20,44 @@ def test_get_online_url_remote_target():
     assert url == "https://bitbucket.org/user/repo/src/main/file.py#lines-10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-@patch('gptscan._get_git_revision')
-def test_get_online_url_local_file(mock_rev, mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_local_file(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "git@github.com:user/repo.git"
-    mock_rev.return_value = "abcdef"
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return "git@github.com:user/repo.git"
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return "abcdef"
+        return ""
+
+    mock_check_output.side_effect = side_effect
 
     url = get_online_url("/app/src/file.py", 10)
     assert url == "https://github.com/user/repo/blob/abcdef/src/file.py#L10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-def test_get_online_url_local_file_gitlab(mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_local_file_gitlab(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "https://gitlab.com/user/repo.git"
 
-    with patch('gptscan._get_git_revision', return_value="main"):
-        url = get_online_url("/app/src/file.py", 10)
-        assert url == "https://gitlab.com/user/repo/-/blob/main/src/file.py#L10"
+    def side_effect(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return "https://gitlab.com/user/repo.git"
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return "main"
+        return ""
+
+    mock_check_output.side_effect = side_effect
+
+    url = get_online_url("/app/src/file.py", 10)
+    assert url == "https://gitlab.com/user/repo/-/blob/main/src/file.py#L10"
 
 @patch('gptscan._get_git_info')
-@patch('gptscan._get_git_remote_url')
-def test_get_online_url_unsupported_remote(mock_remote, mock_info):
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_unsupported_remote(mock_check_output, mock_info):
     mock_info.return_value = ("/app", "src/file.py")
-    mock_remote.return_value = "https://myserver.com/repo.git"
+    mock_check_output.return_value = "https://myserver.com/repo.git"
 
     url = get_online_url("/app/src/file.py", 10)
     assert url is None


### PR DESCRIPTION
**PR Title:** [Refactor] Inline redundant Git helpers into get_online_url

**Description:**
* **What:** Inlined the private helper functions `_get_git_remote_url` and `_get_git_revision` directly into their only call site, `get_online_url`. The implementation uses `subprocess.check_output` and includes robust handling for empty command output (returning `None` for remote and defaulting to `'HEAD'` for revision) to maintain behavioral parity. Associated unit tests in `tests/test_view_online.py` were updated to mock `subprocess.check_output` directly.
* **Why:** This change removes premature abstractions and simplifies the module's internal API. By reducing the number of top-level private functions, the code's readability and maintainability are improved without altering external behavior. No breaking changes were introduced, as verified by the full test suite.

---
*PR created automatically by Jules for task [14122919750289174503](https://jules.google.com/task/14122919750289174503) started by @RainRat*