### PR TITLE
Improve hashing accuracy for virtual files and fix brittle tests

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2103,6 +2103,8 @@ def get_file_sha256(file_path_or_data: Union[str, Path, bytes]) -> str:
 def get_effective_sha256(path: str, snippet: Optional[str] = None) -> str:
     """Calculate the effective SHA256 hash, falling back to hashing the snippet for virtual paths."""
     if path.startswith("[") or not os.path.exists(path):
+        if path in _virtual_source_cache:
+            return get_file_sha256(_virtual_source_cache[path].encode('utf-8'))
         if snippet:
             return get_file_sha256(snippet.encode('utf-8'))
         return ""

--- a/tests/test_git_hooks_scanning.py
+++ b/tests/test_git_hooks_scanning.py
@@ -8,6 +8,8 @@ def test_get_git_hooks_paths(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo)
+    # Ensure local hooks are used despite global core.hooksPath=/dev/null
+    subprocess.run(["git", "config", "core.hooksPath", ""], cwd=repo)
     hooks = repo / ".git" / "hooks"
 
     pre_commit = hooks / "pre-commit"
@@ -25,6 +27,8 @@ def test_cli_git_hooks(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo)
+    # Ensure local hooks are used despite global core.hooksPath=/dev/null
+    subprocess.run(["git", "config", "core.hooksPath", ""], cwd=repo)
     hooks = repo / ".git" / "hooks"
 
     pre_commit = hooks / "pre-commit"


### PR DESCRIPTION
This PR addresses a logic gap in file hashing and improves test suite reliability.

- **Hashing Improvement**: The `get_effective_sha256` function now checks `_virtual_source_cache` for full file content before falling back to a 1024-byte snippet. This ensures that VirusTotal links and SHA256 copies for virtual files (like those inside archives or fetched from URLs) are based on the complete file rather than a partial window.
- **Test Fix**: `tests/test_git_hooks_scanning.py` has been updated to locally override any global `core.hooksPath` setting (e.g., `/dev/null`). This prevents legitimate local hooks from being ignored during testing, fixing an issue where tests would fail in specific environments.

All 834 tests passed successfully after these changes.

---
*PR created automatically by Jules for task [17896104103348752073](https://jules.google.com/task/17896104103348752073) started by @RainRat*