### PR TITLE
[TEST] Add support and test for Makefile shell assignment operator

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3891,8 +3891,8 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                         yield (f"{name} [Recipe {recipes_count}]", cmd.encode('utf-8'))
                         yielded_any = True
                 else:
-                    # Check for variable assignment: VAR = val, VAR := val, VAR += val, VAR ?= val
-                    var_match = re.match(r'^([\w.-]+)\s*([:+?]?=)\s*(.*)', line)
+                    # Check for variable assignment: VAR = val, VAR := val, VAR += val, VAR ?= val, VAR != cmd
+                    var_match = re.match(r'^([\w.-]+)\s*([:+?!]?=)\s*(.*)', line)
                     if var_match:
                         content_parts = [var_match.group(3)]
                         while line.rstrip().endswith('\\') and i < len(lines):

--- a/tests/test_makefile_shell_assignment.py
+++ b/tests/test_makefile_shell_assignment.py
@@ -1,0 +1,17 @@
+import pytest
+from gptscan import unpack_content
+
+def test_makefile_shell_assignment():
+    """Verify that Makefile shell assignment operator (!=) is correctly extracted."""
+    content = b"""
+SHELL_VAR != echo "malicious"
+NORMAL_VAR = normal
+"""
+    results = list(unpack_content("Makefile", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "Makefile [Variable 1]" in scripts
+    assert scripts["Makefile [Variable 1]"] == 'echo "malicious"'
+
+    assert "Makefile [Variable 2]" in scripts
+    assert scripts["Makefile [Variable 2]"] == 'normal'


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** Updated the Makefile variable assignment regex in `gptscan.py` to support the shell assignment operator (`!=`) and added a new test `tests/test_makefile_shell_assignment.py` to verify it.
* **Why:** Makefile shell assignments (`VAR != cmd`) execute the RHS in a shell, making them a critical target for security scanning. Previously, these were ignored by the scanner.

---
*PR created automatically by Jules for task [17459234429326630522](https://jules.google.com/task/17459234429326630522) started by @RainRat*