### PR TITLE
[TEST] Expand shell profile discovery and improve robustness

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1111,6 +1111,23 @@ def get_shell_profile_paths() -> List[str]:
         if p.exists():
             paths.append(str(p))
 
+    # System-wide POSIX profiles
+    if sys.platform != "win32":
+        system_files = ['/etc/profile', '/etc/bash.bashrc', '/etc/environment']
+        for f in system_files:
+            p = Path(f)
+            if p.exists():
+                paths.append(str(p))
+
+        # profile.d scripts
+        profile_d = Path("/etc/profile.d")
+        if profile_d.exists() and profile_d.is_dir():
+            try:
+                for p in profile_d.glob("*.sh"):
+                    paths.append(str(p))
+            except Exception:
+                pass
+
     # Windows PowerShell Profiles
     if sys.platform == "win32":
         try:
@@ -1119,10 +1136,14 @@ def get_shell_profile_paths() -> List[str]:
             output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, universal_newlines=True)
             if output.strip():
                 data = json.loads(output)
+                profile_list = []
                 if isinstance(data, str):
-                    data = [data]
-                for p_str in data:
-                    if p_str and os.path.exists(p_str):
+                    profile_list = [data]
+                elif isinstance(data, list):
+                    profile_list = data
+
+                for p_str in profile_list:
+                    if p_str and isinstance(p_str, str) and os.path.exists(p_str):
                         paths.append(p_str)
         except Exception:
             pass

--- a/tests/test_shell_profile_expansion.py
+++ b/tests/test_shell_profile_expansion.py
@@ -1,0 +1,97 @@
+import pytest
+import sys
+import os
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import gptscan
+
+def test_get_shell_profile_paths_system_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    def mock_exists(self):
+        valid = [
+            "/etc/profile",
+            "/etc/bash.bashrc",
+            "/etc/environment",
+            "/home/user/.bashrc"
+        ]
+        return str(self) in valid
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(Path, "is_dir", lambda self: False)
+
+    paths = gptscan.get_shell_profile_paths()
+
+    assert "/etc/profile" in paths
+    assert "/etc/bash.bashrc" in paths
+    assert "/etc/environment" in paths
+    assert "/home/user/.bashrc" in paths
+
+def test_get_shell_profile_paths_profile_d(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    def mock_exists(self):
+        return str(self) == "/etc/profile.d"
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(Path, "is_dir", lambda self: str(self) == "/etc/profile.d")
+
+    mock_sh = Path("/etc/profile.d/test.sh")
+    monkeypatch.setattr(Path, "glob", lambda self, pattern: [mock_sh] if pattern == "*.sh" else [])
+
+    paths = gptscan.get_shell_profile_paths()
+
+    assert "/etc/profile.d/test.sh" in paths
+
+def test_get_shell_profile_paths_windows_robustness_list(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(Path, "home", lambda: Path("C:/Users/user"))
+
+    mock_output = json.dumps(["C:\\path1.ps1", "C:\\path2.ps1"])
+
+    with patch("subprocess.check_output", return_value=mock_output), \
+         patch("os.path.exists", return_value=True):
+        paths = gptscan.get_shell_profile_paths()
+        assert "C:\\path1.ps1" in paths
+        assert "C:\\path2.ps1" in paths
+
+def test_get_shell_profile_paths_windows_robustness_single(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(Path, "home", lambda: Path("C:/Users/user"))
+
+    mock_output = json.dumps("C:\\path1.ps1")
+
+    with patch("subprocess.check_output", return_value=mock_output), \
+         patch("os.path.exists", return_value=True):
+        paths = gptscan.get_shell_profile_paths()
+        assert "C:\\path1.ps1" in paths
+
+def test_get_shell_profile_paths_windows_robustness_null(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(Path, "home", lambda: Path("C:/Users/user"))
+
+    mock_output = "null"
+
+    with patch("subprocess.check_output", return_value=mock_output):
+        paths = gptscan.get_shell_profile_paths()
+        # Should not crash and just return user profiles (if any)
+        assert isinstance(paths, list)
+
+def test_get_shell_profile_paths_windows_robustness_invalid_type(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(Path, "home", lambda: Path("C:/Users/user"))
+
+    # PowerShell could theoretically return an object if ConvertTo-Json is used on a single object
+    mock_output = json.dumps({"AllUsersAllHosts": "C:\\path1.ps1"})
+
+    with patch("subprocess.check_output", return_value=mock_output):
+        paths = gptscan.get_shell_profile_paths()
+        # Should not crash
+        assert isinstance(paths, list)

--- a/tests/test_shell_profiles.py
+++ b/tests/test_shell_profiles.py
@@ -16,7 +16,6 @@ def test_get_shell_profile_paths_linux(tmp_path):
         paths = gptscan.get_shell_profile_paths()
         assert str(bashrc) in paths
         assert str(profile) in paths
-        assert len(paths) == 2
 
 @patch("sys.platform", "win32")
 @patch("subprocess.check_output")


### PR DESCRIPTION
Expanded `get_shell_profile_paths` in `gptscan.py` to include system-wide POSIX profiles (`/etc/profile`, `/etc/bash.bashrc`, `/etc/environment`) and `/etc/profile.d/*.sh` scripts. This ensures that the system audit scan covers potentially dangerous configurations outside of the user's home directory. Additionally, improved the robustness of Windows PowerShell profile discovery by refactoring the JSON parsing logic to safely handle `null`, single `string`, or `list` outputs, preventing potential iteration errors. Verified the improvements with a new test suite (`tests/test_shell_profile_expansion.py`) and updated existing tests to ensure overall stability.

---
*PR created automatically by Jules for task [10861779132056021062](https://jules.google.com/task/10861779132056021062) started by @RainRat*