### PR TITLE
[FEAT] Comprehensive shell profile and alias scanning

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1095,7 +1095,7 @@ def motion_handler(tree: ttk.Treeview, event: Optional[tk.Event]) -> None:
 
 
 def get_shell_profile_paths() -> List[str]:
-    """Identify common shell profile and RC files on the current system."""
+    """Identify common shell profile and RC files, including system-wide profiles and aliases."""
     paths = []
     home = Path.home()
 
@@ -1103,13 +1103,29 @@ def get_shell_profile_paths() -> List[str]:
     common_files = [
         '.bashrc', '.bash_profile', '.bash_login', '.profile',
         '.zshrc', '.zprofile', '.zshenv', '.zlogin',
-        '.bash_logout', '.zlogout'
+        '.bash_logout', '.zlogout', '.bash_aliases', '.zsh_aliases'
     ]
 
     for f in common_files:
         p = home / f
         if p.exists():
             paths.append(str(p))
+
+    # System-wide POSIX profiles
+    if sys.platform != "win32":
+        system_files = [
+            '/etc/profile', '/etc/bash.bashrc', '/etc/environment'
+        ]
+        for f in system_files:
+            p = Path(f)
+            if p.exists():
+                paths.append(str(p))
+
+        # /etc/profile.d/*.sh scripts
+        profile_d = Path('/etc/profile.d')
+        if profile_d.exists() and profile_d.is_dir():
+            for script in profile_d.glob('*.sh'):
+                paths.append(str(script))
 
     # Windows PowerShell Profiles
     if sys.platform == "win32":
@@ -7633,7 +7649,7 @@ def main():
     system_group.add_argument(
         '--shell-profiles',
         action='store_true',
-        help='Scan common shell profile and RC files.'
+        help='Scan common shell profile and RC files, including system-wide profiles.'
     )
     system_group.add_argument(
         '--shell-history',

--- a/tests/test_shell_profiles.py
+++ b/tests/test_shell_profiles.py
@@ -14,9 +14,10 @@ def test_get_shell_profile_paths_linux(tmp_path):
 
     with patch("pathlib.Path.home", return_value=home):
         paths = gptscan.get_shell_profile_paths()
-        assert str(bashrc) in paths
-        assert str(profile) in paths
-        assert len(paths) == 2
+        home_paths = [p for p in paths if p.startswith(str(home))]
+        assert str(bashrc) in home_paths
+        assert str(profile) in home_paths
+        assert len(home_paths) == 2
 
 @patch("sys.platform", "win32")
 @patch("subprocess.check_output")


### PR DESCRIPTION
This PR enhances the shell profile scanning feature by including system-wide configuration files and common alias files.

### Changes
- **Core Logic:** `get_shell_profile_paths` now searches for system-wide POSIX profiles and `/etc/profile.d/` scripts.
- **User Files:** Added support for `.bash_aliases` and `.zsh_aliases` in the home directory.
- **Consistency:** Refactored system-wide path checks to use `pathlib.Path.exists()` for better consistency with the rest of the function.
- **Documentation:** Updated the function's docstring and the CLI `--shell-profiles` help text to reflect the expanded scope.
- **Testing:** Updated `tests/test_shell_profiles.py` to ensure tests remain isolated from real system files on the test runner.

### Why
Malicious scripts often hide in system-wide profiles or aliases to achieve persistence or intercept commands. Expanding the scanner's reach to these locations provides a more thorough system audit.

---
*PR created automatically by Jules for task [13421846043420276760](https://jules.google.com/task/13421846043420276760) started by @RainRat*