### PR TITLE
[FEAT] Add "Scan SSH Configuration" feature

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2691,6 +2691,19 @@ def scan_editor_extensions_click():
         messagebox.showwarning("Editor Extensions Error", f"Could not scan editor extensions: {e}")
 
 
+def scan_ssh_config_click():
+    """Scan all common SSH configuration files."""
+    try:
+        ssh_paths = get_ssh_config_paths()
+        if ssh_paths:
+            _set_scan_target(ssh_paths)
+            button_click()
+        else:
+            messagebox.showinfo("SSH Configuration", "No common SSH configuration files were found on this system.")
+    except Exception as e:
+        messagebox.showwarning("SSH Configuration Error", f"Could not scan SSH configuration: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -6997,6 +7010,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
+    system_menu.add_command(label="Scan SSH Configuration", command=scan_ssh_config_click, accelerator="Ctrl+Shift+R")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
 
@@ -7381,6 +7395,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-W>', lambda event: scan_browser_extensions_click())
     root.bind('<Control-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
+    root.bind('<Control-Shift-R>', lambda event: scan_ssh_config_click())
+    root.bind('<Command-Shift-R>', lambda event: scan_ssh_config_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7585,6 +7601,11 @@ def main():
         '--editor-extensions',
         action='store_true',
         help='Scan all common editor extension directories.'
+    )
+    scan_group.add_argument(
+        '--ssh-config',
+        action='store_true',
+        help='Scan all common SSH configuration files.'
     )
     scan_group.add_argument(
         '--env-vars',
@@ -7876,6 +7897,13 @@ def main():
                 scan_targets.extend(extension_paths)
             else:
                 print("No editor extension directories were found.", file=sys.stderr)
+
+        if args.ssh_config:
+            ssh_paths = get_ssh_config_paths()
+            if ssh_paths:
+                scan_targets.extend(ssh_paths)
+            else:
+                print("No common SSH configuration files were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Access these options from the **Browse** menu:
 *   **Scan Node.js Packages:** Scan all directories containing global Node.js packages (global node_modules) for potentially malicious modules (Ctrl+Shift+M).
 *   **Scan Browser Extensions:** Scan all common browser extension directories for potentially malicious scripts (Ctrl+Shift+W).
 *   **Scan Editor Extensions:** Scan all directories containing editor extensions (VS Code, Sublime Text, Vim) for potentially malicious scripts (Ctrl+Shift+X).
+*   **Scan SSH Configuration:** Scan all common SSH configuration files for suspicious commands or settings (Ctrl+Shift+R).
 
 ### Keyboard Shortcuts
 The scanner includes shortcuts for faster navigation:
@@ -108,6 +109,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+M` | Scan Node.js Packages |
 | `Ctrl+Shift+W` | Scan Browser Extensions |
 | `Ctrl+Shift+X` | Scan Editor Extensions |
+| `Ctrl+Shift+R` | Scan SSH Configuration |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -181,6 +183,11 @@ python3 gptscan.py --browser-extensions --cli
 Scan all directories containing editor extensions:
 ```bash
 python3 gptscan.py --editor-extensions --cli
+```
+
+Scan all common SSH configuration files:
+```bash
+python3 gptscan.py --ssh-config --cli
 ```
 
 Scan all common shell profile and RC files:


### PR DESCRIPTION
I noticed that while SSH configuration scanning was partially integrated into the "System Audit" feature, it was not accessible as a standalone scan option. Providing it as a first-class feature (similar to Node.js packages or Browser extensions) improves symmetry and convenience for users who want to specifically audit their SSH setup without running a full system scan.

The new feature identifies common SSH configuration and authorized_keys files (~/.ssh/config, ~/.ssh/authorized_keys, /etc/ssh/sshd_config, etc.) across Windows and POSIX platforms and triggers a scan for suspicious commands or settings.

Summary of changes:
- **GUI:** New menu item "Scan SSH Configuration" in the "System Scans" menu.
- **Shortcuts:** Added `Ctrl+Shift+R` (and `Command+Shift+R` for macOS) support.
- **CLI:** New `--ssh-config` flag for terminal use.
- **Documentation:** Updated `readme.md` with the new shortcut and CLI example.

---
*PR created automatically by Jules for task [6724182810936007871](https://jules.google.com/task/6724182810936007871) started by @RainRat*