### PR TITLE
[TEST] [Bug Fix] Fix pyproject.toml inline table parsing with brackets in strings

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3342,7 +3342,8 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                 # Inside a flat section like [project.scripts] or [tool.poe.tasks]
                                 if command_val.startswith('{'):
                                     # Inline table
-                                    cmd_match = re.search(r'(?:cmd|command|shell|composite|script|expr)\s*=\s*("[^"]*"|\'[^\']*\'|\[[^\]]*\])', command_val)
+                                    # Robustly handle brackets and quotes within the inline table value
+                                    cmd_match = re.search(r'(?:cmd|command|shell|composite|script|expr)\s*=\s*("(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\[(?:[^"\'\]]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*\])', command_val)
                                     if cmd_match:
                                         yield from yield_pyproject_scripts(script_key, cmd_match.group(1).strip())
                                 else:

--- a/tests/test_pyproject_regex_bug.py
+++ b/tests/test_pyproject_regex_bug.py
@@ -1,0 +1,59 @@
+import pytest
+from gptscan import unpack_content
+
+def test_pyproject_inline_table_with_bracket_in_string():
+    """Verify bug where bracket in string breaks inline table array parsing."""
+    content = b"""
+[tool.pdm.scripts]
+test = { cmd = ["echo", "bracket ] here"] }
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "pyproject.toml [Script: test (1)]" in scripts
+    assert scripts["pyproject.toml [Script: test (1)]"] == "echo"
+    assert "pyproject.toml [Script: test (2)]" in scripts
+    assert scripts["pyproject.toml [Script: test (2)]"] == "bracket ] here"
+
+def test_pyproject_multiline_array_with_bracket_in_string():
+    """Verify bug where bracket in string breaks multiline array parsing."""
+    content = b"""
+[tool.pdm.scripts]
+test = [
+    "echo ]",
+    "done"
+]
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "pyproject.toml [Script: test (1)]" in scripts
+    assert scripts["pyproject.toml [Script: test (1)]"] == "echo ]"
+    assert "pyproject.toml [Script: test (2)]" in scripts
+    assert scripts["pyproject.toml [Script: test (2)]"] == "done"
+
+def test_pyproject_multiline_array_stops_too_early():
+    """Verify that multiline array parsing doesn't stop at a bracket inside a string."""
+    content = b"""
+[tool.pdm.scripts]
+test = [
+    "echo ]"
+]
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "pyproject.toml [Script: test (1)]" in scripts
+    assert scripts["pyproject.toml [Script: test (1)]"] == "echo ]"
+
+def test_pyproject_inline_table_with_escaped_quotes_and_brackets():
+    """Verify robust parsing of inline tables with complex strings."""
+    content = b"""
+[tool.pdm.scripts]
+test = { cmd = ["echo \\"escaped ] quote\\"", 'single ] quote'] }
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert scripts["pyproject.toml [Script: test (1)]"] == 'echo \\"escaped ] quote\\"'
+    assert scripts["pyproject.toml [Script: test (2)]"] == 'single ] quote'


### PR DESCRIPTION
**PR Title:** [TEST] [Bug Fix] Fix pyproject.toml inline table parsing with brackets in strings

**Description:**
* **Type:** Bug Fix / New Coverage
* **What:** Updated the regex in `gptscan.py` to robustly handle brackets and escaped quotes within TOML inline tables and arrays. Added a new test suite `tests/test_pyproject_regex_bug.py` covering these edge cases.
* **Why:** Brackets appearing inside quoted strings within inline table arrays were causing the parser to truncate commands prematurely. The new regex ensures correct extraction of scripts from `pyproject.toml` even when they contain complex characters.

---
*PR created automatically by Jules for task [14140252861098188548](https://jules.google.com/task/14140252861098188548) started by @RainRat*