### PR TITLE
[Logic Bug] Correctly handle all iterable types in _set_scan_target

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -744,7 +744,7 @@ def _set_scan_target(path: Union[str, Iterable[str]]) -> None:
         return
 
     # Handle multiple paths or a single path string
-    if isinstance(path, (list, tuple)):
+    if not isinstance(path, str) and isinstance(path, Iterable):
         # Join multiple targets with appropriate quoting, ensuring all are strings
         formatted_path = " ".join(_quote_for_ui(str(p)) for p in path)
     else:


### PR DESCRIPTION
PR Title: [Logic Bug] Correctly handle all iterable types in _set_scan_target

Description:
* What: Updated the `isinstance` check in `_set_scan_target` from `isinstance(path, (list, tuple))` to `not isinstance(path, str) and isinstance(path, Iterable)`.
* Why: This fixes a logic bug where iterable types other than list or tuple (such as sets or generators) were being stringified as a single object representation (e.g., "{'path1'}") instead of being processed as multiple space-separated targets. This ensures consistent behavior across all scan target input methods in the GUI.

---
*PR created automatically by Jules for task [16129536110182196217](https://jules.google.com/task/16129536110182196217) started by @RainRat*