### PR TITLE
[Maintenance] Standardize file encoding in load_file

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -235,7 +235,7 @@ def load_file(filename: str, mode: str = 'single_line') -> Union[str, List[str]]
         The file content, or an empty result if the file is missing.
     """
     try:
-        with open(filename, 'r') as file:
+        with open(filename, 'r', encoding='utf-8', errors='replace') as file:
             if mode == 'single_line':
                 return file.readline().strip()
             elif mode == 'multi_line':


### PR DESCRIPTION
* **What:** Updated the `load_file` function in `gptscan.py` to use `encoding='utf-8'` and `errors='replace'` when opening files.
* **Why:** This ensures consistency with the saving functions and prevents `UnicodeDecodeError` crashes on systems where the default encoding is not UTF-8. The use of `errors='replace'` allows the scanner to continue operating even when encountering malformed characters in configuration or task files.

---
*PR created automatically by Jules for task [16860808042260006042](https://jules.google.com/task/16860808042260006042) started by @RainRat*