### PR TITLE
[UI/UX] Increase CLI report information density

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4625,31 +4625,39 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
         else:
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
-        lines.append(f"{BOLD}[{i}] {risk_label} - {path}{RESET}")
-        lines.append(f"    {BOLD}Threat Level:{RESET} Local: {own_conf}" + (f", AI: {gpt_conf}" if gpt_conf else ""))
-        lines.append(f"    {BOLD}Location:{RESET}   Line {line_num}")
+        lines.append(f"{BOLD}[{i}] {risk_label} - {path}:{line_num}{RESET}")
 
-        # Links
+        # Consolidate scores and links
+        meta_parts = [f"Scores: {own_conf}"]
+        if gpt_conf:
+            meta_parts.append(f"AI: {gpt_conf}")
+
         vt_url = get_virustotal_url(path, snippet)
-        online_url = get_online_url(path, line_num)
-
         if vt_url:
-            lines.append(f"    {BOLD}VirusTotal:{RESET} {vt_url}")
+            meta_parts.append(f"VT: {vt_url}")
+
+        online_url = get_online_url(path, line_num)
         if online_url:
-            lines.append(f"    {BOLD}Online View:{RESET} {online_url}")
+            meta_parts.append(f"Online: {online_url}")
 
+        lines.append(f"    {GRAY}{' | '.join(meta_parts)}{RESET}")
+
+        # Consolidate AI analysis
         if admin or user:
-            lines.append(f"    {BOLD}AI Analysis:{RESET}")
+            analysis_parts = []
             if admin:
-                lines.append(f"        {GRAY}Admin:{RESET} {admin}")
+                clean_admin = admin.strip().replace('\n', ' ')
+                analysis_parts.append(f"{BOLD}Admin:{RESET} {clean_admin}")
             if user:
-                lines.append(f"        {GRAY}User:{RESET}  {user}")
+                clean_user = user.strip().replace('\n', ' ')
+                analysis_parts.append(f"{BOLD}User:{RESET} {clean_user}")
+            lines.append(f"    {' | '.join(analysis_parts)}")
 
-        # Snippet preview (first line or first 100 chars)
+        # Snippet preview
         clean_snippet = snippet.strip().split('\n')[0]
-        if len(clean_snippet) > 80:
-            clean_snippet = clean_snippet[:77] + "..."
-        lines.append(f"    {BOLD}Snippet:{RESET}    {GRAY}{clean_snippet}{RESET}")
+        if len(clean_snippet) > 100:
+            clean_snippet = clean_snippet[:97] + "..."
+        lines.append(f"    > {GRAY}{clean_snippet}{RESET}")
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -131,12 +131,13 @@ def test_generate_console_report():
     # Without color
     report = gptscan.generate_console_report(results, use_color=False)
     assert "--- GPT SCAN TRIAGE REPORT ---" in report
-    assert "[1] HIGH RISK - suspicious.py" in report
-    assert "Threat Level: Local: 90%, AI: 95%" in report
-    assert "Admin: Admin note" in report
-    assert "User:  User note" in report
-    assert "VirusTotal: https://www.virustotal.com/gui/file/" in report
-    assert "[2] LOW RISK - safe.py" in report
+    assert "[1] HIGH RISK - suspicious.py:10" in report
+    assert "Scores: 90% | AI: 95% | VT: https://www.virustotal.com/gui/file/" in report
+    assert "Admin: Admin note | User: User note" in report
+    assert "> dangerous_code()" in report
+    assert "[2] LOW RISK - safe.py:1" in report
+    assert "Scores: 10%" in report
+    assert "> print('ok')" in report
 
     # With color (check for ANSI codes)
     report_color = gptscan.generate_console_report(results, use_color=True)


### PR DESCRIPTION
This PR improves the usability and aesthetics of the CLI triage report by increasing information density. 

**Problem:** 
The previous console report was vertically verbose, requiring excessive scrolling for scans with multiple findings. Metadata and AI analysis were spread across many lines, making it harder to quickly triage results.

**Solution:**
The `generate_console_report` function was refactored to:
1.  **Compact Headers:** Use the standard `path:line_num` notation.
2.  **Meta Consolidation:** Group threat scores and external resource links (VirusTotal, Online) onto a single indented line separated by pipes (`|`).
3.  **Analysis Consolidation:** Merge Administrator and End-User AI notes into a single line, stripping internal newlines to keep the report "high-density".
4.  **Compact Snippets:** Use a simpler `> ` prefix for code previews.

**Verification:**
- Updated existing unit tests in `tests/test_reporting_features.py` to match the new format.
- Ran the full test suite (820 tests passed).
- Manually verified the output format for both single and multiple findings.

---
*PR created automatically by Jules for task [4783678671912580337](https://jules.google.com/task/4783678671912580337) started by @RainRat*