### PR TITLE
[REFACTOR] Consolidate path resolution and verification logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5752,8 +5752,14 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
     return [str(v).replace('\n', ' ') for v in values[:7]]
 
 
-def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True) -> Optional[str]:
-    """Retrieve and optionally verify a file path from an event or direct argument."""
+def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True, show_warning: bool = True) -> Optional[str]:
+    """Retrieve and optionally verify a file path from an event or direct argument.
+
+    Args:
+        event_or_path: A Tkinter event, a direct path string, or None to use selection.
+        verify: Whether to check if the file exists on disk.
+        show_warning: Whether to display a warning dialog if the file is not found.
+    """
     if isinstance(event_or_path, str):
         file_path = event_or_path
     else:
@@ -5768,7 +5774,8 @@ def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool =
         file_path = str(values[0])
 
     if verify and not file_path.startswith("[") and not file_path.startswith(("http://", "https://")) and not os.path.exists(file_path):
-        messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
+        if show_warning:
+            messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
         return None
     return file_path
 
@@ -5789,9 +5796,9 @@ def _resolve_file_paths(event_or_path: Union[tk.Event, str, None], verify: bool 
 
     valid_paths = []
     for path in targets:
-        if verify and not path.startswith("[") and not path.startswith(("http://", "https://")) and not os.path.exists(path):
-            continue
-        valid_paths.append(path)
+        resolved = _resolve_file_path(path, verify=verify, show_warning=False)
+        if resolved:
+            valid_paths.append(resolved)
 
     if verify and targets and not valid_paths:
         messagebox.showwarning("Files Not Found", "The selected file(s) could not be located on disk.")


### PR DESCRIPTION
* **What:** Refactored `_resolve_file_paths` to reuse the existing `_resolve_file_path` helper function for individual path resolution and verification. Extended `_resolve_file_path` with an optional `show_warning` parameter to allow suppression of individual warning dialogs during batch operations.
* **Why:** This change eliminates logic duplication and ensures consistent path resolution behavior across the application. It improves maintainability by centralizing validation logic (e.g., handling of virtual paths and URLs). No breaking changes were introduced, as `_resolve_file_path` maintains its previous behavior by default.

---
*PR created automatically by Jules for task [3016209424715441297](https://jules.google.com/task/3016209424715441297) started by @RainRat*