### PR TITLE
[FEAT] Scan Downloads folder for suspicious files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1180,6 +1180,16 @@ def get_system_path_directories() -> List[str]:
     return _normalize_and_filter_dirs(path_env.split(os.pathsep))
 
 
+def get_downloads_paths() -> List[str]:
+    """Identify the standard Downloads directory."""
+    paths = []
+    home = Path.home()
+    downloads = home / "Downloads"
+    if downloads.exists():
+        paths.append(str(downloads))
+    return paths
+
+
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all running processes."""
     processes = []
@@ -2703,6 +2713,19 @@ def scan_editor_extensions_click():
         messagebox.showwarning("Editor Extensions Error", f"Could not scan editor extensions: {e}")
 
 
+def scan_downloads_click():
+    """Scan the standard Downloads directory."""
+    try:
+        paths = get_downloads_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Downloads", "The standard Downloads folder was not found on this system.")
+    except Exception as e:
+        messagebox.showwarning("Downloads Error", f"Could not scan Downloads: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2716,6 +2739,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_nodejs_package_paths())
     all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
+    all_paths.extend(get_downloads_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -7011,6 +7035,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
+    system_menu.add_command(label="Scan Downloads", command=scan_downloads_click, accelerator="Ctrl+Shift+J")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
 
@@ -7397,6 +7422,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-W>', lambda event: scan_browser_extensions_click())
     root.bind('<Control-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
+    root.bind('<Control-Shift-J>', lambda event: scan_downloads_click())
+    root.bind('<Command-Shift-J>', lambda event: scan_downloads_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7633,6 +7660,11 @@ def main():
         '--modified',
         type=str,
         help="Only scan files changed within this timeframe (for example: '24h', '1h', '7d')."
+    )
+    scan_group.add_argument(
+        '--downloads',
+        action='store_true',
+        help='Scan the standard Downloads folder.'
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
@@ -7918,6 +7950,9 @@ def main():
             paths, snippets = get_system_audit_data()
             scan_targets.extend(paths)
             extra_snippets.extend(snippets)
+
+        if args.downloads:
+            scan_targets.extend(get_downloads_paths())
 
         modified_since = None
         if args.modified:

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Access these options from the **Browse** menu:
 *   **Scan Node.js Packages (Ctrl+Shift+M):** Scan your global Node.js packages.
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
+*   **Scan Downloads (Ctrl+Shift+J):** Scan your standard Downloads folder for suspicious files.
 
 
 ### Keyboard Shortcuts
@@ -118,6 +119,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+M` | Scan Node.js Packages |
 | `Ctrl+Shift+W` | Scan Browser Extensions |
 | `Ctrl+Shift+X` | Scan Editor Extensions |
+| `Ctrl+Shift+J` | Scan Downloads |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -194,6 +196,11 @@ python3 gptscan.py --editor-extensions --cli
 Scan all common shell profile and RC files:
 ```bash
 python3 gptscan.py --shell-profiles --cli
+```
+
+Scan the standard Downloads folder:
+```bash
+python3 gptscan.py --downloads --cli
 ```
 
 Scan your terminal history (Bash, Zsh, PowerShell, etc.):

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import gptscan
+from pathlib import Path
+
+def test_get_downloads_paths_exists(monkeypatch):
+    mock_home = Path("/home/testuser")
+    monkeypatch.setattr("pathlib.Path.home", lambda: mock_home)
+
+    # Mock Path.exists to return True for the Downloads folder
+    original_exists = Path.exists
+    def mock_exists(self):
+        if str(self) == str(mock_home / "Downloads"):
+            return True
+        return False
+
+    monkeypatch.setattr("pathlib.Path.exists", mock_exists)
+
+    paths = gptscan.get_downloads_paths()
+    assert len(paths) == 1
+    assert paths[0] == str(mock_home / "Downloads")
+
+def test_get_downloads_paths_not_exists(monkeypatch):
+    mock_home = Path("/home/testuser")
+    monkeypatch.setattr("pathlib.Path.home", lambda: mock_home)
+
+    # Mock Path.exists to return False
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: False)
+
+    paths = gptscan.get_downloads_paths()
+    assert len(paths) == 0
+
+def test_scan_downloads_click(monkeypatch):
+    monkeypatch.setattr("gptscan.get_downloads_paths", lambda: ["/downloads"])
+
+    target_paths = []
+    def mock_set_target(paths):
+        nonlocal target_paths
+        target_paths = paths
+    monkeypatch.setattr("gptscan._set_scan_target", mock_set_target)
+
+    clicked = False
+    def mock_button_click():
+        nonlocal clicked
+        clicked = True
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+
+    gptscan.scan_downloads_click()
+
+    assert "/downloads" in target_paths
+    assert clicked
+
+def test_cli_downloads_flag(monkeypatch):
+    monkeypatch.setattr("gptscan.get_downloads_paths", lambda: ["/downloads"])
+
+    cli_args = []
+    def mock_run_cli(targets, *args, **kwargs):
+        nonlocal cli_args
+        cli_args = targets
+        return 0
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+
+    import sys
+    test_args = ["gptscan.py", "--downloads", "--cli"]
+    with patch.object(sys, 'argv', test_args):
+        gptscan.main()
+
+    assert "/downloads" in cli_args


### PR DESCRIPTION
The 'Scan Downloads' feature allows users to quickly check their standard Downloads folder for suspicious files. This is a logical extension of the scanner's existing system-level scan capabilities (like Browser Extensions and Node.js packages), targeting a high-risk entry point for potentially malicious code. The feature is available via the GUI (Browse > System Scans > Scan Downloads or Ctrl+Shift+J), the CLI (`--downloads`), and is included in the full `--audit` scan.

---
*PR created automatically by Jules for task [7397680943515280625](https://jules.google.com/task/7397680943515280625) started by @RainRat*