### PR TITLE
[TEST] Add coverage for platform-specific path quoting logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .coverage
 .pytest_cache/
 .gptscan_settings.json
+.gptscan_cache.json

--- a/tests/test_quote_for_ui.py
+++ b/tests/test_quote_for_ui.py
@@ -1,0 +1,38 @@
+import sys
+import shlex
+import pytest
+from gptscan import _quote_for_ui
+
+def test_quote_for_ui_posix_no_spaces(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    path = "/home/user/file.py"
+    # shlex.quote behavior might vary slightly by python version,
+    # but for simple paths it usually returns it as is or single quoted.
+    assert _quote_for_ui(path) == shlex.quote(path)
+
+def test_quote_for_ui_posix_with_spaces(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    path = "/home/user/my file.py"
+    assert _quote_for_ui(path) == shlex.quote(path)
+
+def test_quote_for_ui_windows_no_special_chars(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    path = "C:\\Users\\file.py"
+    assert _quote_for_ui(path) == path
+
+def test_quote_for_ui_windows_with_spaces(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    path = "C:\\Users\\my file.py"
+    assert _quote_for_ui(path) == '"C:\\Users\\my file.py"'
+
+def test_quote_for_ui_windows_with_special_chars(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    special_chars = '%&^|<>'
+    for char in special_chars:
+        path = f"C:\\temp\\file{char}.py"
+        assert _quote_for_ui(path) == f'"{path}"'
+
+def test_quote_for_ui_windows_escapes_double_quotes(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    path = 'C:\\temp\\"file".py'
+    assert _quote_for_ui(path) == '"C:\\temp\\""file"".py"'


### PR DESCRIPTION
**PR Title:** [TEST] Add coverage for platform-specific path quoting logic

**Description:**
* **Type:** New Coverage
* **What:** Implemented unit tests for the `_quote_for_ui` function in `gptscan.py`. These tests cover both POSIX and Windows platforms, including cases with spaces, special shell characters (`%&^|<>`), and double quote escaping.
* **Why:** This function was previously untested. Ensuring robust path quoting is critical for correct shell command generation and UI display across different operating systems.

---
*PR created automatically by Jules for task [9048623978038586202](https://jules.google.com/task/9048623978038586202) started by @RainRat*