### PR TITLE
[BUG] [AUDIT] Expand scheduled task scanning to include system crontabs

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1394,24 +1394,54 @@ def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
                     if command and command.strip() and command.lower() != "n/a":
                         tasks.append((f"[Task] {name}", command.encode('utf-8')))
         else:
-            # Linux/macOS - Collect from user crontab
+            # Linux/macOS - Collect from user and system crontabs
+
+            # 1. User crontab
             try:
                 output = subprocess.check_output(["crontab", "-l"], stderr=subprocess.PIPE, universal_newlines=True)
                 for line in output.splitlines():
                     line = line.strip()
                     if line and not line.startswith('#'):
-                        # Crontab format: min hour day month dow command
-                        # Try to skip the first 5 fields
+                        # User crontab: min hour day month dow command
                         parts = line.split(None, 5)
                         if len(parts) > 5:
-                            command = parts[5]
-                            tasks.append(("[Cron] User", command.encode('utf-8')))
+                            tasks.append(("[Cron] User", parts[5].encode('utf-8')))
                         elif line.startswith('@'):
                             parts = line.split(None, 1)
                             if len(parts) > 1:
                                 tasks.append(("[Cron] User", parts[1].encode('utf-8')))
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
+
+            # 2. System crontabs
+            cron_files = ["/etc/crontab"]
+            cron_d = Path("/etc/cron.d")
+            if cron_d.exists() and cron_d.is_dir():
+                try:
+                    for p in cron_d.iterdir():
+                        if p.is_file():
+                            cron_files.append(str(p))
+                except Exception:
+                    pass
+
+            for cron_path in cron_files:
+                if os.path.exists(cron_path):
+                    try:
+                        with open(cron_path, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                line = line.strip()
+                                if line and not line.startswith('#') and '=' not in line:
+                                    # System crontab: min hour day month dow user command
+                                    parts = line.split(None, 6)
+                                    if len(parts) > 6:
+                                        tasks.append((f"[Cron] System ({os.path.basename(cron_path)})", parts[6].encode('utf-8')))
+                                    elif line.startswith('@'):
+                                        # @reboot user command
+                                        parts = line.split(None, 2)
+                                        if len(parts) > 2:
+                                            tasks.append((f"[Cron] System ({os.path.basename(cron_path)})", parts[2].encode('utf-8')))
+                    except Exception:
+                        pass
     except Exception:
         pass
 

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1,21 +1,62 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 import subprocess
 import os
-import sys
+from pathlib import Path
 from gptscan import get_scheduled_task_commands, scan_scheduled_tasks_click
 
-def test_get_scheduled_task_commands_linux():
-    mock_crontab = "# Some comment\n* * * * * /usr/bin/python3 /path/to/script.py\n@daily /usr/bin/cleanup.sh\n"
-    with patch("sys.platform", "linux"):
-        with patch("subprocess.check_output", return_value=mock_crontab):
-            tasks = get_scheduled_task_commands()
+def test_get_scheduled_task_commands_linux_all():
+    mock_crontab_l = "# Some comment\n* * * * * /usr/bin/python3 /path/to/script.py\n@daily /usr/bin/cleanup.sh\n"
+    mock_etc_crontab = "17 *	* * *	root    cd / && run-parts --report /etc/cron.hourly\n"
+    mock_cron_d_file = "30 4	* * *	user    /usr/local/bin/daily_backup.sh\n@reboot root /usr/bin/reboot_task\n"
 
-            assert len(tasks) == 2
-            assert tasks[0][0] == "[Cron] User"
-            assert tasks[0][1] == b"/usr/bin/python3 /path/to/script.py"
-            assert tasks[1][0] == "[Cron] User"
-            assert tasks[1][1] == b"/usr/bin/cleanup.sh"
+    with patch("sys.platform", "linux"):
+        with patch("subprocess.check_output", return_value=mock_crontab_l):
+            with patch("os.path.exists") as mock_exists:
+                # We want to mock exists for /etc/crontab and /etc/cron.d/test_task
+                def exists_side_effect(path):
+                    if path in ["/etc/crontab", "/etc/cron.d/test_task"]:
+                        return True
+                    return False
+                mock_exists.side_effect = exists_side_effect
+
+                with patch("gptscan.Path") as mock_path_cls:
+                    mock_cron_d = MagicMock()
+                    mock_cron_d.exists.return_value = True
+                    mock_cron_d.is_dir.return_value = True
+
+                    mock_file = MagicMock()
+                    mock_file.is_file.return_value = True
+                    mock_file.__str__.return_value = "/etc/cron.d/test_task"
+                    mock_file.name = "test_task"
+
+                    mock_cron_d.iterdir.return_value = [mock_file]
+
+                    def path_side_effect(p):
+                        if str(p) == "/etc/cron.d":
+                            return mock_cron_d
+                        return MagicMock()
+
+                    mock_path_cls.side_effect = path_side_effect
+
+                    # Mock open for /etc/crontab and /etc/cron.d/test_task
+                    def open_side_effect(path, *args, **kwargs):
+                        if path == "/etc/crontab":
+                            return mock_open(read_data=mock_etc_crontab).return_value
+                        if path == "/etc/cron.d/test_task":
+                            return mock_open(read_data=mock_cron_d_file).return_value
+                        raise FileNotFoundError(path)
+
+                    with patch("builtins.open", side_effect=open_side_effect):
+                        tasks = get_scheduled_task_commands()
+
+                        # 2 from crontab -l, 1 from /etc/crontab, 2 from /etc/cron.d/test_task = 5
+                        assert len(tasks) == 5
+                        assert tasks[0] == ("[Cron] User", b"/usr/bin/python3 /path/to/script.py")
+                        assert tasks[1] == ("[Cron] User", b"/usr/bin/cleanup.sh")
+                        assert tasks[2] == ("[Cron] System (crontab)", b"cd / && run-parts --report /etc/cron.hourly")
+                        assert tasks[3] == ("[Cron] System (test_task)", b"/usr/local/bin/daily_backup.sh")
+                        assert tasks[4] == ("[Cron] System (test_task)", b"/usr/bin/reboot_task")
 
 def test_get_scheduled_task_commands_windows():
     # schtasks /query /fo CSV /v output
@@ -32,9 +73,13 @@ def test_get_scheduled_task_commands_windows():
             assert tasks[0][1] == b"C:\\Windows\\System32\\calc.exe"
 
 def test_get_scheduled_task_commands_error():
-    with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "crontab")):
-        tasks = get_scheduled_task_commands()
-        assert tasks == []
+    with patch("sys.platform", "linux"):
+        with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "crontab")):
+            with patch("gptscan.Path") as mock_path:
+                mock_path.return_value.exists.return_value = False
+                with patch("os.path.exists", return_value=False):
+                    tasks = get_scheduled_task_commands()
+                    assert tasks == []
 
 @patch("gptscan.get_scheduled_task_commands")
 @patch("gptscan.button_click")


### PR DESCRIPTION
### What:
This PR expands the `get_scheduled_task_commands` function in `gptscan.py` to include system-wide crontab files on Linux/macOS systems. It now scans `/etc/crontab` and all files within the `/etc/cron.d/` directory in addition to the current user's crontab (via `crontab -l`). The parsing logic was also improved to correctly handle the different format used in system crontabs, which include a mandatory 'user' field before the command.

### Why:
System-wide crontabs are a common location for persistence mechanisms and scheduled maintenance tasks that may contain malicious or poorly secured scripts. Previously, the scanner only audited the local user's tasks, leaving a significant gap in system audit coverage. The updated logic ensures that commands are extracted accurately from both user and system crontab formats, improving the thoroughness of the 'System Audit' feature. This is a non-breaking change as it only increases the scope of discovery and includes robust error handling for restricted files.

---
*PR created automatically by Jules for task [16240665977588750395](https://jules.google.com/task/16240665977588750395) started by @RainRat*