### PR TITLE
[TEST] Improve YAML script extraction and coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3898,7 +3898,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         try:
             text = content.decode('utf-8', errors='ignore')
             snippets = []
-            script_keys = ['run', 'script', 'command', 'before_script', 'after_script', 'entrypoint', 'commands', 'entry', 'bash', 'powershell', 'pwsh', 'cmd']
+            script_keys = ['run', 'script', 'command', 'before_script', 'after_script', 'entrypoint', 'commands', 'entry', 'bash', 'powershell', 'pwsh', 'cmd', 'runcmd', 'bootcmd', 'args', 'setup', 'install', 'test']
             # Match keys, optionally prefixed by a dash (common in YAML lists)
             key_pattern = r'^\s*(?:-\s*)?(?:' + '|'.join(script_keys) + r'):\s*(.*)'
             lines = text.splitlines()
@@ -3937,7 +3937,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                 j += 1
                                 continue
                             curr_indent = len(lines[j]) - len(lines[j].lstrip())
-                            if curr_indent <= indent:
+                            if curr_indent < indent:
                                 break
                             list_match = re.match(r'^\s*-\s*(.*)', lines[j])
                             if list_match:

--- a/tests/test_yaml_improvements.py
+++ b/tests/test_yaml_improvements.py
@@ -1,0 +1,75 @@
+import pytest
+from gptscan import unpack_content
+
+def test_yaml_extraction_new_keys():
+    """Verify that newly added script keys like 'runcmd', 'bootcmd', 'args', etc. are correctly extracted."""
+    yaml_content = b"""
+cloud-init:
+  runcmd:
+    - echo "cloud-init runcmd"
+  bootcmd:
+    - echo "cloud-init bootcmd"
+
+build:
+  setup:
+    - apt-get update
+  install:
+    - pip install .
+  test:
+    - pytest
+
+meta:
+  args:
+    - --payload
+    - rm -rf /
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    contents = {r[0]: r[1].decode('utf-8') for r in results}
+
+    assert "test.yml [Script 1]" in contents
+    assert 'echo "cloud-init runcmd"' in contents["test.yml [Script 1]"]
+
+    assert "test.yml [Script 2]" in contents
+    assert 'echo "cloud-init bootcmd"' in contents["test.yml [Script 2]"]
+
+    assert "test.yml [Script 3]" in contents
+    assert "apt-get update" in contents["test.yml [Script 3]"]
+
+    assert "test.yml [Script 4]" in contents
+    assert "pip install ." in contents["test.yml [Script 4]"]
+
+    assert "test.yml [Script 5]" in contents
+    assert "pytest" in contents["test.yml [Script 5]"]
+
+    assert "test.yml [Script 6]" in contents
+    assert "--payload\nrm -rf /" in contents["test.yml [Script 6]"]
+
+def test_yaml_list_same_indentation():
+    """Verify that YAML lists at the same indentation level as their key are correctly handled."""
+    # This is common in some YAML variants/parsers
+    yaml_content = b"""
+script:
+- echo "item 1"
+- echo "item 2"
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    assert len(results) == 1
+    assert "echo \"item 1\"\necho \"item 2\"" in results[0][1].decode('utf-8')
+
+def test_yaml_multiline_list_mixed_improvements():
+    """Verify that a mix of single-line and multi-line list items works correctly."""
+    yaml_content = b"""
+script:
+  - echo "start"
+  - |
+    echo "middle line 1"
+    echo "middle line 2"
+  - echo "end"
+"""
+    results = list(unpack_content("test.yml", yaml_content))
+    assert len(results) == 1
+    text = results[0][1].decode('utf-8')
+    assert 'echo "start"' in text
+    assert 'echo "middle line 1"' in text
+    assert 'echo "middle line 2"' in text
+    assert 'echo "end"' in text


### PR DESCRIPTION
This PR improves the robustness of YAML script extraction in `gptscan.py`. It addresses a gap where several common configuration keys (used in cloud-init, CI/CD, and build scripts) were missed during scanning. Additionally, it fixes a logic error in the YAML parser that caused list items at the same indentation level as their parent key to be ignored.

Changes:
- Updated `script_keys` in `unpack_content` to include `runcmd`, `bootcmd`, `args`, `setup`, `install`, and `test`.
- Modified the indentation check for YAML lists from `<=` to `<` to correctly handle same-level list items.
- Created `tests/test_yaml_improvements.py` with tests for:
    - New script keys.
    - Same-level indentation for lists.
    - Mixed single-line and multi-line list items.

---
*PR created automatically by Jules for task [7821478956997097243](https://jules.google.com/task/7821478956997097243) started by @RainRat*