### PR TITLE
Refine CLI triage report visual hierarchy and multi-line AI analysis

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4998,7 +4998,8 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
         location = f"{path}:{line_num}" if line_num != "-" else path
-        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")
+        # Re-apply BOLD after risk_label's RESET to ensure location is bolded
+        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label}{BOLD} - {location}{RESET}")
 
         # Consolidate scores and links
         meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
@@ -5015,16 +5016,15 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
 
         lines.append(f"    {'  '.join(meta_parts)}")
 
-        # Consolidate AI analysis
+        # AI analysis with preserved newlines
         if admin or user:
-            analysis_parts = []
+            lines.append("")
             if admin:
-                clean_admin = admin.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}Admin:{RESET} {clean_admin}")
+                for line in admin.strip().splitlines():
+                    lines.append(f"    {GRAY}Admin:{RESET} {line}")
             if user:
-                clean_user = user.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}User:{RESET} {clean_user}")
-            lines.append(f"    {'  '.join(analysis_parts)}")
+                for line in user.strip().splitlines():
+                    lines.append(f"    {GRAY}User:{RESET} {line}")
 
         # Snippet preview (up to 3 lines)
         snippet_lines = snippet.strip().split('\n')[:3]

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -132,7 +132,8 @@ def test_generate_console_report():
     report = gptscan.generate_console_report(results, use_color=False)
     assert "--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---" in report
     assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
-    assert "Admin: Admin note  User: User note" in report
+    assert "Admin: Admin note" in report
+    assert "User: User note" in report
     assert "> dangerous_code()" in report
     assert "[2] LOW RISK - safe.py:1" in report
     assert "Local: 10%" in report
@@ -144,6 +145,8 @@ def test_generate_console_report():
     assert "\033[0;90mLOW RISK\033[0m" in report_color
     # Verify dimmed index
     assert "\033[0;90m[1]\033[0m" in report_color
+    # Verify bolded location
+    assert "\x1b[1m\x1b[1;91mHIGH RISK\x1b[0m\x1b[1m - suspicious.py:10\x1b[0m" in report_color
     # Verify dimmed labels and emphasized values (scores >= 50%)
     assert "\033[0;90mLocal:\033[0m \033[1;91m\033[1m90%\033[0m" in report_color
     assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color


### PR DESCRIPTION
**PR Title:** [UI/UX] Refine CLI triage report visual hierarchy and multi-line AI analysis

**Description:**
* **Context:** CLI
* **Problem:** The CLI triage report (`--report` flag) collapsed multi-line AI analysis notes into a single line, destroying the structure of detailed explanations. Additionally, the bold formatting for the file location in the finding header was lost after colorized risk labels because of ANSI reset sequences.
* **Solution:** Improved `generate_console_report` to preserve and indent newlines in AI analysis notes, using repeating gray prefixes for context. The finding header was updated to explicitly re-apply bold formatting after the risk label. These changes enhance information density while maintaining a clean, POSIX-style aesthetic.

**Changes:**
```python
# gptscan.py
<<<<<<< SEARCH
        location = f"{path}:{line_num}" if line_num != "-" else path
        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")

        # Consolidate scores and links
        meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
        if gpt_conf:
            meta_parts.append(f"{GRAY}AI:{RESET} {color_conf(gpt_conf)}")

        vt_url = get_virustotal_url(path, snippet)
        if vt_url:
            meta_parts.append(f"{GRAY}VT:{RESET} {vt_url}")

        online_url = get_online_url(path, line_num)
        if online_url:
            meta_parts.append(f"{GRAY}Online:{RESET} {online_url}")

        lines.append(f"    {'  '.join(meta_parts)}")

        # Consolidate AI analysis
        if admin or user:
            analysis_parts = []
            if admin:
                clean_admin = admin.strip().replace('\n', ' ')
                analysis_parts.append(f"{GRAY}Admin:{RESET} {clean_admin}")
            if user:
                clean_user = user.strip().replace('\n', ' ')
                analysis_parts.append(f"{GRAY}User:{RESET} {clean_user}")
            lines.append(f"    {'  '.join(analysis_parts)}")
=======
        location = f"{path}:{line_num}" if line_num != "-" else path
        # Re-apply BOLD after risk_label's RESET to ensure location is bolded
        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label}{BOLD} - {location}{RESET}")

        # Consolidate scores and links
        meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
        if gpt_conf:
            meta_parts.append(f"{GRAY}AI:{RESET} {color_conf(gpt_conf)}")

        vt_url = get_virustotal_url(path, snippet)
        if vt_url:
            meta_parts.append(f"{GRAY}VT:{RESET} {vt_url}")

        online_url = get_online_url(path, line_num)
        if online_url:
            meta_parts.append(f"{GRAY}Online:{RESET} {online_url}")

        lines.append(f"    {'  '.join(meta_parts)}")

        # AI analysis with preserved newlines
        if admin or user:
            lines.append("")
            if admin:
                for line in admin.strip().splitlines():
                    lines.append(f"    {GRAY}Admin:{RESET} {line}")
            if user:
                for line in user.strip().splitlines():
                    lines.append(f"    {GRAY}User:{RESET} {line}")
>>>>>>> REPLACE
```

```python
# tests/test_reporting_features.py
<<<<<<< SEARCH
    # Without color
    report = gptscan.generate_console_report(results, use_color=False)
    assert "--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---" in report
    assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
    assert "Admin: Admin note  User: User note" in report
    assert "> dangerous_code()" in report
=======
    # Without color
    report = gptscan.generate_console_report(results, use_color=False)
    assert "--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---" in report
    assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
    assert "Admin: Admin note" in report
    assert "User: User note" in report
    assert "> dangerous_code()" in report
>>>>>>> REPLACE
<<<<<<< SEARCH
    # Verify dimmed index
    assert "\033[0;90m[1]\033[0m" in report_color
    # Verify dimmed labels and emphasized values (scores >= 50%)
=======
    # Verify dimmed index
    assert "\033[0;90m[1]\033[0m" in report_color
    # Verify bolded location
    assert "\x1b[1m\x1b[1;91mHIGH RISK\x1b[0m\x1b[1m - suspicious.py:10\x1b[0m" in report_color
    # Verify dimmed labels and emphasized values (scores >= 50%)
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [584614017979013999](https://jules.google.com/task/584614017979013999) started by @RainRat*