### PR TITLE
[TEST] Add coverage for _quote_for_ui path quoting

### DIFF
--- a/tests/test_quote_for_ui.py
+++ b/tests/test_quote_for_ui.py
@@ -1,0 +1,40 @@
+import sys
+from unittest.mock import patch
+import gptscan
+
+def test_quote_for_ui_posix_simple():
+    with patch("sys.platform", "linux"):
+        assert gptscan._quote_for_ui("path/to/file") == "path/to/file"
+
+def test_quote_for_ui_posix_with_space():
+    with patch("sys.platform", "linux"):
+        assert gptscan._quote_for_ui("path with space") == "'path with space'"
+
+def test_quote_for_ui_windows_simple():
+    with patch("sys.platform", "win32"):
+        assert gptscan._quote_for_ui(r"C:\path\to\file") == r"C:\path\to\file"
+
+def test_quote_for_ui_windows_with_space():
+    with patch("sys.platform", "win32"):
+        assert gptscan._quote_for_ui(r"C:\path to\file") == r'"C:\path to\file"'
+
+def test_quote_for_ui_windows_with_special_chars():
+    with patch("sys.platform", "win32"):
+        assert gptscan._quote_for_ui(r"C:\path%with&special^chars|and<others>") == r'"C:\path%with&special^chars|and<others>"'
+
+def test_quote_for_ui_windows_escapes_double_quotes():
+    with patch("sys.platform", "win32"):
+        path = r'C:\path "with" quotes'
+        expected = r'"C:\path ""with"" quotes"'
+        assert gptscan._quote_for_ui(path) == expected
+
+def test_quote_for_ui_windows_only_quotes_if_needed():
+    with patch("sys.platform", "win32"):
+        path = r"C:\Windows\System32\cmd.exe"
+        assert gptscan._quote_for_ui(path) == path
+
+def test_quote_for_ui_windows_quotes_and_escapes_single_quote_path():
+    with patch("sys.platform", "win32"):
+        path = '"'
+        expected = '""""'
+        assert gptscan._quote_for_ui(path) == expected


### PR DESCRIPTION
Type: New Coverage
What: Added comprehensive unit tests for the `_quote_for_ui` utility function in `gptscan.py`. These tests cover both POSIX and Windows platform-specific quoting logic, including edge cases like spaces, special shell characters (`%&^|<>`), and internal double quotes.
Why: `_quote_for_ui` is a critical utility used to ensure paths are correctly handled across different operating systems. It previously lacked dedicated unit test coverage.

---
*PR created automatically by Jules for task [17924928063931331774](https://jules.google.com/task/17924928063931331774) started by @RainRat*