### PR TITLE
[Deduplicate file path resolution logic]

### DIFF
--- a/.gptscan_cache.json
+++ b/.gptscan_cache.json
@@ -1,0 +1,7 @@
+{
+    "c961e56142c0e2771271fdc84e59ce81e0c27d0b83888a77b0a9032d554e9b26": {
+        "administrator": "Admin",
+        "end-user": "User",
+        "threat-level": 70
+    }
+}

--- a/gptscan.py
+++ b/gptscan.py
@@ -5752,7 +5752,7 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
     return [str(v).replace('\n', ' ') for v in values[:7]]
 
 
-def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True) -> Optional[str]:
+def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True, show_warning: bool = True) -> Optional[str]:
     """Retrieve and optionally verify a file path from an event or direct argument."""
     if isinstance(event_or_path, str):
         file_path = event_or_path
@@ -5768,7 +5768,8 @@ def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool =
         file_path = str(values[0])
 
     if verify and not file_path.startswith("[") and not file_path.startswith(("http://", "https://")) and not os.path.exists(file_path):
-        messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
+        if show_warning:
+            messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
         return None
     return file_path
 
@@ -5789,9 +5790,9 @@ def _resolve_file_paths(event_or_path: Union[tk.Event, str, None], verify: bool 
 
     valid_paths = []
     for path in targets:
-        if verify and not path.startswith("[") and not path.startswith(("http://", "https://")) and not os.path.exists(path):
-            continue
-        valid_paths.append(path)
+        resolved = _resolve_file_path(path, verify=verify, show_warning=False)
+        if resolved is not None:
+            valid_paths.append(resolved)
 
     if verify and targets and not valid_paths:
         messagebox.showwarning("Files Not Found", "The selected file(s) could not be located on disk.")


### PR DESCRIPTION
* **What:** Refactored `_resolve_file_paths` to reuse the `_resolve_file_path` helper function. Added an optional `show_warning` parameter to `_resolve_file_path` to allow batch processing without redundant individual warning dialogs. Specifically, `_resolve_file_paths` now uses `if resolved is not None:` to strictly preserve original behavior for falsy path strings.
* **Why:** Reduces code duplication and improves maintainability by centralizing validation logic (handling virtual paths, protocols, and existence checks). This ensures consistent behavior across all GUI actions that resolve file paths. All tests passed, confirming that external behavior remains identical.

---
*PR created automatically by Jules for task [10598465000091707757](https://jules.google.com/task/10598465000091707757) started by @RainRat*