### PR TITLE
[FEAT] Expand system coverage to Ruby, PHP, Rust, Go, and Documents

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1455,6 +1455,145 @@ def get_nodejs_package_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_ruby_gems_paths() -> List[str]:
+    """Find all folders containing installed Ruby gems."""
+    paths = []
+    # 1. Check GEM_HOME
+    gem_home = os.environ.get("GEM_HOME")
+    if gem_home:
+        paths.append(os.path.join(gem_home, "gems"))
+
+    # 2. Ask gem for its home
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['gem', 'env', 'home'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            paths.append(os.path.join(output, "gems"))
+    except Exception:
+        pass
+
+    # 3. Common paths
+    home = Path.home()
+    if sys.platform == "win32":
+        # Windows RubyInstaller default
+        paths.append("C:\\Ruby*\\lib\\ruby\\gems\\*\\gems")
+    else:
+        paths.extend([
+            str(home / ".gem" / "ruby" / "*" / "gems"),
+            "/usr/lib/ruby/gems/*/gems",
+            "/usr/local/lib/ruby/gems/*/gems"
+        ])
+
+    # Expand globs if any
+    expanded_paths = []
+    for p in paths:
+        if "*" in p:
+            expanded_paths.extend(glob.glob(p))
+        else:
+            expanded_paths.append(p)
+
+    return sorted(_normalize_and_filter_dirs(expanded_paths))
+
+
+def get_php_packages_paths() -> List[str]:
+    """Find all folders containing global PHP Composer packages."""
+    paths = []
+    # 1. Ask composer for its global home
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['composer', 'global', 'config', 'home', '--quiet'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            paths.append(os.path.join(output, "vendor"))
+    except Exception:
+        pass
+
+    # 2. Common paths
+    home = Path.home()
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            paths.append(os.path.join(appdata, "Composer", "vendor"))
+    else:
+        paths.extend([
+            str(home / ".composer" / "vendor"),
+            str(home / ".config" / "composer" / "vendor")
+        ])
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_rust_packages_paths() -> List[str]:
+    """Find all folders containing downloaded Rust Cargo packages."""
+    paths = []
+    cargo_home = os.environ.get("CARGO_HOME")
+    if cargo_home:
+        paths.append(os.path.join(cargo_home, "registry", "src"))
+    else:
+        paths.append(str(Path.home() / ".cargo" / "registry" / "src"))
+
+    # Each registry has its own subdirectory under src, so we might need one more level of glob
+    expanded_paths = []
+    for p in paths:
+        expanded_paths.extend(glob.glob(os.path.join(p, "*")))
+
+    return sorted(_normalize_and_filter_dirs(expanded_paths))
+
+
+def get_go_packages_paths() -> List[str]:
+    """Find all folders containing downloaded Go modules."""
+    paths = []
+    # 1. Check GOPATH
+    gopath = os.environ.get("GOPATH")
+    if gopath:
+        for p in gopath.split(os.pathsep):
+            paths.append(os.path.join(p, "pkg", "mod"))
+
+    # 2. Ask go for its GOPATH
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['go', 'env', 'GOPATH'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            for p in output.split(os.pathsep):
+                paths.append(os.path.join(p, "pkg", "mod"))
+    except Exception:
+        pass
+
+    # 3. Default path
+    paths.append(str(Path.home() / "go" / "pkg" / "mod"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_documents_paths() -> List[str]:
+    """Find the user's Documents folder."""
+    paths = []
+    home = Path.home()
+    # On Windows, Documents can be moved. We could use shell folders,
+    # but let's stick to Path.home() / "Documents" for now as a common place.
+    docs = home / "Documents"
+    if docs.exists():
+        paths.append(str(docs))
+
+    # Also check OneDrive path on Windows
+    if sys.platform == "win32":
+        onedrive = os.environ.get("OneDrive")
+        if onedrive:
+            docs = Path(onedrive) / "Documents"
+            if docs.exists():
+                paths.append(str(docs))
+
+    return sorted(list(set(paths)))
+
+
 def get_system_service_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all system services (Windows Service PathName)."""
     items = []
@@ -2837,6 +2976,58 @@ def scan_nodejs_packages_click():
         messagebox.showwarning("Node.js Packages Error", f"Could not scan Node.js packages: {e}")
 
 
+def scan_ruby_gems_click():
+    """Scan all folders containing installed Ruby gems."""
+    try:
+        package_paths = get_ruby_gems_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Ruby Gems", "No Ruby gems folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Ruby Gems Error", f"Could not scan Ruby gems: {e}")
+
+
+def scan_php_packages_click():
+    """Scan all folders containing global PHP Composer packages."""
+    try:
+        package_paths = get_php_packages_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("PHP Packages", "No global PHP package folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("PHP Packages Error", f"Could not scan PHP packages: {e}")
+
+
+def scan_rust_packages_click():
+    """Scan all folders containing downloaded Rust Cargo packages."""
+    try:
+        package_paths = get_rust_packages_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Rust Packages", "No Rust package folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Rust Packages Error", f"Could not scan Rust packages: {e}")
+
+
+def scan_go_packages_click():
+    """Scan all folders containing downloaded Go modules."""
+    try:
+        package_paths = get_go_packages_paths()
+        if package_paths:
+            _set_scan_target(package_paths)
+            button_click()
+        else:
+            messagebox.showinfo("Go Packages", "No Go module folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Go Packages Error", f"Could not scan Go packages: {e}")
+
+
 def scan_browser_extensions_click():
     """Scan all common browser extension folders."""
     try:
@@ -2889,6 +3080,19 @@ def scan_desktop_click():
         messagebox.showwarning("Desktop Error", f"Could not scan Desktop: {e}")
 
 
+def scan_documents_click():
+    """Scan the user's Documents folder."""
+    try:
+        paths = get_documents_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Documents", "The Documents folder was not found on this system.")
+    except Exception as e:
+        messagebox.showwarning("Documents Error", f"Could not scan Documents: {e}")
+
+
 def scan_temp_click():
     """Scan common temporary folders."""
     try:
@@ -2913,10 +3117,15 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
     all_paths.extend(get_nodejs_package_paths())
+    all_paths.extend(get_ruby_gems_paths())
+    all_paths.extend(get_php_packages_paths())
+    all_paths.extend(get_rust_packages_paths())
+    all_paths.extend(get_go_packages_paths())
     all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
     all_paths.extend(get_downloads_paths())
     all_paths.extend(get_desktop_paths())
+    all_paths.extend(get_documents_paths())
     all_paths.extend(get_temp_paths())
 
     all_snippets = []
@@ -7210,7 +7419,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     button_box.grid(row=0, column=3, sticky="e")
     browse_button = ttk.Menubutton(button_box, text="Browse", width=10)
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
-    bind_hover_message(browse_button, "Browse for scan targets (Ctrl+Shift+O/F/U/V/D/G/Q/I/B/H/P/K/N/T/A/S/R/Y/M/W/X/J/L/Z).")
+    bind_hover_message(browse_button, "Select scan targets or perform system audits.")
 
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
@@ -7258,10 +7467,15 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan SSH Configuration", command=scan_ssh_config_click, accelerator="Ctrl+Shift+R")
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
+    system_menu.add_command(label="Scan Ruby Gems", command=scan_ruby_gems_click)
+    system_menu.add_command(label="Scan PHP Packages", command=scan_php_packages_click)
+    system_menu.add_command(label="Scan Rust Packages", command=scan_rust_packages_click)
+    system_menu.add_command(label="Scan Go Packages", command=scan_go_packages_click)
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
     system_menu.add_command(label="Scan Downloads", command=scan_downloads_click, accelerator="Ctrl+Shift+J")
     system_menu.add_command(label="Scan Desktop", command=scan_desktop_click, accelerator="Ctrl+Shift+L")
+    system_menu.add_command(label="Scan Documents", command=scan_documents_click)
     system_menu.add_command(label="Scan Temporary Folders", command=scan_temp_click, accelerator="Ctrl+Shift+Z")
     browse_menu.add_cascade(label="System Scans", menu=system_menu)
     browse_button["menu"] = browse_menu
@@ -7814,6 +8028,11 @@ def main():
         action='store_true',
         help="Scan the user's Desktop folder."
     )
+    scan_group.add_argument(
+        '--documents',
+        action='store_true',
+        help="Scan the user's Documents folder."
+    )
 
     git_group = parser.add_argument_group("Git Integration")
     git_group.add_argument(
@@ -7894,6 +8113,26 @@ def main():
         '--nodejs-packages',
         action='store_true',
         help='Scan all folders containing global Node.js packages.'
+    )
+    system_group.add_argument(
+        '--ruby-gems',
+        action='store_true',
+        help='Scan all folders containing installed Ruby gems.'
+    )
+    system_group.add_argument(
+        '--php-packages',
+        action='store_true',
+        help='Scan all folders containing global PHP Composer packages.'
+    )
+    system_group.add_argument(
+        '--rust-packages',
+        action='store_true',
+        help='Scan all folders containing downloaded Rust Cargo packages.'
+    )
+    system_group.add_argument(
+        '--go-packages',
+        action='store_true',
+        help='Scan all folders containing downloaded Go modules.'
     )
     system_group.add_argument(
         '--browser-extensions',
@@ -7980,7 +8219,12 @@ def main():
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
             args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
-            args.system_services, args.audit, args.modified
+            args.system_services, args.audit, args.modified,
+            args.downloads, args.desktop, args.documents,
+            args.python_packages, args.nodejs_packages, args.ruby_gems,
+            args.php_packages, args.rust_packages, args.go_packages,
+            args.browser_extensions, args.editor_extensions, args.ssh_config,
+            args.temp
         ]):
             sys.exit(0)
 
@@ -8216,6 +8460,21 @@ def main():
 
         if args.desktop:
             scan_targets.extend(get_desktop_paths())
+
+        if args.documents:
+            scan_targets.extend(get_documents_paths())
+
+        if args.ruby_gems:
+            scan_targets.extend(get_ruby_gems_paths())
+
+        if args.php_packages:
+            scan_targets.extend(get_php_packages_paths())
+
+        if args.rust_packages:
+            scan_targets.extend(get_rust_packages_paths())
+
+        if args.go_packages:
+            scan_targets.extend(get_go_packages_paths())
 
         if args.temp:
             scan_targets.extend(get_temp_paths())

--- a/readme.md
+++ b/readme.md
@@ -80,10 +80,15 @@ Access these options from the **Browse** menu:
 *   **Scan SSH Configuration (Ctrl+Shift+R):** Scan all common SSH configuration and authorized_keys files.
 *   **Scan Python Packages (Ctrl+Shift+Y):** Scan your installed Python packages for malicious code.
 *   **Scan Node.js Packages (Ctrl+Shift+M):** Scan your global Node.js packages.
+*   **Scan Ruby Gems:** Scan your installed Ruby gems.
+*   **Scan PHP Packages:** Scan your global PHP Composer packages.
+*   **Scan Rust Packages:** Scan your downloaded Rust Cargo packages.
+*   **Scan Go Packages:** Scan your downloaded Go modules.
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
 *   **Scan Downloads (Ctrl+Shift+J):** Scan your standard Downloads folder for suspicious files.
 *   **Scan Desktop (Ctrl+Shift+L):** Scan your standard Desktop folder for suspicious files.
+*   **Scan Documents:** Scan your standard Documents folder for suspicious files.
 *   **Scan Temporary Folders (Ctrl+Shift+Z):** Scan common temporary folders for suspicious files.
 
 
@@ -190,6 +195,26 @@ Scan all folders containing global Node.js packages:
 python3 gptscan.py --nodejs-packages --cli
 ```
 
+Scan all folders containing installed Ruby gems:
+```bash
+python3 gptscan.py --ruby-gems --cli
+```
+
+Scan all folders containing global PHP Composer packages:
+```bash
+python3 gptscan.py --php-packages --cli
+```
+
+Scan all folders containing downloaded Rust Cargo packages:
+```bash
+python3 gptscan.py --rust-packages --cli
+```
+
+Scan all folders containing downloaded Go modules:
+```bash
+python3 gptscan.py --go-packages --cli
+```
+
 Scan all common browser extension folders:
 ```bash
 python3 gptscan.py --browser-extensions --cli
@@ -213,6 +238,11 @@ python3 gptscan.py --downloads --cli
 Scan the standard Desktop folder:
 ```bash
 python3 gptscan.py --desktop --cli
+```
+
+Scan the standard Documents folder:
+```bash
+python3 gptscan.py --documents --cli
 ```
 
 Scan your terminal history (Bash, Zsh, PowerShell, etc.):

--- a/tests/test_system_coverage.py
+++ b/tests/test_system_coverage.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import gptscan
+import os
+import sys
+
+def test_new_discovery_functions(monkeypatch):
+    # Mock os.path.isdir to return True for our test paths
+    monkeypatch.setattr("os.path.isdir", lambda x: True)
+    # Mock Path.exists to return True
+    monkeypatch.setattr("gptscan.Path.exists", lambda x: True)
+
+    # Test get_documents_paths
+    with patch("gptscan.Path.home", return_value=gptscan.Path("/home/user")):
+        paths = gptscan.get_documents_paths()
+        assert str(gptscan.Path("/home/user/Documents")) in paths
+
+    # Test get_ruby_gems_paths
+    monkeypatch.setenv("GEM_HOME", "/gem/home")
+    paths = gptscan.get_ruby_gems_paths()
+    assert "/gem/home/gems" in paths
+
+    # Test get_php_packages_paths
+    def mock_check_output(cmd, **kwargs):
+        if cmd[0] == 'composer':
+            return "/composer/home"
+        return ""
+    monkeypatch.setattr("subprocess.check_output", mock_check_output)
+    paths = gptscan.get_php_packages_paths()
+    assert "/composer/home/vendor" in paths
+
+    # Test get_rust_packages_paths
+    monkeypatch.setenv("CARGO_HOME", "/cargo/home")
+    with patch("glob.glob", return_value=["/cargo/home/registry/src/github.com-1ecc6299db9ec823"]):
+        paths = gptscan.get_rust_packages_paths()
+        assert "/cargo/home/registry/src/github.com-1ecc6299db9ec823" in paths
+
+    # Test get_go_packages_paths
+    monkeypatch.setenv("GOPATH", "/go/path")
+    paths = gptscan.get_go_packages_paths()
+    assert "/go/path/pkg/mod" in paths
+
+def test_system_audit_integration(monkeypatch):
+    monkeypatch.setattr("gptscan.get_shell_profile_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_shell_history_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_path_directories", lambda: [])
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_nodejs_package_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_browser_extensions_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_editor_extensions_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_downloads_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_desktop_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_temp_paths", lambda: [])
+
+    # New ones
+    monkeypatch.setattr("gptscan.get_ruby_gems_paths", lambda: ["/ruby/gems"])
+    monkeypatch.setattr("gptscan.get_php_packages_paths", lambda: ["/php/packages"])
+    monkeypatch.setattr("gptscan.get_rust_packages_paths", lambda: ["/rust/packages"])
+    monkeypatch.setattr("gptscan.get_go_packages_paths", lambda: ["/go/packages"])
+    monkeypatch.setattr("gptscan.get_documents_paths", lambda: ["/user/documents"])
+
+    monkeypatch.setattr("gptscan.get_running_process_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_environment_variable_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_scheduled_task_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_startup_item_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_stash_snippets", lambda: [])
+
+    paths, snippets = gptscan.get_system_audit_data()
+    assert "/ruby/gems" in paths
+    assert "/php/packages" in paths
+    assert "/rust/packages" in paths
+    assert "/go/packages" in paths
+    assert "/user/documents" in paths
+
+def test_cli_new_flags(monkeypatch):
+    captured_targets = []
+    def mock_run_cli(targets, *args, **kwargs):
+        nonlocal captured_targets
+        captured_targets = targets
+        return 0
+
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+    monkeypatch.setattr("gptscan.get_documents_paths", lambda: ["/docs"])
+    monkeypatch.setattr("gptscan.get_ruby_gems_paths", lambda: ["/gems"])
+
+    test_args = ["gptscan.py", "--documents", "--ruby-gems", "--cli"]
+    with patch.object(sys, 'argv', test_args):
+        gptscan.main()
+
+    assert "/docs" in captured_targets
+    assert "/gems" in captured_targets


### PR DESCRIPTION
This PR expands the system scanning capabilities of GPT Virus Scanner by adding support for several new target types. Following the "Symmetry" and "Batching" heuristics, I noticed that while the tool already supported Python and Node.js package discovery, it was missing other major ecosystems.

### Changes:
- **Language Ecosystems:** Added discovery for Ruby gems, PHP Composer packages, Rust Cargo packages, and Go modules across Windows and POSIX systems.
- **User Files:** Added scanning support for the standard Documents folder.
- **System Audit Integration:** The comprehensive "System Audit" feature now automatically includes these new targets.
- **CLI & GUI:** Added dedicated flags and menu items for each new target.
- **Robustness:** Added defensive error handling around subprocess calls to ensure the tool remains functional even if specific package managers are not installed.
- **Tests:** Added `tests/test_system_coverage.py` to verify the new discovery functions and their integration.
- **Documentation:** Updated `readme.md` and CLI help text to reflect the new capabilities.

---
*PR created automatically by Jules for task [8815393004275738042](https://jules.google.com/task/8815393004275738042) started by @RainRat*