### PR TITLE
[UI/UX] Improve CLI triage report visual hierarchy and density

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4773,7 +4773,17 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
     BOLD = "\033[1m" if use_color else ""
     RESET = "\033[0m" if use_color else ""
 
-    lines = [f"{BOLD}--- GPT SCAN TRIAGE REPORT ---{RESET}", ""]
+    lines = [f"{BOLD}--- GPT SCAN - CONSOLE TRIAGE REPORT ---{RESET}", ""]
+
+    def color_conf(conf_str):
+        if not use_color:
+            return conf_str
+        val = parse_percent(conf_str)
+        if val >= 80:
+            return f"{RED}{BOLD}{conf_str}{RESET}"
+        if val >= 50:
+            return f"{YELLOW}{BOLD}{conf_str}{RESET}"
+        return f"{BOLD}{conf_str}{RESET}"
 
     for i, r in enumerate(results, 1):
         path = r.get("path", "unknown")
@@ -4797,36 +4807,37 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
         lines.append(f"{BOLD}[{i}] {risk_label} - {path}:{line_num}{RESET}")
 
         # Consolidate scores and links
-        meta_parts = [f"{BOLD}Local:{RESET} {GRAY}{own_conf}{RESET}"]
+        meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
         if gpt_conf:
-            meta_parts.append(f"{BOLD}AI:{RESET} {GRAY}{gpt_conf}{RESET}")
+            meta_parts.append(f"{GRAY}AI:{RESET} {color_conf(gpt_conf)}")
 
         vt_url = get_virustotal_url(path, snippet)
         if vt_url:
-            meta_parts.append(f"{BOLD}VT:{RESET} {GRAY}{vt_url}{RESET}")
+            meta_parts.append(f"{GRAY}VT:{RESET} {BOLD}{vt_url}{RESET}")
 
         online_url = get_online_url(path, line_num)
         if online_url:
-            meta_parts.append(f"{BOLD}Online:{RESET} {GRAY}{online_url}{RESET}")
+            meta_parts.append(f"{GRAY}Online:{RESET} {BOLD}{online_url}{RESET}")
 
-        lines.append(f"    {' | '.join(meta_parts)}")
+        lines.append(f"    {'  '.join(meta_parts)}")
 
         # Consolidate AI analysis
         if admin or user:
             analysis_parts = []
             if admin:
                 clean_admin = admin.strip().replace('\n', ' ')
-                analysis_parts.append(f"{BOLD}Admin:{RESET} {GRAY}{clean_admin}{RESET}")
+                analysis_parts.append(f"{GRAY}Admin:{RESET} {BOLD}{clean_admin}{RESET}")
             if user:
                 clean_user = user.strip().replace('\n', ' ')
-                analysis_parts.append(f"{BOLD}User:{RESET} {GRAY}{clean_user}{RESET}")
-            lines.append(f"    {' | '.join(analysis_parts)}")
+                analysis_parts.append(f"{GRAY}User:{RESET} {BOLD}{clean_user}{RESET}")
+            lines.append(f"    {'  '.join(analysis_parts)}")
 
-        # Snippet preview
-        clean_snippet = snippet.strip().split('\n')[0]
-        if len(clean_snippet) > 100:
-            clean_snippet = clean_snippet[:97] + "..."
-        lines.append(f"    > {GRAY}{clean_snippet}{RESET}")
+        # Snippet preview (up to 3 lines)
+        snippet_lines = snippet.strip().split('\n')[:3]
+        for sl in snippet_lines:
+            if len(sl) > 100:
+                sl = sl[:97] + "..."
+            lines.append(f"    {GRAY}> {sl}{RESET}")
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -130,9 +130,9 @@ def test_generate_console_report():
 
     # Without color
     report = gptscan.generate_console_report(results, use_color=False)
-    assert "--- GPT SCAN TRIAGE REPORT ---" in report
-    assert "Local: 90% | AI: 95% | VT: https://www.virustotal.com/gui/file/" in report
-    assert "Admin: Admin note | User: User note" in report
+    assert "--- GPT SCAN - CONSOLE TRIAGE REPORT ---" in report
+    assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
+    assert "Admin: Admin note  User: User note" in report
     assert "> dangerous_code()" in report
     assert "[2] LOW RISK - safe.py:1" in report
     assert "Local: 10%" in report
@@ -142,7 +142,7 @@ def test_generate_console_report():
     report_color = gptscan.generate_console_report(results, use_color=True)
     assert "\033[1;91mHIGH RISK\033[0m" in report_color
     assert "\033[0;90mLOW RISK\033[0m" in report_color
-    # Verify bold labels and gray values
-    assert "\033[1mLocal:\033[0m \033[0;90m90%\033[0m" in report_color
-    assert "\033[1mAI:\033[0m \033[0;90m95%\033[0m" in report_color
-    assert "\033[1mAdmin:\033[0m \033[0;90mAdmin note\033[0m" in report_color
+    # Verify dimmed labels and emphasized values
+    assert "\033[0;90mLocal:\033[0m \033[1;91m\033[1m90%\033[0m" in report_color
+    assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color
+    assert "\033[0;90mAdmin:\033[0m \033[1mAdmin note\033[0m" in report_color


### PR DESCRIPTION
This PR improves the visual hierarchy and information density of the CLI triage report.

### Problem
The previous CLI report emphasized labels (e.g., "Local:") over the actual values (e.g., "90%"), and used pipes ("|") which added visual noise. Code snippet previews were also limited to a single line, making it hard to understand the context of a detection without opening the file.

### Solution
- **Visual Hierarchy:** Labels are now dimmed (GRAY), while values are emphasized (BOLD).
- **Feedback & Clarity:** Confidence scores are color-coded based on risk level (Red for >=80%, Yellow for >=50%).
- **Friction Reduction:** Snippet previews now show up to 3 lines of code, allowing for faster triage directly from the terminal.
- **Consistency:** The header was updated to "--- GPT SCAN - CONSOLE TRIAGE REPORT ---" to match project standards.

### Testing
- Updated `tests/test_reporting_features.py` to verify the new format and color codes.
- Ran full test suite (850 tests passed).

---
*PR created automatically by Jules for task [10980930870340023897](https://jules.google.com/task/10980930870340023897) started by @RainRat*