### PR TITLE
[FEAT] Add Scan Temporary Folders feature

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -14,6 +14,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import tarfile
 import threading
 import time
@@ -1188,6 +1189,12 @@ def get_downloads_paths() -> List[str]:
     if downloads.exists():
         paths.append(str(downloads))
     return paths
+
+
+def get_temp_paths() -> List[str]:
+    """Identify common temporary directories."""
+    paths = [tempfile.gettempdir(), "/tmp", "/var/tmp"]
+    return sorted(_normalize_and_filter_dirs(paths))
 
 
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
@@ -2730,6 +2737,19 @@ def scan_downloads_click():
         messagebox.showwarning("Downloads Error", f"Could not scan Downloads: {e}")
 
 
+def scan_temp_click():
+    """Scan common temporary directories."""
+    try:
+        paths = get_temp_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Temporary Folders", "No common temporary folders were found on this system.")
+    except Exception as e:
+        messagebox.showwarning("Temporary Folders Error", f"Could not scan temporary folders: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2744,6 +2764,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
     all_paths.extend(get_downloads_paths())
+    all_paths.extend(get_temp_paths())
 
     all_snippets = []
     all_snippets.extend(get_running_process_commands())
@@ -6982,7 +7003,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y/M/X).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J/Z).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -7032,6 +7053,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
     system_menu.add_command(label="Scan Downloads", command=scan_downloads_click, accelerator="Ctrl+Shift+J")
+    system_menu.add_command(label="Scan Temporary Folders", command=scan_temp_click, accelerator="Ctrl+Shift+Z")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
 
@@ -7420,6 +7442,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-X>', lambda event: scan_editor_extensions_click())
     root.bind('<Control-Shift-J>', lambda event: scan_downloads_click())
     root.bind('<Command-Shift-J>', lambda event: scan_downloads_click())
+    root.bind('<Control-Shift-Z>', lambda event: scan_temp_click())
+    root.bind('<Command-Shift-Z>', lambda event: scan_temp_click())
     root.bind('<Control-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Command-Shift-I>', lambda event: scan_system_audit_click())
     root.bind('<Control-e>', export_results)
@@ -7665,6 +7689,11 @@ def main():
         '--env-vars',
         action='store_true',
         help='Scan all non-empty environment variables.'
+    )
+    system_group.add_argument(
+        '--temp',
+        action='store_true',
+        help='Scan common temporary directories.'
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
@@ -7953,6 +7982,9 @@ def main():
 
         if args.downloads:
             scan_targets.extend(get_downloads_paths())
+
+        if args.temp:
+            scan_targets.extend(get_temp_paths())
 
         modified_since = None
         if args.modified:

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Access these options from the **Browse** menu:
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
 *   **Scan Downloads (Ctrl+Shift+J):** Scan your standard Downloads folder for suspicious files.
+*   **Scan Temporary Folders (Ctrl+Shift+Z):** Scan common temporary folders for suspicious files.
 
 
 ### Keyboard Shortcuts
@@ -120,6 +121,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+W` | Scan Browser Extensions |
 | `Ctrl+Shift+X` | Scan Editor Extensions |
 | `Ctrl+Shift+J` | Scan Downloads |
+| `Ctrl+Shift+Z` | Scan Temporary Folders |
 | **Results List** | |
 | `Space` / `Enter` | View Details |
 | `F5` / `r` | Rescan |
@@ -236,6 +238,11 @@ python3 gptscan.py --system-services --cli
 Scan SSH configuration and authorized keys:
 ```bash
 python3 gptscan.py --ssh-config --cli
+```
+
+Scan common temporary directories:
+```bash
+python3 gptscan.py --temp --cli
 ```
 
 Scan all environment variables:

--- a/tests/test_temp_scan.py
+++ b/tests/test_temp_scan.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from gptscan import get_temp_paths, scan_temp_click, get_system_audit_data
+
+def test_get_temp_paths():
+    """Verify that get_temp_paths returns valid directories and includes the standard temp dir."""
+    paths = get_temp_paths()
+    assert isinstance(paths, list)
+    # tempfile.gettempdir() should always be in there if it exists
+    standard_temp = os.path.abspath(tempfile.gettempdir())
+    if os.path.isdir(standard_temp):
+        assert standard_temp in paths
+
+def test_system_audit_includes_temp():
+    """Verify that the system audit data includes temporary folder paths."""
+    all_paths, _ = get_system_audit_data()
+    temp_paths = get_temp_paths()
+    for p in temp_paths:
+        assert p in all_paths
+
+@patch('gptscan._set_scan_target')
+@patch('gptscan.button_click')
+def test_scan_temp_click(mock_button_click, mock_set_target):
+    """Verify that scan_temp_click sets the target and triggers a scan."""
+    scan_temp_click()
+    mock_set_target.assert_called_once()
+    mock_button_click.assert_called_once()
+
+    # Check that the paths passed to _set_scan_target are what we expect
+    args, _ = mock_set_target.call_args
+    assert args[0] == get_temp_paths()


### PR DESCRIPTION
### [FEAT] Add Scan Temporary Folders feature

**What:**
Implemented a new system scan feature that targets common temporary directories where malware often hides.
- Core: Added `get_temp_paths()` to discover platform-specific temp folders.
- GUI: Added "Scan Temporary Folders" to the System Scans menu with shortcut `Ctrl+Shift+Z`.
- CLI: Added `--temp` flag.
- Audit: Integrated temp folder scanning into the full System Audit (`--audit`).
- UX: Updated the "Browse" button tooltip to include recently added shortcut keys (R, W, J, Z).
- Docs: Updated `readme.md` with GUI, CLI, and keyboard shortcut information.
- Tests: Added `tests/test_temp_scan.py` and verified with the full suite.

**Why:**
Temporary folders are frequently used by malicious scripts for persistence or execution staging. Providing a one-click/one-flag method to scan these areas increases the utility and convenience of the scanner for security-conscious users.

---
*PR created automatically by Jules for task [10488105570186863973](https://jules.google.com/task/10488105570186863973) started by @RainRat*