### PR TITLE
[TEST] Add unit tests for _get_initial_dir

### DIFF
--- a/tests/test_get_initial_dir.py
+++ b/tests/test_get_initial_dir.py
@@ -1,0 +1,93 @@
+import os
+import shlex
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+from gptscan import _get_initial_dir, Config
+
+@pytest.fixture
+def mock_textbox(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("gptscan.textbox", mock)
+    return mock
+
+def test_get_initial_dir_textbox_directory(mock_textbox, tmp_path):
+    d = tmp_path / "test_dir"
+    d.mkdir()
+    mock_textbox.get.return_value = str(d)
+
+    assert _get_initial_dir() == str(d.absolute())
+
+def test_get_initial_dir_textbox_file(mock_textbox, tmp_path):
+    d = tmp_path / "test_dir"
+    d.mkdir()
+    f = d / "test_file.txt"
+    f.write_text("hello")
+    mock_textbox.get.return_value = str(f)
+
+    # Should return the parent directory
+    assert _get_initial_dir() == str(d.absolute())
+
+def test_get_initial_dir_fallback_last_path(mock_textbox, tmp_path, monkeypatch):
+    mock_textbox.get.return_value = ""
+    d = tmp_path / "last_dir"
+    d.mkdir()
+    monkeypatch.setattr(Config, "last_path", str(d))
+
+    assert _get_initial_dir() == str(d.absolute())
+
+def test_get_initial_dir_fallback_last_path_file(mock_textbox, tmp_path, monkeypatch):
+    mock_textbox.get.return_value = ""
+    d = tmp_path / "last_dir"
+    d.mkdir()
+    f = d / "last_file.txt"
+    f.write_text("hello")
+    monkeypatch.setattr(Config, "last_path", str(f))
+
+    assert _get_initial_dir() == str(d.absolute())
+
+def test_get_initial_dir_empty(mock_textbox, monkeypatch):
+    mock_textbox.get.return_value = ""
+    monkeypatch.setattr(Config, "last_path", "")
+
+    assert _get_initial_dir() is None
+
+def test_get_initial_dir_multiple_paths(mock_textbox, tmp_path):
+    d1 = tmp_path / "dir1"
+    d1.mkdir()
+    d2 = tmp_path / "dir2"
+    d2.mkdir()
+
+    # Simulate multiple paths in the textbox
+    # Use shlex style quoting for paths with spaces if needed, but tmp_path usually doesn't have spaces.
+    # However, let's just use shlex.quote to be safe.
+    path1 = str(d1)
+    path2 = str(d2)
+    mock_textbox.get.return_value = f'{shlex.quote(path1)} {shlex.quote(path2)}'
+
+    assert _get_initial_dir() == str(d1.absolute())
+
+def test_get_initial_dir_url(mock_textbox):
+    mock_textbox.get.return_value = "https://example.com"
+    assert _get_initial_dir() is None
+
+def test_get_initial_dir_virtual_path(mock_textbox):
+    mock_textbox.get.return_value = "[Stdin]"
+    assert _get_initial_dir() is None
+
+def test_get_initial_dir_non_existent(mock_textbox, tmp_path):
+    mock_textbox.get.return_value = str(tmp_path / "ghost")
+    assert _get_initial_dir() is None
+
+def test_get_initial_dir_exception(mock_textbox, monkeypatch):
+    mock_textbox.get.return_value = "unclosed 'quote"
+    # shlex.split should raise an exception here, which _get_initial_dir catches
+    assert _get_initial_dir() is None
+
+def test_get_initial_dir_no_textbox(monkeypatch, tmp_path):
+    monkeypatch.setattr("gptscan.textbox", None)
+    d = tmp_path / "last_dir"
+    d.mkdir()
+    monkeypatch.setattr(Config, "last_path", str(d))
+
+    assert _get_initial_dir() == str(d.absolute())


### PR DESCRIPTION
This PR adds comprehensive unit test coverage for the `_get_initial_dir` function in `gptscan.py`. This function is responsible for determining the starting directory for folder and file selection dialogs in the GUI.

**Type:** New Coverage

**What:** Created `tests/test_get_initial_dir.py` containing 11 test cases covering:
- Directory path resolution from the UI textbox.
- File path resolution (returning the parent directory).
- Fallback to `Config.last_path` when the textbox is empty.
- Fallback for `Config.last_path` being a file.
- Handling of multiple paths in the textbox using `shlex` splitting.
- Correctly ignoring URLs and virtual paths (like `[Stdin]`).
- Handling of non-existent paths and parsing exceptions.

**Why:** `_get_initial_dir` was previously untested. Ensuring this function works correctly is vital for a smooth user experience when browsing for scan targets.

---
*PR created automatically by Jules for task [11047887096852257105](https://jules.google.com/task/11047887096852257105) started by @RainRat*