### PR TITLE
Optimize scan target categorization efficiency in `scan_files`

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4102,8 +4102,14 @@ def scan_files(
     # Identify which files were explicitly passed as targets and deduplicate them
     scan_targets = _normalize_targets(scan_targets)
 
-    url_targets = [str(t) for t in scan_targets if str(t).lower().startswith(('http://', 'https://'))]
-    local_targets = [t for t in scan_targets if str(t) not in url_targets]
+    url_targets = []
+    local_targets = []
+    for t in scan_targets:
+        t_str = str(t)
+        if t_str.lower().startswith(('http://', 'https://')):
+            url_targets.append(t_str)
+        else:
+            local_targets.append(t)
 
     explicit_targets = {Path(t) for t in local_targets}
     explicit_files = {f for f in explicit_targets if f.is_file()}


### PR DESCRIPTION
This change optimizes the `scan_files` function in `gptscan.py` by replacing two list comprehensions with a single loop for categorizing scan targets.

The original implementation performed an $O(M)$ lookup (`in url_targets`) for every element of `scan_targets`, leading to $O(N \cdot M)$ complexity. The refactored version achieves $O(N)$ complexity and includes a defensive `str()` conversion to ensure that `Path` objects are correctly handled before the URL check.

Performance and reliability are improved without altering external behavior. All existing tests pass.

---
*PR created automatically by Jules for task [5516603072638009404](https://jules.google.com/task/5516603072638009404) started by @RainRat*