### PR TITLE
[UI/UX] Improve CLI Triage Report visual hierarchy and labeling

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4733,17 +4733,17 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
         lines.append(f"{BOLD}[{i}] {risk_label} - {path}:{line_num}{RESET}")
 
         # Consolidate scores and links
-        meta_parts = [f"Scores: {own_conf}"]
+        meta_parts = [f"{BOLD}Local:{RESET}{GRAY} {own_conf}"]
         if gpt_conf:
-            meta_parts.append(f"AI: {gpt_conf}")
+            meta_parts.append(f"{BOLD}AI:{RESET}{GRAY} {gpt_conf}")
 
         vt_url = get_virustotal_url(path, snippet)
         if vt_url:
-            meta_parts.append(f"VT: {vt_url}")
+            meta_parts.append(f"{BOLD}VT:{RESET}{GRAY} {vt_url}")
 
         online_url = get_online_url(path, line_num)
         if online_url:
-            meta_parts.append(f"Online: {online_url}")
+            meta_parts.append(f"{BOLD}Online:{RESET}{GRAY} {online_url}")
 
         lines.append(f"    {GRAY}{' | '.join(meta_parts)}{RESET}")
 

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -131,11 +131,11 @@ def test_generate_console_report():
     # Without color
     report = gptscan.generate_console_report(results, use_color=False)
     assert "--- GPT SCAN TRIAGE REPORT ---" in report
-    assert "Scores: 90% | AI: 95% | VT: https://www.virustotal.com/gui/file/" in report
+    assert "Local: 90% | AI: 95% | VT: https://www.virustotal.com/gui/file/" in report
     assert "Admin: Admin note | User: User note" in report
     assert "> dangerous_code()" in report
     assert "[2] LOW RISK - safe.py:1" in report
-    assert "Scores: 10%" in report
+    assert "Local: 10%" in report
     assert "> print('ok')" in report
 
     # With color (check for ANSI codes)


### PR DESCRIPTION
**PR Title:** [UI/UX] Improve CLI Triage Report visual hierarchy and labeling 
 
**Description:** 
* **Context:** CLI 
* **Problem:** The CLI triage report used the generic "Scores:" label for local threat levels, which was inconsistent with the "AI:" label and GUI terminology. Additionally, metadata labels were not visually distinguished from their values, making the high-density report harder to scan quickly. 
* **Solution:** Renamed "Scores:" to "Local:" to standardize terminology across the application. Applied bold formatting to metadata labels ("Local:", "AI:", "VT:", "Online:") to improve visual hierarchy and scannability, while keeping the values themselves subtle in gray. 
 
**Changes:** 
In `gptscan.py`, the `generate_console_report` function was updated to use the new label and apply bold styling to metadata headers. The corresponding unit test in `tests/test_reporting_features.py` was also updated to reflect these formatting improvements.

---
*PR created automatically by Jules for task [7520334781207996442](https://jules.google.com/task/7520334781207996442) started by @RainRat*