### PR TITLE
Improve SHA256 hashing for virtual files by using content cache

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2101,8 +2101,11 @@ def get_file_sha256(file_path_or_data: Union[str, Path, bytes]) -> str:
 
 
 def get_effective_sha256(path: str, snippet: Optional[str] = None) -> str:
-    """Calculate the effective SHA256 hash, falling back to hashing the snippet for virtual paths."""
+    """Calculate the effective SHA256 hash, prioritizing full content from cache for virtual/missing paths."""
     if path.startswith("[") or not os.path.exists(path):
+        # Prioritize full content from cache if available
+        if path in _virtual_source_cache:
+            return get_file_sha256(_virtual_source_cache[path].encode('utf-8'))
         if snippet:
             return get_file_sha256(snippet.encode('utf-8'))
         return ""

--- a/tests/test_threat_intel.py
+++ b/tests/test_threat_intel.py
@@ -110,17 +110,32 @@ def test_check_virustotal_virtual_path(mock_tree):
     expected_url = f"https://www.virustotal.com/gui/file/{expected_hash}"
     mock_open.assert_called_once_with(expected_url)
 
+def test_get_effective_sha256_uses_cache():
+    """Test that get_effective_sha256 prioritizes the virtual source cache."""
+    path = "test.zip[script.py]"
+    full_content = "print('full content')"
+    snippet = "print('snippet')"
+
+    expected_hash = hashlib.sha256(full_content.encode('utf-8')).hexdigest()
+
+    with patch.dict(gptscan._virtual_source_cache, {path: full_content}):
+        h = gptscan.get_effective_sha256(path, snippet)
+        assert h == expected_hash
+
 def test_copy_sha256_archive_member(mock_tree):
-    """Test that copy_sha256 hashes the snippet for archive members."""
+    """Test that copy_sha256 hashes the full content from cache for archive members."""
+    path = "test.zip[malicious.py]"
+    full_content = "print('malicious full')"
     snippet = "print('archive')"
-    expected_hash = hashlib.sha256(snippet.encode('utf-8')).hexdigest()
+    expected_hash = hashlib.sha256(full_content.encode('utf-8')).hexdigest()
 
     mock_tree.selection.return_value = ["item1"]
-    path = "test.zip[malicious.py]"
     raw_values = [path, "50%", "", "", "", snippet]
     mock_tree._item_values["item1"] = (path, "50%", "", "", "", snippet, json.dumps(raw_values))
 
-    with patch('gptscan.update_status'), patch('os.path.exists', return_value=False):
+    with patch('gptscan.update_status'), \
+         patch('os.path.exists', return_value=False), \
+         patch.dict(gptscan._virtual_source_cache, {path: full_content}):
         gptscan.copy_sha256()
 
     mock_tree.clipboard_append.assert_called_with(expected_hash)


### PR DESCRIPTION
* **What:** Updated `get_effective_sha256` in `gptscan.py` to prioritize the `_virtual_source_cache` when calculating hashes for virtual or missing paths. Previously, it would fall back directly to hashing a small code snippet.
* **Why:** This ensures that files extracted from archives or fetched from URLs have accurate SHA256 hashes based on their full content rather than just a 1024-byte snippet. This is critical for reliable VirusTotal lookups and threat intelligence. No breaking changes were introduced as the snippet fallback remains for uncached virtual paths.

---
*PR created automatically by Jules for task [10890747022438138145](https://jules.google.com/task/10890747022438138145) started by @RainRat*