### PR TITLE
[TEST] Add coverage for SHA256 hashing and fix cache priority logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2101,8 +2101,11 @@ def get_file_sha256(file_path_or_data: Union[str, Path, bytes]) -> str:
 
 
 def get_effective_sha256(path: str, snippet: Optional[str] = None) -> str:
-    """Calculate the effective SHA256 hash, falling back to hashing the snippet for virtual paths."""
+    """Calculate the effective SHA256 hash, prioritizing full content cache for virtual paths."""
     if path.startswith("[") or not os.path.exists(path):
+        # Prioritize full content from cache if available
+        if path in _virtual_source_cache:
+            return get_file_sha256(_virtual_source_cache[path].encode('utf-8'))
         if snippet:
             return get_file_sha256(snippet.encode('utf-8'))
         return ""

--- a/tests/test_effective_sha256.py
+++ b/tests/test_effective_sha256.py
@@ -1,0 +1,51 @@
+import hashlib
+from pathlib import Path
+import pytest
+import gptscan
+
+def test_get_effective_sha256_local_file(tmp_path):
+    f = tmp_path / "test.txt"
+    content = b"local content"
+    f.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert gptscan.get_effective_sha256(str(f)) == expected
+
+def test_get_effective_sha256_virtual_snippet():
+    snippet = "snippet content"
+    expected = hashlib.sha256(snippet.encode()).hexdigest()
+    # Virtual path starting with [
+    assert gptscan.get_effective_sha256("[Clipboard]", snippet=snippet) == expected
+
+def test_get_effective_sha256_missing_file_snippet():
+    snippet = "snippet for missing file"
+    expected = hashlib.sha256(snippet.encode()).hexdigest()
+    assert gptscan.get_effective_sha256("missing.py", snippet=snippet) == expected
+
+def test_get_effective_sha256_virtual_cache_priority(monkeypatch):
+    path = "[URL] https://example.com/script.py"
+    snippet = "snippet content"
+    full_content = "full content from cache"
+
+    # Populating cache
+    monkeypatch.setattr(gptscan, "_virtual_source_cache", {path: full_content})
+
+    expected_full = hashlib.sha256(full_content.encode()).hexdigest()
+
+    # This is expected to FAIL before the fix
+    assert gptscan.get_effective_sha256(path, snippet=snippet) == expected_full
+
+def test_get_effective_sha256_none_snippet():
+    assert gptscan.get_effective_sha256("[Clipboard]", snippet=None) == ""
+    assert gptscan.get_effective_sha256("missing.py", snippet=None) == ""
+
+def test_get_file_sha256_bytes():
+    content = b"raw bytes"
+    expected = hashlib.sha256(content).hexdigest()
+    assert gptscan.get_file_sha256(content) == expected
+
+def test_get_file_sha256_path_object(tmp_path):
+    f = tmp_path / "path_obj.txt"
+    content = b"path object test"
+    f.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert gptscan.get_file_sha256(f) == expected


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** Implemented unit tests for `get_effective_sha256` and `get_file_sha256` in a new test module `tests/test_effective_sha256.py`. Fixed a logic bug in `get_effective_sha256` where virtual paths would prioritize hashing the snippet even if full content was available in the `_virtual_source_cache`.
* **Why:** To ensure accurate and consistent file hashing for threat intelligence (VirusTotal) and SHA256 copy actions, especially for virtual targets like archive members or remote URLs where the full content is cached during scanning.

---
*PR created automatically by Jules for task [4558662248240603182](https://jules.google.com/task/4558662248240603182) started by @RainRat*