### PR TITLE
[TEST] [Expand scheduled task scanning to include system-wide crontabs]

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1412,6 +1412,31 @@ def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
                                 tasks.append(("[Cron] User", parts[1].encode('utf-8')))
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
+
+            # Linux/macOS - Collect from system crontabs
+            system_cron_files = [Path("/etc/crontab")]
+            cron_d = Path("/etc/cron.d")
+            if cron_d.is_dir():
+                try:
+                    system_cron_files.extend(list(cron_d.iterdir()))
+                except OSError:
+                    pass
+
+            for cron_file in system_cron_files:
+                if cron_file.is_file():
+                    try:
+                        with open(cron_file, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                line = line.strip()
+                                if line and not line.startswith(('#', '@')) and '=' not in line:
+                                    # System crontab format: min hour day month dow user command
+                                    # Try to skip the first 6 fields
+                                    parts = line.split(None, 6)
+                                    if len(parts) > 6:
+                                        command = parts[6]
+                                        tasks.append((f"[Cron] {cron_file.name}", command.encode('utf-8')))
+                    except (OSError, PermissionError):
+                        pass
     except Exception:
         pass
 

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -9,9 +9,11 @@ def test_get_scheduled_task_commands_linux():
     mock_crontab = "# Some comment\n* * * * * /usr/bin/python3 /path/to/script.py\n@daily /usr/bin/cleanup.sh\n"
     with patch("sys.platform", "linux"):
         with patch("subprocess.check_output", return_value=mock_crontab):
-            tasks = get_scheduled_task_commands()
+            with patch("gptscan.Path.is_dir", return_value=False):
+                with patch("gptscan.Path.is_file", return_value=False):
+                    tasks = get_scheduled_task_commands()
 
-            assert len(tasks) == 2
+                    assert len(tasks) == 2
             assert tasks[0][0] == "[Cron] User"
             assert tasks[0][1] == b"/usr/bin/python3 /path/to/script.py"
             assert tasks[1][0] == "[Cron] User"
@@ -33,8 +35,45 @@ def test_get_scheduled_task_commands_windows():
 
 def test_get_scheduled_task_commands_error():
     with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "crontab")):
-        tasks = get_scheduled_task_commands()
-        assert tasks == []
+        # Also patch Path.is_dir and Path.is_file to avoid scanning real system files during test
+        with patch("gptscan.Path.is_dir", return_value=False):
+            with patch("gptscan.Path.is_file", return_value=False):
+                tasks = get_scheduled_task_commands()
+                assert tasks == []
+
+def test_get_scheduled_task_commands_system_cron():
+    """Verify parsing of system-wide crontab files."""
+    def mock_is_dir(self):
+        return str(self) == "/etc/cron.d"
+
+    def mock_is_file(self):
+        return str(self) in ["/etc/crontab", "/etc/cron.d/php"]
+
+    def mock_iterdir(self):
+        if str(self) == "/etc/cron.d":
+            from pathlib import Path
+            return [Path("/etc/cron.d/php")]
+        return []
+
+    mock_content = {
+        "/etc/crontab": "17 * * * * root /usr/bin/system-task\n",
+        "/etc/cron.d/php": "09,39 * * * * root /usr/lib/php/sessionclean\n"
+    }
+
+    from unittest.mock import mock_open
+    m = mock_open()
+    m.side_effect = lambda p, *args, **kwargs: mock_open(read_data=mock_content[str(p)])(p, *args, **kwargs)
+
+    with patch("sys.platform", "linux"):
+        with patch("gptscan.subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "crontab")):
+            with patch("gptscan.Path.is_dir", mock_is_dir):
+                with patch("gptscan.Path.is_file", mock_is_file):
+                    with patch("gptscan.Path.iterdir", mock_iterdir):
+                        with patch("gptscan.open", m):
+                            tasks = get_scheduled_task_commands()
+
+    assert any(t[0] == "[Cron] crontab" and t[1] == b"/usr/bin/system-task" for t in tasks)
+    assert any(t[0] == "[Cron] php" and t[1] == b"/usr/lib/php/sessionclean" for t in tasks)
 
 @patch("gptscan.get_scheduled_task_commands")
 @patch("gptscan.button_click")


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Expanded the `get_scheduled_task_commands` function to include system-wide crontab files (`/etc/crontab` and `/etc/cron.d/*`) on Linux/macOS and added comprehensive unit tests for this new functionality.
* **Why:** Previously, only user-specific crontabs (via `crontab -l`) were scanned, leaving a significant gap in system auditing. System-wide crontabs are common locations for persistence and malicious tasks.

---
*PR created automatically by Jules for task [449202177116280490](https://jules.google.com/task/449202177116280490) started by @RainRat*