### PR TITLE
Optimize target categorization in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4102,8 +4102,14 @@ def scan_files(
     # Identify which files were explicitly passed as targets and deduplicate them
     scan_targets = _normalize_targets(scan_targets)
 
-    url_targets = [str(t) for t in scan_targets if str(t).lower().startswith(('http://', 'https://'))]
-    local_targets = [t for t in scan_targets if str(t) not in url_targets]
+    url_targets = []
+    local_targets = []
+    for t in scan_targets:
+        t_str = str(t)
+        if t_str.lower().startswith(('http://', 'https://')):
+            url_targets.append(t_str)
+        else:
+            local_targets.append(t)
 
     explicit_targets = {Path(t) for t in local_targets}
     explicit_files = {f for f in explicit_targets if f.is_file()}


### PR DESCRIPTION
Optimized target categorization in `scan_files` by refactoring the logic to use a single $O(N)$ loop instead of multiple passes with $O(N^2)$ behavior. Added defensive `str()` conversion for robustness.

---
*PR created automatically by Jules for task [14700252112259978718](https://jules.google.com/task/14700252112259978718) started by @RainRat*