### PR TITLE
[FEAT] Scan SSH Configuration

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2614,6 +2614,19 @@ def scan_system_services_click():
         messagebox.showwarning("System Services Error", f"Could not scan system services: {e}")
 
 
+def scan_ssh_config_click():
+    """Scan all common SSH configuration and authorized_keys files."""
+    try:
+        paths = get_ssh_config_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("SSH Configuration", "No SSH configuration or authorized_keys files were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("SSH Configuration Error", f"Could not scan SSH configuration: {e}")
+
+
 def scan_python_packages_click():
     """Scan all directories containing installed Python packages (site-packages)."""
     try:
@@ -6993,6 +7006,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Scheduled Tasks", command=scan_scheduled_tasks_click, accelerator="Ctrl+Shift+T")
     system_menu.add_command(label="Scan Startup Items", command=scan_startup_items_click, accelerator="Ctrl+Shift+A")
     system_menu.add_command(label="Scan System Services", command=scan_system_services_click, accelerator="Ctrl+Shift+S")
+    system_menu.add_command(label="Scan SSH Configuration", command=scan_ssh_config_click, accelerator="Ctrl+Shift+R")
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
@@ -7373,6 +7387,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-A>', lambda event: scan_startup_items_click())
     root.bind('<Control-Shift-S>', lambda event: scan_system_services_click())
     root.bind('<Command-Shift-S>', lambda event: scan_system_services_click())
+    root.bind('<Control-Shift-R>', lambda event: scan_ssh_config_click())
+    root.bind('<Command-Shift-R>', lambda event: scan_ssh_config_click())
     root.bind('<Control-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Command-Shift-Y>', lambda event: scan_python_packages_click())
     root.bind('<Control-Shift-M>', lambda event: scan_nodejs_packages_click())
@@ -7456,6 +7472,8 @@ def main():
                "  python3 gptscan.py --audit --cli\n\n"
                "  # Scan all installed editor extensions\n"
                "  python3 gptscan.py --editor-extensions --cli\n\n"
+               "  # Scan SSH configuration and authorized keys\n"
+               "  python3 gptscan.py --ssh-config --cli\n\n"
                "  # Scan files changed in the last 24 hours\n"
                "  python3 gptscan.py --modified 24h --cli\n\n"
                "Note: Run the script from its own folder so it can find its data files.",
@@ -7585,6 +7603,11 @@ def main():
         '--editor-extensions',
         action='store_true',
         help='Scan all common editor extension directories.'
+    )
+    scan_group.add_argument(
+        '--ssh-config',
+        action='store_true',
+        help='Scan all common SSH configuration and authorized_keys files.'
     )
     scan_group.add_argument(
         '--env-vars',
@@ -7876,6 +7899,13 @@ def main():
                 scan_targets.extend(extension_paths)
             else:
                 print("No editor extension directories were found.", file=sys.stderr)
+
+        if args.ssh_config:
+            ssh_paths = get_ssh_config_paths()
+            if ssh_paths:
+                scan_targets.extend(ssh_paths)
+            else:
+                print("No SSH configuration or authorized_keys files were found.", file=sys.stderr)
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Access these options from the **Browse** menu:
 *   **Scan Scheduled Tasks:** Scan all scheduled tasks (Windows) and Cron jobs (Linux/macOS) to identify dangerous ways for programs to stay on your system (Ctrl+Shift+T).
 *   **Scan Startup Items:** Scan all system startup items and LaunchAgents to find malicious ways for programs to stay on your system (Ctrl+Shift+A).
 *   **Scan System Services:** Scan all system services (systemd files on Linux, Service PathName on Windows) to identify dangerous ways for programs to stay on your system (Ctrl+Shift+S).
+*   **Scan SSH Configuration:** Scan all common SSH configuration and authorized_keys files (Ctrl+Shift+R).
 *   **Scan Python Packages:** Scan all directories containing installed Python packages (site-packages) for potentially malicious modules (Ctrl+Shift+Y).
 *   **Scan Node.js Packages:** Scan all directories containing global Node.js packages (global node_modules) for potentially malicious modules (Ctrl+Shift+M).
 *   **Scan Browser Extensions:** Scan all common browser extension directories for potentially malicious scripts (Ctrl+Shift+W).
@@ -104,6 +105,7 @@ The scanner includes shortcuts for faster navigation:
 | `Ctrl+Shift+T` | Scan Scheduled Tasks |
 | `Ctrl+Shift+A` | Scan Startup Items |
 | `Ctrl+Shift+S` | Scan System Services |
+| `Ctrl+Shift+R` | Scan SSH Configuration |
 | `Ctrl+Shift+Y` | Scan Python Packages |
 | `Ctrl+Shift+M` | Scan Node.js Packages |
 | `Ctrl+Shift+W` | Scan Browser Extensions |
@@ -216,6 +218,11 @@ python3 gptscan.py --startup-items --cli
 Scan all system services:
 ```bash
 python3 gptscan.py --system-services --cli
+```
+
+Scan SSH configuration and authorized keys:
+```bash
+python3 gptscan.py --ssh-config --cli
 ```
 
 Scan all environment variables:


### PR DESCRIPTION
Implemented a "Scan SSH Configuration" feature that exposes existing SSH path discovery logic as a standalone scan option. This allows users to specifically audit their SSH configurations and authorized keys for suspicious entries. The feature is available via a new GUI menu item, the Ctrl+Shift+R shortcut, and the --ssh-config CLI flag. Documentation in readme.md has been updated to reflect these changes.

---
*PR created automatically by Jules for task [355233727335849631](https://jules.google.com/task/355233727335849631) started by @RainRat*