### PR TITLE
[Maintenance] Optimize result standardization lookup logic

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5519,10 +5519,14 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
     if not isinstance(item, dict):
         return {k: "" for k in REPORT_FIELD_MAPPING}
 
-    res = {
-        key: next((str(item[alt]) for alt in alts if item.get(alt) not in (None, "")), "")
-        for key, alts in REPORT_FIELD_MAPPING.items()
-    }
+    res = {}
+    for key, alts in REPORT_FIELD_MAPPING.items():
+        found_val = ""
+        for alt in alts:
+            if (val := item.get(alt)) not in (None, ""):
+                found_val = str(val)
+                break
+        res[key] = found_val
     # Fallback: if own_conf is empty but gpt_conf has a value, they might be using a report
     # where both mapped to 'Threat Level' (like in Markdown) or 'Confidence'.
     if not res.get('own_conf') and res.get('gpt_conf'):


### PR DESCRIPTION
Refactored the `standardize_result_dict` function in `gptscan.py` to replace a dictionary comprehension containing a nested generator expression with an explicit loop using the walrus operator.

Benefit:
- Improved performance by eliminating redundant dictionary lookups (reducing 2 lookups per key to 1).
- Enhanced code readability.
- Zero breaking changes; functional behavior remains identical.

Verification:
- Created and ran a targeted verification script covering multiple edge cases (aliases, empty strings, fallback logic).
- Ran the full test suite (878 tests) using `pytest`. All tests passed.

---
*PR created automatically by Jules for task [2773760975910356216](https://jules.google.com/task/2773760975910356216) started by @RainRat*