### PR TITLE
[UI/UX] Refine Visual Hierarchy in CLI Triage Report

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4976,7 +4976,7 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             return f"{RED}{BOLD}{conf_str}{RESET}"
         if val >= 50:
             return f"{YELLOW}{BOLD}{conf_str}{RESET}"
-        return f"{BOLD}{conf_str}{RESET}"
+        return f"{conf_str}"
 
     for i, r in enumerate(results, 1):
         path = r.get("path", "unknown")
@@ -4998,7 +4998,7 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
         location = f"{path}:{line_num}" if line_num != "-" else path
-        lines.append(f"{BOLD}[{i}] {risk_label} - {location}{RESET}")
+        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")
 
         # Consolidate scores and links
         meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
@@ -5007,11 +5007,11 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
 
         vt_url = get_virustotal_url(path, snippet)
         if vt_url:
-            meta_parts.append(f"{GRAY}VT:{RESET} {BOLD}{vt_url}{RESET}")
+            meta_parts.append(f"{GRAY}VT:{RESET} {vt_url}")
 
         online_url = get_online_url(path, line_num)
         if online_url:
-            meta_parts.append(f"{GRAY}Online:{RESET} {BOLD}{online_url}{RESET}")
+            meta_parts.append(f"{GRAY}Online:{RESET} {online_url}")
 
         lines.append(f"    {'  '.join(meta_parts)}")
 
@@ -5020,10 +5020,10 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             analysis_parts = []
             if admin:
                 clean_admin = admin.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}Admin:{RESET} {BOLD}{clean_admin}{RESET}")
+                analysis_parts.append(f"{GRAY}Admin:{RESET} {clean_admin}")
             if user:
                 clean_user = user.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}User:{RESET} {BOLD}{clean_user}{RESET}")
+                analysis_parts.append(f"{GRAY}User:{RESET} {clean_user}")
             lines.append(f"    {'  '.join(analysis_parts)}")
 
         # Snippet preview (up to 3 lines)
@@ -5031,7 +5031,7 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
         for sl in snippet_lines:
             if len(sl) > 100:
                 sl = sl[:97] + "..."
-            lines.append(f"    {GRAY}> {BOLD}{sl}{RESET}")
+            lines.append(f"    {GRAY}> {sl}{RESET}")
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -142,9 +142,11 @@ def test_generate_console_report():
     report_color = gptscan.generate_console_report(results, use_color=True)
     assert "\033[1;91mHIGH RISK\033[0m" in report_color
     assert "\033[0;90mLOW RISK\033[0m" in report_color
-    # Verify dimmed labels and emphasized values
+    # Verify dimmed index
+    assert "\033[0;90m[1]\033[0m" in report_color
+    # Verify dimmed labels and emphasized values (scores >= 50%)
     assert "\033[0;90mLocal:\033[0m \033[1;91m\033[1m90%\033[0m" in report_color
     assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color
-    assert "\033[0;90mAdmin:\033[0m \033[1mAdmin note\033[0m" in report_color
-    # Verify emphasized snippet
-    assert "\033[0;90m> \033[1mdangerous_code()\033[0m" in report_color
+    # Verify AI notes and snippets are NOT bolded
+    assert "\033[0;90mAdmin:\033[0m Admin note" in report_color
+    assert "\033[0;90m> dangerous_code()\033[0m" in report_color


### PR DESCRIPTION
### Context
CLI

### Problem
The CLI triage report used excessive bolding for almost all output elements (indices, URLs, AI notes, snippets, and all threat scores). This created visual clutter and made it difficult for users to quickly identify the most critical information (High Risk findings and their locations).

### Solution
Improved visual hierarchy by:
1. De-emphasizing the finding index `[{i}]` using gray color and removing bold.
2. Restricting bolding for threat scores to only those at or above 50%, keeping low-threat scores in normal weight.
3. Removing bolding from metadata links (VirusTotal, Online view), AI analysis notes (Admin/User), and code snippet previews.

This ensures that "HIGH RISK" labels and significant threat levels remain the primary focal points while keeping secondary metadata readable but unobtrusive.

### Changes
Modified `generate_console_report` and its helper `color_conf` in `gptscan.py`. Updated `tests/test_reporting_features.py` to match the new format.

---
*PR created automatically by Jules for task [7835652276902175148](https://jules.google.com/task/7835652276902175148) started by @RainRat*