### PR TITLE
[TEST] Fix adjust_newlines to preserve trailing and consecutive newlines

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1035,9 +1035,8 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
         return val
 
     measure = measure or tkinter.font.Font(font='TkDefaultFont').measure
-    original_lines = val.splitlines()
-    if not original_lines:
-        return val
+    # Use split('\n') to preserve all empty lines, including trailing ones
+    original_lines = val.split('\n')
 
     wrapped_lines = []
     for line in original_lines:

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -129,6 +129,30 @@ def test_adjust_newlines_wrap(monkeypatch):
 def test_adjust_newlines_non_string():
     assert adjust_newlines(123, 100) == 123
 
+def test_adjust_newlines_preserves_trailing_newline():
+    text = "line1\nline2\n"
+    # measure=len for simplicity in testing
+    result = adjust_newlines(text, width=100, measure=len)
+    assert result == text
+
+def test_adjust_newlines_preserves_multiple_trailing_newlines():
+    text = "line1\nline2\n\n"
+    result = adjust_newlines(text, width=100, measure=len)
+    assert result == text
+
+def test_adjust_newlines_preserves_consecutive_newlines():
+    text = "line1\n\nline2"
+    result = adjust_newlines(text, width=100, measure=len)
+    assert result == text
+
+def test_adjust_newlines_only_newlines():
+    text = "\n\n\n"
+    result = adjust_newlines(text, width=100, measure=len)
+    assert result == text
+
+def test_adjust_newlines_empty_string():
+    assert adjust_newlines("", 100) == ""
+
 # --- sort_column Tests ---
 
 def test_sort_column_numeric(monkeypatch):


### PR DESCRIPTION
Analysis of the `adjust_newlines` function revealed a logic error where trailing newlines and consecutive empty lines were being lost due to the use of `splitlines()`. This was particularly problematic for preserving text structure during wrapping.

The fix involves switching to `split('\n')`, which ensures that the string can be perfectly reconstructed with its original newline count. The associated tests in `tests/test_config_and_utils.py` verify this behavior across several edge cases that were previously failing.

---
*PR created automatically by Jules for task [6034327782197250949](https://jules.google.com/task/6034327782197250949) started by @RainRat*