### PR TITLE
[UI/UX] Ensure file location remains bold in console report

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4998,7 +4998,7 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
         location = f"{path}:{line_num}" if line_num != "-" else path
-        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")
+        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label}{BOLD} - {location}{RESET}")
 
         # Consolidate scores and links
         meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]


### PR DESCRIPTION
### What
Updated the `generate_console_report` function in `gptscan.py` to re-apply the `{BOLD}` ANSI escape code immediately after the `{risk_label}` variable in the report finding header.

### Why
The `risk_label` variable contains a `{RESET}` escape code at its end. In the previous implementation, this reset was clearing the bold styling that had been applied at the start of the line, leaving the file location and separator unbolded. By explicitly re-applying `{BOLD}` after the label, the intended visual hierarchy is restored. This is a non-breaking change that only affects terminal output when colors are enabled.

---
*PR created automatically by Jules for task [4538945300997086465](https://jules.google.com/task/4538945300997086465) started by @RainRat*