### PR TITLE
[FEAT] Browser Extension Scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1269,6 +1269,70 @@ def get_python_package_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_browser_extensions_paths() -> List[str]:
+    """Identify common browser extension directories (Chrome, Firefox, Edge)."""
+    paths = []
+    home = Path.home()
+
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        appdata = os.environ.get("APPDATA")
+        if local_appdata:
+            # Chrome
+            chrome_base = Path(local_appdata) / "Google" / "Chrome" / "User Data"
+            paths.append(str(chrome_base / "Default" / "Extensions"))
+            for p in chrome_base.glob("Profile */Extensions"):
+                paths.append(str(p))
+            # Edge
+            edge_base = Path(local_appdata) / "Microsoft" / "Edge" / "User Data"
+            paths.append(str(edge_base / "Default" / "Extensions"))
+            for p in edge_base.glob("Profile */Extensions"):
+                paths.append(str(p))
+        if appdata:
+            # Firefox
+            ff_base = Path(appdata) / "Mozilla" / "Firefox" / "Profiles"
+            if ff_base.exists():
+                for p in ff_base.glob("*/extensions"):
+                    paths.append(str(p))
+    elif sys.platform == "darwin":
+        lib_support = home / "Library" / "Application Support"
+        # Chrome
+        chrome_base = lib_support / "Google" / "Chrome"
+        paths.append(str(chrome_base / "Default" / "Extensions"))
+        for p in chrome_base.glob("Profile */Extensions"):
+            paths.append(str(p))
+        # Edge
+        edge_base = lib_support / "Microsoft Edge"
+        paths.append(str(edge_base / "Default" / "Extensions"))
+        for p in edge_base.glob("Profile */Extensions"):
+            paths.append(str(p))
+        # Firefox
+        ff_base = lib_support / "Firefox" / "Profiles"
+        if ff_base.exists():
+            for p in ff_base.glob("*/extensions"):
+                paths.append(str(p))
+    else:
+        # Linux
+        config = home / ".config"
+        # Chrome
+        chrome_base = config / "google-chrome"
+        paths.append(str(chrome_base / "Default" / "Extensions"))
+        for p in chrome_base.glob("Profile */Extensions"):
+            paths.append(str(p))
+        # Chromium
+        chromium_base = config / "chromium"
+        paths.append(str(chromium_base / "Default" / "Extensions"))
+        for p in chromium_base.glob("Profile */Extensions"):
+            paths.append(str(p))
+        # Firefox
+        ff_base = home / ".mozilla" / "firefox"
+        if ff_base.exists():
+            for p in ff_base.glob("*/extensions"):
+                paths.append(str(p))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
 def get_editor_extensions_paths() -> List[str]:
     """Identify common editor extension directories (VS Code, Sublime Text, Vim/Neovim)."""
     paths = []
@@ -2575,6 +2639,19 @@ def scan_nodejs_packages_click():
         messagebox.showwarning("Node.js Packages Error", f"Could not scan Node.js packages: {e}")
 
 
+def scan_browser_extensions_click():
+    """Scan all common browser extension directories."""
+    try:
+        extension_paths = get_browser_extensions_paths()
+        if extension_paths:
+            _set_scan_target(extension_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Browser Extensions", "No browser extension directories were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Browser Extensions Error", f"Could not scan browser extensions: {e}")
+
+
 def scan_editor_extensions_click():
     """Scan all directories containing editor extensions (VS Code, Sublime Text, Vim)."""
     try:
@@ -2599,6 +2676,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
     all_paths.extend(get_nodejs_package_paths())
+    all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
 
     all_snippets = []
@@ -6823,6 +6901,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
+    system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
@@ -7204,6 +7283,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Control-Shift-M>', lambda event: scan_nodejs_packages_click())
     root.bind('<Command-Shift-M>', lambda event: scan_nodejs_packages_click())
+    root.bind('<Control-Shift-W>', lambda event: scan_browser_extensions_click())
+    root.bind('<Command-Shift-W>', lambda event: scan_browser_extensions_click())
     root.bind('<Control-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
@@ -7400,6 +7481,11 @@ def main():
         '--nodejs-packages',
         action='store_true',
         help='Scan all directories containing global Node.js packages.'
+    )
+    scan_group.add_argument(
+        '--browser-extensions',
+        action='store_true',
+        help='Scan all common browser extension directories.'
     )
     scan_group.add_argument(
         '--editor-extensions',
@@ -7682,6 +7768,13 @@ def main():
                 scan_targets.extend(node_paths)
             else:
                 print("No global Node.js package directories were found.", file=sys.stderr)
+
+        if args.browser_extensions:
+            extension_paths = get_browser_extensions_paths()
+            if extension_paths:
+                scan_targets.extend(extension_paths)
+            else:
+                print("No browser extension directories were found.", file=sys.stderr)
 
         if args.editor_extensions:
             extension_paths = get_editor_extensions_paths()

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Access these options from the **Browse** menu:
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious persistence (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous persistence (Ctrl+Shift+S).
 *   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
+*   **Scan Browser Extensions:** Scan all common browser extension directories for potentially malicious scripts (Ctrl+Shift+W).
 *   **Scan Editor Extensions:** Scan all directories containing editor extensions (VS Code, Sublime Text, Vim) for potentially malicious scripts (Ctrl+Shift+X).
 
 ### Keyboard Shortcuts
@@ -103,6 +104,8 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+A` | Scan Startup Items |
 | `Ctrl+Shift+S` | Scan System Services |
 | `Ctrl+Shift+Y` | Scan Python Packages |
+| `Ctrl+Shift+M` | Scan Node.js Packages |
+| `Ctrl+Shift+W` | Scan Browser Extensions |
 | `Ctrl+Shift+X` | Scan Editor Extensions |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
@@ -162,6 +165,11 @@ python3 gptscan.py --audit --cli
 Scan all directories containing installed Python packages:
 ```bash
 python3 gptscan.py --python-packages --cli
+```
+
+Scan all common browser extension directories:
+```bash
+python3 gptscan.py --browser-extensions --cli
 ```
 
 Scan all directories containing editor extensions:

--- a/tests/test_browser_extensions.py
+++ b/tests/test_browser_extensions.py
@@ -1,0 +1,75 @@
+import sys
+import os
+from pathlib import Path
+import pytest
+import gptscan
+from gptscan import get_browser_extensions_paths, scan_browser_extensions_click
+
+def test_get_browser_extensions_paths_linux(monkeypatch):
+    """Verify the logic of get_browser_extensions_paths on Linux."""
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    fake_paths = [
+        home / ".config" / "google-chrome" / "Default" / "Extensions",
+        home / ".mozilla" / "firefox" / "profile.default" / "extensions",
+    ]
+
+    def mock_exists(self):
+        return self in fake_paths or str(self).endswith(".mozilla/firefox")
+
+    def mock_isdir(p):
+        return Path(p) in fake_paths
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
+
+    def mock_glob(self, pattern):
+        if str(self).endswith(".mozilla/firefox") and pattern == "*/extensions":
+            return [home / ".mozilla" / "firefox" / "profile.default" / "extensions"]
+        return []
+
+    monkeypatch.setattr(Path, "glob", mock_glob)
+
+    # We also need to mock _normalize_and_filter_dirs because it uses os.path.isdir
+    # which we already mocked, but it also uses os.path.abspath and Path.exists.
+    monkeypatch.setattr(gptscan, "_normalize_and_filter_dirs", lambda paths: [str(p) for p in paths if p])
+
+    paths = get_browser_extensions_paths()
+
+    assert str(home / ".config" / "google-chrome" / "Default" / "Extensions") in paths
+    assert str(home / ".mozilla" / "firefox" / "profile.default" / "extensions") in paths
+
+def test_scan_browser_extensions_click(monkeypatch):
+    """Verify the GUI callback for scanning browser extensions."""
+    target_paths = []
+    def mock_set_scan_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+
+    def mock_button_click():
+        pass
+
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_scan_target)
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+    monkeypatch.setattr("gptscan.get_browser_extensions_paths", lambda: ["/mock/chrome/extensions"])
+
+    scan_browser_extensions_click()
+    assert target_paths == ["/mock/chrome/extensions"]
+
+def test_scan_browser_extensions_click_no_paths(monkeypatch):
+    """Verify the GUI callback when no paths are found."""
+    monkeypatch.setattr("gptscan.get_browser_extensions_paths", lambda: [])
+
+    message_box_shown = False
+    def mock_showinfo(title, message):
+        nonlocal message_box_shown
+        message_box_shown = True
+        assert "No browser extension directories" in message
+
+    import gptscan
+    monkeypatch.setattr(gptscan.messagebox, "showinfo", mock_showinfo)
+
+    scan_browser_extensions_click()
+    assert message_box_shown


### PR DESCRIPTION
### Description
* **What:** Added "Browser Extension Scanning" to the tool's security auditing capabilities. This feature identifies extension directories for Google Chrome, Microsoft Edge, Chromium, and Mozilla Firefox across Windows, macOS, and Linux. It is integrated as a standalone CLI flag (`--browser-extensions`), a GUI menu action with the `Ctrl+Shift+W` keyboard shortcut, and as a core component of the "Scan System Audit" feature.
* **Why:** Browser extensions are a common vector for malicious scripts and persistence. The tool already scanned Python/Node packages and editor extensions; adding browser extensions provides a logical completion of the "System Scan" suite, significantly increasing security coverage without requiring any user configuration.

### Changes
- **gptscan.py**: 
    - Added `get_browser_extensions_paths()` to discover cross-platform paths, including support for multiple browser profiles and randomized Firefox profile names.
    - Added `scan_browser_extensions_click()` GUI callback.
    - Added `--browser-extensions` flag to the CLI argument parser and execution logic.
    - Updated `get_system_audit_data()` to include browser extension paths.
    - Integrated the new scan type into the "System Scans" menu and assigned `Ctrl+Shift+W`.
- **readme.md**: Documented the new CLI flag, GUI option, and keyboard shortcut.
- **tests/test_browser_extensions.py**: New unit tests verifying path discovery and GUI callbacks.

---
*PR created automatically by Jules for task [11285839445397187285](https://jules.google.com/task/11285839445397187285) started by @RainRat*