### PR TITLE
[DOCS] Standardize "temporary directories" to "temporary folders"

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1192,7 +1192,7 @@ def get_downloads_paths() -> List[str]:
 
 
 def get_temp_paths() -> List[str]:
-    """Identify common temporary directories."""
+    """Identify common temporary folders."""
     paths = [tempfile.gettempdir(), "/tmp", "/var/tmp"]
     return sorted(_normalize_and_filter_dirs(paths))
 
@@ -2741,7 +2741,7 @@ def scan_downloads_click():
 
 
 def scan_temp_click():
-    """Scan common temporary directories."""
+    """Scan common temporary folders."""
     try:
         paths = get_temp_paths()
         if paths:
@@ -7698,7 +7698,7 @@ def main():
     system_group.add_argument(
         '--temp',
         action='store_true',
-        help='Scan common temporary directories.'
+        help='Scan common temporary folders.'
     )
 
     ai_group = parser.add_argument_group("AI Analysis")

--- a/readme.md
+++ b/readme.md
@@ -241,7 +241,7 @@ Scan SSH configuration and authorized keys:
 python3 gptscan.py --ssh-config --cli
 ```
 
-Scan common temporary directories:
+Scan common temporary folders:
 ```bash
 python3 gptscan.py --temp --cli
 ```


### PR DESCRIPTION
This change standardizes the terminology for temporary path scanning by replacing technical jargon ("directories") with "folders" across internal docstrings, CLI help text, and the project documentation. 

This improvement:
- Follows "Plain English" guidelines for better accessibility.
- Ensures consistency with other features (like "Scan Folder") already using the simplified term.
- Passes all 850 functional tests.

---
*PR created automatically by Jules for task [16156756895525680488](https://jules.google.com/task/16156756895525680488) started by @RainRat*