### PR TITLE
[TEST] Expand shell profile discovery and improve test robustness

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1111,6 +1111,17 @@ def get_shell_profile_paths() -> List[str]:
         if p.exists():
             paths.append(str(p))
 
+    # System-wide POSIX profiles
+    if sys.platform != "win32":
+        for f in ['/etc/profile', '/etc/bash.bashrc', '/etc/environment']:
+            p = Path(f)
+            if p.exists():
+                paths.append(str(p))
+        profile_d = Path("/etc/profile.d")
+        if profile_d.exists() and profile_d.is_dir():
+            for p in profile_d.glob("*.sh"):
+                paths.append(str(p))
+
     # Windows PowerShell Profiles
     if sys.platform == "win32":
         try:

--- a/tests/test_shell_profile_expansion.py
+++ b/tests/test_shell_profile_expansion.py
@@ -1,0 +1,51 @@
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import gptscan
+
+def test_get_shell_profile_paths_posix_system_wide(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Mock Path.home()
+    home = Path("/home/user")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    # Files that exist
+    existing_files = {
+        str(home / ".bashrc"),
+        "/etc/profile",
+        "/etc/environment",
+        "/etc/profile.d/test.sh",
+        "/etc/profile.d/other.sh"
+    }
+
+    # Directories that exist
+    existing_dirs = {
+        "/etc/profile.d"
+    }
+
+    def mock_exists(self):
+        return str(self) in existing_files or str(self) in existing_dirs
+
+    def mock_is_dir(self):
+        return str(self) in existing_dirs
+
+    def mock_glob(self, pattern):
+        if str(self) == "/etc/profile.d" and pattern == "*.sh":
+            return [Path("/etc/profile.d/test.sh"), Path("/etc/profile.d/other.sh")]
+        return []
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+    monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+    monkeypatch.setattr(Path, "glob", mock_glob)
+
+    paths = gptscan.get_shell_profile_paths()
+
+    assert "/etc/profile" in paths
+    assert "/etc/environment" in paths
+    assert "/etc/profile.d/test.sh" in paths
+    assert "/etc/profile.d/other.sh" in paths
+    assert str(home / ".bashrc") in paths
+    # /etc/bash.bashrc was not in existing_files
+    assert "/etc/bash.bashrc" not in paths

--- a/tests/test_shell_profiles.py
+++ b/tests/test_shell_profiles.py
@@ -16,7 +16,9 @@ def test_get_shell_profile_paths_linux(tmp_path):
         paths = gptscan.get_shell_profile_paths()
         assert str(bashrc) in paths
         assert str(profile) in paths
-        assert len(paths) == 2
+        # We check for home-relative paths; system-wide paths may also be present on the actual test runner
+        home_paths = [p for p in paths if p.startswith(str(home))]
+        assert len(home_paths) == 2
 
 @patch("sys.platform", "win32")
 @patch("subprocess.check_output")


### PR DESCRIPTION
This PR addresses a gap in the shell profile scanning logic and improves the reliability of the associated test suite.

### Type:
New Coverage / Refactor

### What:
1.  **Discovery Logic Expansion:** The `get_shell_profile_paths` function now identifies system-wide profiles and scripts on POSIX systems in addition to user-level files.
2.  **New Tests:** Added `tests/test_shell_profile_expansion.py` which specifically mocks platform-specific filesystem states to verify that system-level files and globbed scripts in `/etc/profile.d/` are correctly collected.
3.  **Test Isolation:** Refactored `tests/test_shell_profiles.py` to verify home-directory profiles independently of any system-wide profiles that may exist on the test runner, preventing environment-induced assertion failures.

### Why:
System-wide shell profiles are critical persistence and configuration points for security auditing. Including them ensures the 'System Audit' feature provides more comprehensive coverage. The test refactorings ensure that the suite remains stable across different development and CI environments.

---
*PR created automatically by Jules for task [15066171885962470136](https://jules.google.com/task/15066171885962470136) started by @RainRat*