### PR TITLE
[Fix] [CLI] Resolve early exit bug when --clear-cache is used with specific scan targets

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -7978,9 +7978,11 @@ def main():
         if not any([
             args.target, args.path, args.stdin, args.import_results, args.files,
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
-            args.shell_profiles, args.shell_history, args.system_path,
+            args.git_stash, args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
-            args.system_services, args.audit, args.modified
+            args.system_services, args.audit, args.modified, args.downloads, args.desktop,
+            args.python_packages, args.nodejs_packages, args.browser_extensions,
+            args.editor_extensions, args.ssh_config, args.temp
         ]):
             sys.exit(0)
 


### PR DESCRIPTION
**PR Title:** [Fix] [CLI] Resolve early exit bug when --clear-cache is used with specific scan targets

**Description:**
* **What:** Updated the `any()` check in the `main()` function of `gptscan.py` to include several scan target flags that were previously missing: `--git-stash`, `--downloads`, `--desktop`, `--python-packages`, `--nodejs-packages`, `--browser-extensions`, `--editor-extensions`, `--ssh-config`, and `--temp`.
* **Why:** Previously, using `--clear-cache` alongside these specific flags would cause the program to exit early after clearing the cache, without performing the requested scan. This change ensures that the scan proceeds correctly for all valid targets after the cache is cleared. No breaking changes were introduced, and all 878 tests passed.

---
*PR created automatically by Jules for task [1385187488226212916](https://jules.google.com/task/1385187488226212916) started by @RainRat*