### PR TITLE
[UI/UX] Add keyboard shortcut for Scan Folder (Ctrl+Shift+F)

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6994,7 +6994,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")
-    browse_menu.add_command(label="Scan Folder...", command=browse_dir_click)
+    browse_menu.add_command(label="Scan Folder...", command=browse_dir_click, accelerator="Ctrl+Shift+F")
     browse_menu.add_command(label="Scan URL...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
 
@@ -7384,6 +7384,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-o>', import_results)
     root.bind('<Control-Shift-O>', lambda event: browse_file_click())
     root.bind('<Command-Shift-O>', lambda event: browse_file_click())
+    root.bind('<Control-Shift-F>', lambda event: browse_dir_click())
+    root.bind('<Command-Shift-F>', lambda event: browse_dir_click())
     root.bind('<Control-Shift-U>', lambda event: select_url_click())
     root.bind('<Command-Shift-U>', lambda event: select_url_click())
     root.bind('<Control-Shift-V>', lambda event: scan_clipboard_click())

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Run `python3 gptscan.py` to open the scanner window.
 Access these options from the **Browse** menu:
 #### Common Scans
 *   **Scan File(s)... (Ctrl+Shift+O):** Select specific files to scan.
-*   **Scan Folder...:** Select an entire folder to scan.
+*   **Scan Folder... (Ctrl+Shift+F):** Select an entire folder to scan.
 *   **Scan Recently Modified...:** Scan files changed within a certain time (like the last 24 hours).
 *   **Scan URL... (Ctrl+Shift+U):** Scan code or archives directly from a web link.
 *   **Scan File List...:** Scan a list of files from a text file.
@@ -101,6 +101,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+E` | Copy as Command Line |
 | **Scan Actions** | |
 | `Ctrl+Shift+O` | Scan File(s) |
+| `Ctrl+Shift+F` | Scan Folder |
 | `Ctrl+Shift+U` | Scan URL |
 | `Ctrl+Shift+V` | Scan Clipboard |
 | `Ctrl+Shift+D` | Scan Git Diff |


### PR DESCRIPTION
**PR Title:** [UI/UX] Add keyboard shortcut for Scan Folder (Ctrl+Shift+F)

**Description:**
* **Context:** GUI
* **Problem:** The "Scan Folder..." action was only accessible via mouse in the Browse menu, while most other scanning actions had keyboard shortcuts (e.g., Ctrl+Shift+O for files, Ctrl+Shift+U for URLs). This created friction for keyboard-heavy workflows.
* **Solution:** Added `Ctrl+Shift+F` (and `Command+Shift+F` on macOS) as a shortcut for "Scan Folder...". This improves efficiency and consistency across the interface.

**Changes:**
- Modified `gptscan.py` to include the accelerator in the menu and bind the shortcut to the `browse_dir_click` function.
- Updated `readme.md` to include the new shortcut in the GUI guide and the keyboard shortcuts table.

---
*PR created automatically by Jules for task [6647120371682296548](https://jules.google.com/task/6647120371682296548) started by @RainRat*