### PR TITLE
[UI/UX] Add keyboard shortcut for Scan Folder action

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6982,7 +6982,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/U/V/D/G/I/B/H/P/K/N/T/A/S/Y/M/X).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/F/U/V/D/G/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -6994,7 +6994,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")
-    browse_menu.add_command(label="Scan Folder...", command=browse_dir_click)
+    browse_menu.add_command(label="Scan Folder...", command=browse_dir_click, accelerator="Ctrl+Shift+F")
     browse_menu.add_command(label="Scan URL...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
 
@@ -7384,6 +7384,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-o>', import_results)
     root.bind('<Control-Shift-O>', lambda event: browse_file_click())
     root.bind('<Command-Shift-O>', lambda event: browse_file_click())
+    root.bind('<Control-Shift-F>', lambda event: browse_dir_click())
+    root.bind('<Command-Shift-F>', lambda event: browse_dir_click())
     root.bind('<Control-Shift-U>', lambda event: select_url_click())
     root.bind('<Command-Shift-U>', lambda event: select_url_click())
     root.bind('<Control-Shift-V>', lambda event: scan_clipboard_click())

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Run `python3 gptscan.py` to open the scanner window.
 Access these options from the **Browse** menu:
 #### Common Scans
 *   **Scan File(s)... (Ctrl+Shift+O):** Select specific files to scan.
-*   **Scan Folder...:** Select an entire folder to scan.
+*   **Scan Folder... (Ctrl+Shift+F):** Select an entire folder to scan.
 *   **Scan Recently Modified...:** Scan files changed within a certain time (like the last 24 hours).
 *   **Scan URL... (Ctrl+Shift+U):** Scan code or archives directly from a web link.
 *   **Scan File List...:** Scan a list of files from a text file.
@@ -101,6 +101,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+E` | Copy as Command Line |
 | **Scan Actions** | |
 | `Ctrl+Shift+O` | Scan File(s) |
+| `Ctrl+Shift+F` | Scan Folder |
 | `Ctrl+Shift+U` | Scan URL |
 | `Ctrl+Shift+V` | Scan Clipboard |
 | `Ctrl+Shift+D` | Scan Git Diff |


### PR DESCRIPTION
**PR Title:** [UI/UX] Add keyboard shortcut for Scan Folder action

**Description:**
* **Context:** GUI
* **Problem:** The "Scan Folder" action in the GUI lacked a keyboard shortcut, creating a friction point for users who prefer keyboard-driven workflows, especially since other scan actions (like "Scan File(s)" and "Scan URL") already had shortcuts. Additionally, the Browse button tooltip was missing the `F` shortcut.
* **Solution:** 
    - Added `accelerator="Ctrl+Shift+F"` to the "Scan Folder..." menu item in `gptscan.py`.
    - Added application-level key bindings for `<Control-Shift-F>` (Windows/Linux) and `<Command-Shift-F>` (macOS) to trigger the `browse_dir_click` function.
    - Updated the `browse_button` tooltip to include `F` and exhaustively list all 21 available scan shortcuts: `(Ctrl+Shift+O/F/U/V/D/G/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J)`.
    - Updated `readme.md` to document the new shortcut in both the "Common Scans" section and the "Keyboard Shortcuts" table.

---
*PR created automatically by Jules for task [11316163013710826983](https://jules.google.com/task/11316163013710826983) started by @RainRat*