### PR TITLE
[FEAT] Git Stash Scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1456,6 +1456,47 @@ def get_environment_variable_snippets() -> List[Tuple[str, bytes]]:
     return snippets
 
 
+def get_git_stash_snippets(path: str = ".") -> List[Tuple[str, bytes]]:
+    """Collect the content of all Git stashes as snippets."""
+    snippets = []
+    toplevel, _ = _get_git_info(path)
+    if toplevel is None:
+        return []
+
+    try:
+        # Get list of stashes: stash@{0}: WIP on main: ...
+        output = subprocess.check_output(
+            ["git", "stash", "list"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+        lines = output.splitlines()
+        for line in lines:
+            if not line.strip():
+                continue
+            # Extract stash name (e.g., stash@{0})
+            match = re.match(r'^(stash@\{\d+\}):', line)
+            if match:
+                stash_id = match.group(1)
+                # Get the full diff of the stash
+                try:
+                    diff = subprocess.check_output(
+                        ["git", "stash", "show", "-p", stash_id],
+                        cwd=toplevel,
+                        stderr=subprocess.PIPE,
+                        universal_newlines=True
+                    )
+                    if diff.strip():
+                        snippets.append((f"[{stash_id}] {line.strip()}", diff.encode('utf-8')))
+                except subprocess.CalledProcessError:
+                    continue
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    return snippets
+
+
 def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all scheduled tasks (Cron on Linux/macOS, schtasks on Windows)."""
     tasks = []
@@ -2520,6 +2561,23 @@ def scan_git_config_click():
         messagebox.showwarning("Git Configuration Error", f"Could not scan Git configuration: {e}")
 
 
+def scan_git_stash_click():
+    """Scan all Git stashes."""
+    try:
+        # Get path from textbox or default to current directory
+        target_path = textbox.get().strip() if textbox else "."
+        if not target_path:
+            target_path = "."
+
+        snippets = get_git_stash_snippets(target_path)
+        if snippets:
+            button_click(extra_snippets=snippets)
+        else:
+            messagebox.showinfo("Git Stash", "No Git stashes found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Git Stash Error", f"Could not scan Git stashes: {e}")
+
+
 def scan_git_revision_click():
     """Scan files changed in a specific Git revision."""
     try:
@@ -2776,6 +2834,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_snippets.extend(get_startup_item_commands())
     all_snippets.extend(get_system_service_commands())
     all_snippets.extend(get_git_config_snippets())
+    all_snippets.extend(get_git_stash_snippets())
 
     return all_paths, all_snippets
 
@@ -7006,7 +7065,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
 
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/F/U/V/D/G/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J/Z).")
+    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/F/U/V/D/G/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J/Z/Q).")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -7036,6 +7095,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     git_menu = tk.Menu(browse_menu, tearoff=0)
     git_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
     git_menu.add_command(label="Scan Git Hooks", command=scan_git_hooks_click, accelerator="Ctrl+Shift+G")
+    git_menu.add_command(label="Scan Git Stashes", command=scan_git_stash_click, accelerator="Ctrl+Shift+Q")
     git_menu.add_command(label="Scan Git Configuration", command=scan_git_config_click)
     git_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
     browse_menu.add_cascade(label="Git Integration", menu=git_menu)
@@ -7419,6 +7479,8 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     root.bind('<Command-Shift-D>', lambda event: scan_git_diff_click())
     root.bind('<Control-Shift-G>', lambda event: scan_git_hooks_click())
     root.bind('<Command-Shift-G>', lambda event: scan_git_hooks_click())
+    root.bind('<Control-Shift-Q>', lambda event: scan_git_stash_click())
+    root.bind('<Command-Shift-Q>', lambda event: scan_git_stash_click())
     root.bind('<Control-Shift-B>', lambda event: scan_shell_profiles_click())
     root.bind('<Command-Shift-B>', lambda event: scan_shell_profiles_click())
     root.bind('<Control-Shift-H>', lambda event: scan_shell_history_click())
@@ -7622,6 +7684,11 @@ def main():
         '--git-config',
         action='store_true',
         help='Scan for dangerous Git configuration settings.'
+    )
+    git_group.add_argument(
+        '--git-stash',
+        action='store_true',
+        help='Scan all Git stashes.'
     )
 
     system_group = parser.add_argument_group("System Scans")
@@ -7844,7 +7911,13 @@ def main():
         if args.git_config:
             extra_snippets.extend(get_git_config_snippets())
 
-        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not extra_snippets:
+        if args.git_stash:
+            # Use specified targets as git roots, or current directory if none.
+            git_roots = scan_targets if scan_targets else ["."]
+            for root_dir in git_roots:
+                extra_snippets.extend(get_git_stash_snippets(root_dir))
+
+        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not args.git_stash and not extra_snippets:
             # Default to current directory if no targets provided and NOT using git-changes
             scan_targets = ["."]
 

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ Access these options from the **Browse** menu:
 #### Git Integration
 *   **Scan Git Diff (Ctrl+Shift+D):** Scan your current project changes as a diff.
 *   **Scan Git Hooks (Ctrl+Shift+G):** Scan your local and global Git hooks for suspicious scripts.
+*   **Scan Git Stashes (Ctrl+Shift+Q):** Scan all Git stashes for suspicious code changes.
 *   **Scan Git Configuration:** Scan Git settings for dangerous aliases or editors.
 *   **Scan Git Revision...:** Scan files from a specific Git branch or commit.
 
@@ -107,6 +108,7 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+Shift+V` | Scan Clipboard |
 | `Ctrl+Shift+D` | Scan Git Diff |
 | `Ctrl+Shift+G` | Scan Git Hooks |
+| `Ctrl+Shift+Q` | Scan Git Stashes |
 | `Ctrl+Shift+B` | Scan Shell Profiles |
 | `Ctrl+Shift+I` | Scan System Audit |
 | `Ctrl+Shift+H` | Scan Shell History |
@@ -265,6 +267,11 @@ python3 gptscan.py --git-hooks --cli
 Scan potentially dangerous Git configuration settings:
 ```bash
 python3 gptscan.py --git-config --cli
+```
+
+Scan all Git stashes:
+```bash
+python3 gptscan.py --git-stash --cli
 ```
 
 #### Advanced Scans

--- a/tests/test_git_stash_scanning.py
+++ b/tests/test_git_stash_scanning.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+import pytest
+from pathlib import Path
+from gptscan import get_git_stash_snippets
+
+def test_get_git_stash_snippets(tmp_path):
+    # Initialize a git repo
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Your Name"], cwd=repo_dir, check=True)
+
+    # Create a file and commit it
+    test_file = repo_dir / "test.py"
+    test_file.write_text("print('hello')")
+    subprocess.run(["git", "add", "test.py"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=repo_dir, check=True)
+
+    # Modify the file and stash it
+    test_file.write_text("print('hello world')")
+    subprocess.run(["git", "stash"], cwd=repo_dir, check=True)
+
+    # Get snippets
+    snippets = get_git_stash_snippets(str(repo_dir))
+
+    assert len(snippets) >= 1
+    name, content = snippets[0]
+    assert "stash@{0}" in name
+    assert b"print('hello world')" in content
+
+def test_get_git_stash_snippets_no_stash(tmp_path):
+    # Initialize a git repo
+    repo_dir = tmp_path / "repo_no_stash"
+    repo_dir.mkdir()
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True)
+
+    # Get snippets
+    snippets = get_git_stash_snippets(str(repo_dir))
+    assert snippets == []
+
+def test_get_git_stash_snippets_non_git(tmp_path):
+    non_git_dir = tmp_path / "non_git"
+    non_git_dir.mkdir()
+
+    # Get snippets
+    snippets = get_git_stash_snippets(str(non_git_dir))
+    assert snippets == []


### PR DESCRIPTION
* **What:** Added functionality to scan all Git stashes for suspicious code. This includes a new helper `get_git_stash_snippets`, a GUI menu item "Scan Git Stashes" (shortcut `Ctrl+Shift+Q`), a CLI flag `--git-stash`, and integration into the "System Audit" feature.
* **Why:** I noticed that while the tool scans Git diffs, hooks, and configuration, it missed Git stashes—a common place where developers might temporarily store experimental or sensitive code. Adding stash scanning ensures a more comprehensive security audit for Git-based projects.

---
*PR created automatically by Jules for task [9210243599312017067](https://jules.google.com/task/9210243599312017067) started by @RainRat*