### PR TITLE
[DOCS] Improve local trainer documentation and CLI help text

### DIFF
--- a/train.md
+++ b/train.md
@@ -1,15 +1,15 @@
 # Training the Local Scanner
 
-This tool trains the local model (the file classifier) used by the GPT Virus Scanner. It learns to recognize the difference between safe and dangerous files by studying many examples.
+Train the local model (the file classifier) for the GPT Virus Scanner. It learns to find dangerous files by studying many examples of safe and malicious code.
 
 ## Features
 
-- **Simple settings:** Uses easy-to-read YAML files for configuration.
-- **Smart optimization:** Automatically tries different settings to find the best way to detect threats.
+- **Simple settings:** Use easy-to-read YAML files for configuration.
+- **Smart optimization:** Find the best way to detect threats automatically.
 - **Easy to use:** Run everything from your terminal with simple commands.
-- **Broad support:** Analyzes many different types of files.
-- **Automatic saving:** Keeps your progress safe by saving the best models as it finds them.
-- **Flexible:** Handles files of any size automatically.
+- **Broad support:** Analyze many different types of files.
+- **Automatic saving:** Keep your progress safe with automatic model saves.
+- **Flexible:** Process files of any size automatically.
 
 ## Installation
 
@@ -21,7 +21,7 @@ This tool trains the local model (the file classifier) used by the GPT Virus Sca
 
 ## Configuration
 
-The trainer requires a `config.yml` file to run. This file contains settings for the model, the training process, and the optimization settings.
+The trainer requires a `config.yml` file. This file contains settings for the model, the training process, and the optimization settings.
 
 ### Example `config.yml`
 
@@ -71,9 +71,9 @@ hyperparameters:
   optimizer: 0.5              # How the model learns from its mistakes
 ```
 
-## Directory Structure
+## Folder Structure
 
-The script expects the following directory structure by default:
+The script expects the following folder structure by default:
 
 ```
 project/
@@ -108,22 +108,22 @@ python3 train.py --config config.yml --mode predict
 
 ### Advanced Options
 
-#### Override configuration values:
+#### Override settings:
 
 ```bash
-# Use different model name
+# Use a different model name
 python3 train.py --config config.yml --model-name my_model
 
 # Change training parameters
 python3 train.py --config config.yml --epochs 50 --batch-size 64
 
-# Specify custom data directories
+# Specify custom folders for training data
 python3 train.py --config config.yml \
     --positive-dir /path/to/positive \
     --negative-dir /path/to/negative
 ```
 
-#### Custom prediction directories:
+#### Custom scan folders:
 
 ```bash
 python3 train.py --config config.yml \
@@ -163,15 +163,15 @@ python3 train.py --config config.yml \
 ## Command-Line Options
 
 ```
---config, -c           Path to YAML configuration file (required)
---mode, -m             Mode: train or predict (overrides config)
---model-name           Model name (overrides config)
---positive-dir         Directory with dangerous files
---negative-dir         Directory with safe files
---predict-dir          Directory with files to predict on
---output-dir           Output directory for prediction results
---epochs               Number of training rounds (overrides config)
---batch-size           Number of files processed at once (overrides config)
+--config, -c           Path to the YAML settings file (required).
+--mode, -m             Choose between training a model or making predictions.
+--model-name           Set the model name.
+--positive-dir         Folder containing dangerous files.
+--negative-dir         Folder containing safe files.
+--predict-dir          Folder containing files to scan.
+--output-dir           Folder where suspicious files will be copied.
+--epochs               Number of training rounds.
+--batch-size           Number of files to process at once.
 ```
 
 ## Output Files

--- a/train.py
+++ b/train.py
@@ -132,7 +132,6 @@ class DataLoader:
         y_train = []
         sample_weights = []
         
-        # Load positive examples
         for file_path in positive_dir.iterdir():
             if file_path.is_file():
                 data = self.load_file(file_path)
@@ -140,7 +139,6 @@ class DataLoader:
                 y_train.append(1)
                 sample_weights.append(self.config.positive_sample_weight)
         
-        # Load negative examples
         for file_path in negative_dir.iterdir():
             if file_path.is_file():
                 data = self.load_file(file_path)
@@ -395,7 +393,6 @@ class Trainer:
                 callbacks=[early_stop]
             )
             
-            # Evaluate results
             val_acc = history.history['val_weighted_acc']
             val_loss = history.history['val_weighted_binary_crossentropy']
             
@@ -504,21 +501,21 @@ def load_config(config_path: str) -> Tuple[ModelConfig, Optional[Hyperparameters
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Train or run predictions with a binary file classifier using an automatic optimization process.',
+        description='Train the local classifier or use it to find suspicious files.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Train with config file
-  python train.py --config config.yml --mode train
+  # Train a model using settings from a file
+  python3 train.py --config config.yml --mode train
   
-  # Predict with config file
-  python train.py --config config.yml --mode predict
+  # Use a model to find suspicious files
+  python3 train.py --config config.yml --mode predict
   
-  # Override model name
-  python train.py --config config.yml --model-name my_model
+  # Use a custom model name
+  python3 train.py --config config.yml --model-name my_model
   
-  # Use custom data directories
-  python train.py --config config.yml --positive-dir data/dangerous --negative-dir data/safe
+  # Specify folders for training data
+  python3 train.py --config config.yml --positive-dir data/dangerous --negative-dir data/safe
         """
     )
     
@@ -526,56 +523,56 @@ Examples:
         '--config', '-c',
         type=str,
         required=True,
-        help='Path to YAML settings file'
+        help='Path to the YAML settings file.'
     )
     
     parser.add_argument(
         '--mode', '-m',
         type=str,
         choices=['train', 'predict'],
-        help='Mode: train or predict (overrides config file)'
+        help='Choose between training a model or making predictions.'
     )
     
     parser.add_argument(
         '--model-name',
         type=str,
-        help='Model name (overrides config file)'
+        help='Set the model name.'
     )
     
     parser.add_argument(
         '--positive-dir',
         type=str,
-        help='Directory with dangerous files'
+        help='Folder containing dangerous files.'
     )
     
     parser.add_argument(
         '--negative-dir',
         type=str,
-        help='Directory with safe files'
+        help='Folder containing safe files.'
     )
     
     parser.add_argument(
         '--predict-dir',
         type=str,
-        help='Directory containing files to predict on'
+        help='Folder containing files to scan.'
     )
     
     parser.add_argument(
         '--output-dir',
         type=str,
-        help='Output directory for prediction results'
+        help='Folder where suspicious files will be copied.'
     )
     
     parser.add_argument(
         '--epochs',
         type=int,
-        help='Number of training epochs (overrides config file)'
+        help='Number of training rounds.'
     )
     
     parser.add_argument(
         '--batch-size',
         type=int,
-        help='Batch size (overrides config file)'
+        help='Number of files to process at once.'
     )
     
     return parser.parse_args()


### PR DESCRIPTION
### Improvements to Local Trainer Documentation

This PR enhances the accessibility and clarity of the local model training tools:

1.  **Internal Help Strings (`train.py`):**
    *   Updated CLI `--help` text to use Plain English and active voice.
    *   Replaced "directory" with "folder" for better user accessibility.
    *   Simplified jargon: "epochs" became "training rounds", "batch size" became "number of files to process at once", and "prediction" became "finding suspicious files".
    *   Standardized epilog examples to use `python3` consistently.

2.  **Project Documentation (`train.md`):**
    *   Aligned the Markdown documentation with the refined CLI help text.
    *   Standardized terminology (e.g., "folder structure" instead of "directory structure").
    *   Improved readability with simpler sentence structures and active voice.

3.  **Code Comments (`train.py`):**
    *   Removed redundant comments that merely restated the code's mechanics (e.g., `# Load positive examples`).

All changes were verified against the codebase behavior and confirmed to pass relevant tests in `tests/test_train.py`.

---
*PR created automatically by Jules for task [16997825988653255350](https://jules.google.com/task/16997825988653255350) started by @RainRat*