### PR TITLE
[FEAT] Scan Temporary Folders for suspicious scripts

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1190,6 +1190,27 @@ def get_downloads_paths() -> List[str]:
     return paths
 
 
+def get_temp_folders_paths() -> List[str]:
+    """Identify platform-specific temporary folders."""
+    paths = []
+    if sys.platform == "win32":
+        # Windows temporary folders
+        temp_vars = ["TEMP", "TMP"]
+        for var in temp_vars:
+            val = os.environ.get(var)
+            if val:
+                paths.append(val)
+        # System-wide temp
+        win_temp = "C:\\Windows\\Temp"
+        if os.path.exists(win_temp):
+            paths.append(win_temp)
+    else:
+        # Linux/macOS/Unix temporary folders
+        paths.extend(["/tmp", "/var/tmp", "/dev/shm"])
+
+    return _normalize_and_filter_dirs(paths)
+
+
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all running processes."""
     processes = []
@@ -2730,6 +2751,19 @@ def scan_downloads_click():
         messagebox.showwarning("Downloads Error", f"Could not scan Downloads: {e}")
 
 
+def scan_temp_folders_click():
+    """Scan platform-specific temporary folders."""
+    try:
+        paths = get_temp_folders_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Temporary Folders", "No valid temporary folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Temporary Folders Error", f"Could not scan temporary folders: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2744,6 +2778,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
     all_paths.extend(get_downloads_paths())
+    all_paths.extend(get_temp_folders_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -7032,6 +7067,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
     system_menu.add_command(label="Scan Downloads", command=scan_downloads_click, accelerator="Ctrl+Shift+J")
+    system_menu.add_command(label="Scan Temporary Folders", command=scan_temp_folders_click, accelerator="Ctrl+Shift+L")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
 
@@ -7420,6 +7456,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Control-Shift-J>', lambda event: scan_downloads_click())
     root.bind('<Command-Shift-J>', lambda event: scan_downloads_click())
+    root.bind('<Control-Shift-L>', lambda event: scan_temp_folders_click())
+    root.bind('<Command-Shift-L>', lambda event: scan_temp_folders_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7665,6 +7703,11 @@ def main():
         '--env-vars',
         action='store_true',
         help='Scan all non-empty environment variables.'
+    )
+    system_group.add_argument(
+        '--temp-folders',
+        action='store_true',
+        help='Scan platform-specific temporary folders.'
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
@@ -7953,6 +7996,9 @@ def main():
 
         if args.downloads:
             scan_targets.extend(get_downloads_paths())
+
+        if args.temp_folders:
+            scan_targets.extend(get_temp_folders_paths())
 
         modified_since = None
         if args.modified:

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Access these options from the **Browse** menu:
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
 *   **Scan Downloads (Ctrl+Shift+J):** Scan your standard Downloads folder for suspicious files.
+*   **Scan Temporary Folders (Ctrl+Shift+L):** Scan platform-specific temporary folders (like /tmp or %TEMP%).
 
 
 ### Keyboard Shortcuts
@@ -120,6 +121,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+W` | Scan Browser Extensions |
 | `Ctrl+Shift+X` | Scan Editor Extensions |
 | `Ctrl+Shift+J` | Scan Downloads |
+| `Ctrl+Shift+L` | Scan Temporary Folders |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -201,6 +203,11 @@ python3 gptscan.py --shell-profiles --cli
 Scan the standard Downloads folder:
 ```bash
 python3 gptscan.py --downloads --cli
+```
+
+Scan platform-specific temporary folders:
+```bash
+python3 gptscan.py --temp-folders --cli
 ```
 
 Scan your terminal history (Bash, Zsh, PowerShell, etc.):


### PR DESCRIPTION
I have implemented a new feature that allows users to scan platform-specific temporary folders. This is a common location for malicious scripts and payloads.

### Changes:
- **Core Logic:** Added `get_temp_folders_paths()` to discover standard temporary directories across Windows, macOS, and Linux.
- **System Audit:** Integrated temporary folder scanning into the existing "System Audit" (the comprehensive `--audit` scan).
- **CLI:** Added a new `--temp-folders` flag to the "System Scans" group.
- **GUI:** 
    - Added "Scan Temporary Folders" to the "System Scans" submenu.
    - Bound `Ctrl+Shift+L` (and `Command+Shift+L` on macOS) to trigger the scan.
- **Documentation:** Updated `readme.md` to include instructions and shortcuts for the new feature.

### Verification:**
- Verified the CLI flag and path discovery logic using `--temp-folders --dry-run --cli`.
- Verified that the new feature integrates correctly into the "System Audit" data collection.
- Confirmed that existing unit tests (850 total) still pass.
- GUI changes were verified through code review and internal consistency with established patterns in the codebase (e.g., matching the implementation of "Scan Downloads").

Note: Playwright-based frontend verification was not applicable as this project uses a Tkinter GUI rather than a web-based frontend.

---
*PR created automatically by Jules for task [6600384464922239571](https://jules.google.com/task/6600384464922239571) started by @RainRat*