### PR TITLE
[MAINT] Remove redundant directory existence checks in get_ssh_config_paths

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1425,29 +1425,26 @@ def get_ssh_config_paths() -> List[str]:
 
     # User-level SSH files
     user_ssh = home / ".ssh"
-    if user_ssh.exists():
-        for f in ["config", "authorized_keys"]:
-            p = user_ssh / f
-            if p.exists():
-                paths.append(str(p))
+    for f in ["config", "authorized_keys"]:
+        p = user_ssh / f
+        if p.exists():
+            paths.append(str(p))
 
     # System-level SSH files
     if sys.platform == "win32":
         program_data = os.environ.get("ProgramData")
         if program_data:
             win_system_ssh = Path(program_data) / "ssh"
-            if win_system_ssh.exists():
-                for f in ["sshd_config", "ssh_config"]:
-                    p = win_system_ssh / f
-                    if p.exists():
-                        paths.append(str(p))
-    else:
-        system_ssh_dir = Path("/etc/ssh")
-        if system_ssh_dir.exists():
             for f in ["sshd_config", "ssh_config"]:
-                p = system_ssh_dir / f
+                p = win_system_ssh / f
                 if p.exists():
                     paths.append(str(p))
+    else:
+        system_ssh_dir = Path("/etc/ssh")
+        for f in ["sshd_config", "ssh_config"]:
+            p = system_ssh_dir / f
+            if p.exists():
+                paths.append(str(p))
 
     return sorted(list(set(paths)))
 


### PR DESCRIPTION
**What:** 
Streamlined the `get_ssh_config_paths` function by removing unnecessary `if .exists()` checks for parent directories (`user_ssh`, `win_system_ssh`, and `system_ssh_dir`) before checking for individual files.

**Why:** 
This reduces error handling noise and redundant validation. Behavior remains identical as `pathlib.Path.exists()` on a file path correctly returns `False` if any part of the parent directory structure is missing. No breaking changes were introduced, and the fix was verified against existing unit tests for SSH configuration scanning and system audit.

---
*PR created automatically by Jules for task [17563079876425431623](https://jules.google.com/task/17563079876425431623) started by @RainRat*