### PR TITLE
[TEST] Refine Unified Diff extraction and prefix stripping

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3993,17 +3993,18 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
             hunk_info = None
             hunk_lines = []
 
+            has_additions = False
+
             def finalize_hunk():
-                if current_file and hunk_info and hunk_lines:
-                    # Only yield if there's at least one added line in this hunk
-                    if any(line.startswith('+') and not line.startswith('+++') for line in hunk_lines):
-                        hunk_text = "\n".join(hunk_lines)
-                        yield (f"{name} [{current_file} @ {hunk_info}]", hunk_text.encode('utf-8'))
+                nonlocal has_additions
+                if current_file and hunk_info and hunk_lines and has_additions:
+                    hunk_text = "\n".join(hunk_lines)
+                    yield (f"{name} [{current_file} @ {hunk_info}]", hunk_text.encode('utf-8'))
+                has_additions = False
 
             for line in lines:
                 if line.startswith('+++ '):
                     yield from finalize_hunk()
-                    # Extract file path: +++ b/path/to/file.py -> path/to/file.py
                     path_part = line[4:].split('\t')[0].strip()
                     if path_part.startswith(('a/', 'b/')) and '/' in path_part:
                         path_part = path_part[2:]
@@ -4012,15 +4013,23 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                     hunk_lines = []
                 elif line.startswith('@@ ') and current_file:
                     yield from finalize_hunk()
-                    # Extract starting line: @@ -1,1 +1,2 @@ -> line 1
                     match = re.search(r'@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@', line)
                     hunk_info = f"line {match.group(1)}" if match else "unknown"
                     hunk_lines = []
                 elif hunk_info is not None:
-                    if line.startswith((' ', '+')):
-                        hunk_lines.append(line)
-                    elif not line.startswith('-'):
-                        # End of hunk if line doesn't start with context/add/remove
+                    if line.startswith('+'):
+                        if not line.startswith('+++ '):
+                            hunk_lines.append(line[1:])
+                            has_additions = True
+                    elif line.startswith(' '):
+                        hunk_lines.append(line[1:])
+                    elif line.startswith('-'):
+                        if line.startswith('--- '):
+                            yield from finalize_hunk()
+                            hunk_info = None
+                            hunk_lines = []
+                        continue  # Skip deletions
+                    else:
                         yield from finalize_hunk()
                         hunk_info = None
                         hunk_lines = []

--- a/tests/test_diff_parsing.py
+++ b/tests/test_diff_parsing.py
@@ -12,7 +12,7 @@ def test_unpack_diff_single_file():
     assert len(results) == 1
     name, snippet = results[0]
     assert "test.diff [file.py @ line 1]" == name
-    assert b" print(\"hello\")\n+import os; os.system(\"evil\")" == snippet
+    assert b"print(\"hello\")\nimport os; os.system(\"evil\")" == snippet
 
 def test_unpack_diff_multi_file():
     content = b"""--- a/a.py
@@ -29,9 +29,9 @@ def test_unpack_diff_multi_file():
     results = list(unpack_content("test.diff", content))
     assert len(results) == 2
     assert "test.diff [a.py @ line 10]" == results[0][0]
-    assert b"+new" == results[0][1]
+    assert b"new" == results[0][1]
     assert "test.diff [b.js @ line 5]" == results[1][0]
-    assert b"+eval(\"malicious\")\n context" == results[1][1]
+    assert b"eval(\"malicious\")\ncontext" == results[1][1]
 
 def test_unpack_diff_no_additions():
     content = b"""--- a/file.py
@@ -52,7 +52,7 @@ def test_unpack_diff_added_file():
     results = list(unpack_content("test.diff", content))
     assert len(results) == 1
     assert "test.diff [new_script.sh @ line 1]" == results[0][0]
-    assert b"+#!/bin/bash\n+rm -rf /" == results[0][1]
+    assert b"#!/bin/bash\nrm -rf /" == results[0][1]
 
 def test_unpack_diff_complex_header():
     # Diff with tabs and timestamps in header
@@ -64,4 +64,4 @@ def test_unpack_diff_complex_header():
     results = list(unpack_content("patch.patch", content))
     assert len(results) == 1
     assert "patch.patch [new/file.py @ line 42]" == results[0][0]
-    assert b"+suspicious_call()" == results[0][1]
+    assert b"suspicious_call()" == results[0][1]

--- a/tests/test_diff_stripping.py
+++ b/tests/test_diff_stripping.py
@@ -1,0 +1,44 @@
+import pytest
+from gptscan import unpack_content
+
+def test_diff_prefix_stripping():
+    """Verify that '+' and ' ' prefixes are stripped from Unified Diff hunks."""
+    content = b"""--- a/file.py
++++ b/file.py
+@@ -1,2 +1,3 @@
+ def hello():
+-    print("old")
++    print("new")
++    return True
+"""
+    results = list(unpack_content("test.diff", content))
+    assert len(results) == 1
+    _, snippet = results[0]
+
+    # Expected: prefixes stripped, indentation preserved
+    expected = b'def hello():\n    print("new")\n    return True'
+    assert snippet == expected
+
+def test_diff_prefix_stripping_with_mixed_indent():
+    """Verify that indentation is correctly preserved after stripping prefixes."""
+    content = b"""--- a/script.sh
++++ b/script.sh
+@@ -10,3 +10,4 @@
+ if [ "$1" = "test" ]; then
++    echo "Starting test..."
+     ./run_test.sh
++    echo "Done."
+ fi
+"""
+    results = list(unpack_content("test.diff", content))
+    assert len(results) == 1
+    _, snippet = results[0]
+
+    expected = (
+        b'if [ "$1" = "test" ]; then\n'
+        b'    echo "Starting test..."\n'
+        b'    ./run_test.sh\n'
+        b'    echo "Done."\n'
+        b'fi'
+    )
+    assert snippet == expected

--- a/tests/test_smart_diff_detection.py
+++ b/tests/test_smart_diff_detection.py
@@ -9,7 +9,7 @@ def test_clipboard_diff_unpacked_by_content():
     # It should be unpacked into a hunk
     assert len(results) == 1
     assert results[0][0] == "[Clipboard] [file.py @ line 1]"
-    assert b"+new line" in results[0][1]
+    assert b"new line" in results[0][1]
 
 def test_extensionless_git_diff_unpacked():
     """Verify that 'diff --git' style diffs are recognized by content."""
@@ -18,7 +18,7 @@ def test_extensionless_git_diff_unpacked():
 
     assert len(results) == 1
     assert results[0][0] == "raw_diff [test.js @ line 1]"
-    assert b"+new" in results[0][1]
+    assert b"new" in results[0][1]
 
 def test_docker_compose_is_container():
     """Verify that docker-compose files are recognized as containers for unpacking."""


### PR DESCRIPTION
Refined the `unpack_content` function's Unified Diff extraction logic to produce cleaner, more accurate code snippets for analysis.

**Changes:**
- Modified Unified Diff parsing to explicitly filter out lines starting with `-` (deletions), as they are no longer part of the code state.
- Stripped the first character (the diff prefix: `+` or ` `) from each line within a hunk.
- Added `has_additions` tracking to ensure only hunks that actually introduce code are yielded.
- Improved hunk boundary detection (properly handling `---` and `+++` file markers).
- Added `tests/test_diff_stripping.py` with specific cases for indentation preservation and prefix removal.
- Updated `tests/test_diff_parsing.py` and `tests/test_smart_diff_detection.py` to align with the refined output format.

**Impact:**
Clean code snippets (without diff markers) provide higher quality input for AI and local detection models, reducing noise and potential false positives caused by analyzing removed code.

---
*PR created automatically by Jules for task [14123466289504462162](https://jules.google.com/task/14123466289504462162) started by @RainRat*