### PR TITLE
[UI/UX] Refine CLI Triage Report Layout and Hierarchy

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4979,13 +4979,13 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
         return f"{conf_str}"
 
     for i, r in enumerate(results, 1):
-        path = r.get("path", "unknown")
+        path = html.unescape(r.get("path", "unknown")).strip()
         own_conf = r.get("own_conf", "0%")
         gpt_conf = r.get("gpt_conf", "")
-        admin = r.get("admin_desc", "")
-        user = r.get("end-user_desc", "")
+        admin = html.unescape(r.get("admin_desc", "")).strip()
+        user = html.unescape(r.get("end-user_desc", "")).strip()
         line_num = r.get("line", "-")
-        snippet = r.get("snippet", "")
+        snippet = html.unescape(r.get("snippet", "")).strip()
 
         conf_val = get_effective_threat_level(own_conf, gpt_conf)
         risk = get_risk_category(conf_val, Config.THRESHOLD)
@@ -4998,36 +4998,35 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
         location = f"{path}:{line_num}" if line_num != "-" else path
-        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")
+        lines.append(f"{GRAY}[{i}]{RESET} {risk_label} - {BOLD}{location}{RESET}")
 
-        # Consolidate scores and links
-        meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
+        # Scores
+        scores = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
         if gpt_conf:
-            meta_parts.append(f"{GRAY}AI:{RESET} {color_conf(gpt_conf)}")
+            scores.append(f"{GRAY}AI:{RESET} {color_conf(gpt_conf)}")
+        lines.append(f"    {'  '.join(scores)}")
 
+        # Links
+        links = []
         vt_url = get_virustotal_url(path, snippet)
         if vt_url:
-            meta_parts.append(f"{GRAY}VT:{RESET} {vt_url}")
+            links.append(f"{GRAY}VT:{RESET} {vt_url}")
 
         online_url = get_online_url(path, line_num)
         if online_url:
-            meta_parts.append(f"{GRAY}Online:{RESET} {online_url}")
+            links.append(f"{GRAY}Online:{RESET} {online_url}")
 
-        lines.append(f"    {'  '.join(meta_parts)}")
+        if links:
+            lines.append(f"    {'  '.join(links)}")
 
-        # Consolidate AI analysis
-        if admin or user:
-            analysis_parts = []
-            if admin:
-                clean_admin = admin.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}Admin:{RESET} {clean_admin}")
-            if user:
-                clean_user = user.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}User:{RESET} {clean_user}")
-            lines.append(f"    {'  '.join(analysis_parts)}")
+        # AI analysis
+        if admin:
+            lines.append(f"    {GRAY}Admin:{RESET} {admin.replace('\n', ' ')}")
+        if user:
+            lines.append(f"    {GRAY}User:{RESET} {user.replace('\n', ' ')}")
 
         # Snippet preview (up to 3 lines)
-        snippet_lines = snippet.strip().split('\n')[:3]
+        snippet_lines = snippet.split('\n')[:3]
         for sl in snippet_lines:
             if len(sl) > 100:
                 sl = sl[:97] + "..."

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -131,10 +131,13 @@ def test_generate_console_report():
     # Without color
     report = gptscan.generate_console_report(results, use_color=False)
     assert "--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---" in report
-    assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
-    assert "Admin: Admin note  User: User note" in report
+    assert "Local: 90%  AI: 95%" in report
+    assert "VT: https://www.virustotal.com/gui/file/" in report
+    assert "Admin: Admin note" in report
+    assert "User: User note" in report
     assert "> dangerous_code()" in report
-    assert "[2] LOW RISK - safe.py:1" in report
+    assert "[1] HIGH RISK - suspicious.py:10" in report
+    assert "[2] LOW RISK - safe.py" in report
     assert "Local: 10%" in report
     assert "> print('ok')" in report
 
@@ -144,6 +147,8 @@ def test_generate_console_report():
     assert "\033[0;90mLOW RISK\033[0m" in report_color
     # Verify dimmed index
     assert "\033[0;90m[1]\033[0m" in report_color
+    # Verify bolding on file location
+    assert "\033[1msuspicious.py:10\033[0m" in report_color
     # Verify dimmed labels and emphasized values (scores >= 50%)
     assert "\033[0;90mLocal:\033[0m \033[1;91m\033[1m90%\033[0m" in report_color
     assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color


### PR DESCRIPTION
### PR Title: [UI/UX] Refine CLI Triage Report Layout and Hierarchy

### Description:
* **Context:** CLI
* **Problem:** The existing console triage report was crowded, making it difficult to distinguish between threat scores, external links (VirusTotal/Online), and AI analysis notes. Additionally, a formatting bug caused the file location to lose its bold emphasis, and HTML entities in paths or snippets were not being decoded for terminal display.
* **Solution:** I refined the visual hierarchy of the console report by reorganizing findings into a structured multi-line layout. Threat scores, URLs, and AI analysis now occupy their own logical sections, preventing horizontal clutter. I fixed the bolding logic for file locations and integrated `html.unescape()` to ensure clean, readable text. These changes improve information density and triage efficiency for power users.

### Changes:
- Modified `generate_console_report` in `gptscan.py` to use a multi-line, hierarchical layout.
- Integrated `html.unescape()` and `.strip()` for cleaner path, snippet, and analysis output in the console.
- Updated `tests/test_reporting_features.py` to verify the new report structure and ensure precise matching of findings.

---
*PR created automatically by Jules for task [9840854948436699869](https://jules.google.com/task/9840854948436699869) started by @RainRat*