### PR TITLE
[Maintenance] Optimize target categorization in scan_files

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4102,8 +4102,15 @@ def scan_files(
     # Identify which files were explicitly passed as targets and deduplicate them
     scan_targets = _normalize_targets(scan_targets)
 
-    url_targets = [str(t) for t in scan_targets if str(t).lower().startswith(('http://', 'https://'))]
-    local_targets = [t for t in scan_targets if str(t) not in url_targets]
+    url_targets = []
+    local_targets = []
+    for t in scan_targets:
+        # Defensive str() conversion ensures robustness even if targets are not strings
+        t_str = str(t)
+        if t_str.lower().startswith(('http://', 'https://')):
+            url_targets.append(t_str)
+        else:
+            local_targets.append(t_str)
 
     explicit_targets = {Path(t) for t in local_targets}
     explicit_files = {f for f in explicit_targets if f.is_file()}


### PR DESCRIPTION
* **What:** Refactored the logic in `scan_files` that partitions `scan_targets` into `url_targets` and `local_targets`. The previous implementation used two list comprehensions, where the second one had $O(N^2)$ complexity due to a `not in` check. The new implementation uses a single $O(N)$ loop and removes redundant `str()` conversions.
* **Why:** This change improves the performance of the scanning initialization, especially when dealing with a large number of targets, while maintaining the same robustness and functionality. No breaking changes were introduced.

---
*PR created automatically by Jules for task [14204049303900130874](https://jules.google.com/task/14204049303900130874) started by @RainRat*