### PR TITLE
[DOCS] Standardize 'directory' to 'folder' terminology in gptscan.py

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2476,7 +2476,7 @@ def scan_clipboard_click():
 def scan_git_diff_click():
     """Scan current Git diff (staged and unstaged changes)."""
     try:
-        # Get path from textbox or default to current directory
+        # Get path from textbox or default to current folder
         target_path = textbox.get().strip() if textbox else "."
         if not target_path:
             target_path = "."
@@ -2493,7 +2493,7 @@ def scan_git_diff_click():
 def scan_git_hooks_click():
     """Scan local and global Git hooks."""
     try:
-        # Get path from textbox or default to current directory
+        # Get path from textbox or default to current folder
         target_path = textbox.get().strip() if textbox else "."
         if not target_path:
             target_path = "."
@@ -2741,7 +2741,7 @@ def scan_downloads_click():
 
 
 def scan_temp_click():
-    """Scan common temporary directories."""
+    """Scan common temporary folders."""
     try:
         paths = get_temp_paths()
         if paths:
@@ -7698,7 +7698,7 @@ def main():
     system_group.add_argument(
         '--temp',
         action='store_true',
-        help='Scan common temporary directories.'
+        help='Scan common temporary folders.'
     )
 
     ai_group = parser.add_argument_group("AI Analysis")
@@ -7810,7 +7810,7 @@ def main():
                     scan_targets.append(line)
 
         if args.git_changes:
-            # Use specified targets as git roots, or current directory if none.
+            # Use specified targets as git roots, or current folder if none.
             git_roots = scan_targets if scan_targets else ["."]
             git_files = []
             for root_dir in git_roots:
@@ -7823,7 +7823,7 @@ def main():
 
         extra_snippets = []
         if args.git_diff:
-            # Use specified targets as git roots, or current directory if none.
+            # Use specified targets as git roots, or current folder if none.
             git_roots = scan_targets if scan_targets else ["."]
             diff_count = 0
             for root_dir in git_roots:
@@ -7845,7 +7845,7 @@ def main():
             extra_snippets.extend(get_git_config_snippets())
 
         if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not extra_snippets:
-            # Default to current directory if no targets provided and NOT using git-changes
+            # Default to current folder if no targets provided and NOT using git-changes
             scan_targets = ["."]
 
         output_format = 'report' if sys.stdout.isatty() else 'csv'


### PR DESCRIPTION
This pull request standardizes the terminology used in `gptscan.py` by replacing the technical term "directory" with the more user-friendly term "folder". This change affects user-facing CLI help strings, docstrings, and internal code comments, improving clarity and accessibility in line with the Lead Technical Writer persona's guidelines. No functional logic or variable names were modified.

---
*PR created automatically by Jules for task [11306295890619511669](https://jules.google.com/task/11306295890619511669) started by @RainRat*