### PR TITLE
[TEST] Add support for triple-quoted strings in pyproject.toml inline tables

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3658,7 +3658,7 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                                 if command_val.startswith('{'):
                                     # Inline table
                                     # Robustly handle brackets and quotes within the inline table value
-                                    cmd_match = re.search(r'(?:cmd|command|shell|composite|script|expr)\s*=\s*("(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\[(?:[^"\'\]]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*\])', command_val)
+                                    cmd_match = re.search(r'(?:cmd|command|shell|composite|script|expr)\s*=\s*("{3}(?:\\.|[^\\])*?"{3}(?!")|\'{3}(?:\\.|[^\\])*?\'{3}(?!\')|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\[(?:[^"\'\]]|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')*\])', command_val)
                                     if cmd_match:
                                         yield from yield_pyproject_scripts(script_key, cmd_match.group(1).strip())
                                 else:

--- a/tests/test_pyproject_inline_triple.py
+++ b/tests/test_pyproject_inline_triple.py
@@ -1,0 +1,17 @@
+import pytest
+from gptscan import unpack_content
+
+def test_pyproject_inline_table_triple_quotes():
+    """Verify that triple-quoted strings inside inline tables in pyproject.toml are handled."""
+    content = b"""
+[tool.pdm.scripts]
+test = { shell = \"\"\"echo "triple"\"\"\" }
+test2 = { cmd = '''echo 'triple2' ''' }
+"""
+    results = list(unpack_content("pyproject.toml", content))
+    scripts = {s[0]: s[1].decode() for s in results}
+
+    assert "pyproject.toml [Script: test]" in scripts
+    assert 'echo "triple"' in scripts["pyproject.toml [Script: test]"]
+    assert "pyproject.toml [Script: test2]" in scripts
+    assert "echo 'triple2'" in scripts["pyproject.toml [Script: test2]"]


### PR DESCRIPTION
**PR Title:** [TEST] Add support for triple-quoted strings in pyproject.toml inline tables

**Description:**
* **Type:** Gap Analysis / Bug Fix
* **What:** Added regex support for triple-double quotes (`"""`) and triple-single quotes (`'''`) inside `pyproject.toml` inline tables (e.g., `test = { shell = """echo "hi" """ }`). Previously, these were missed by the heuristic parser. I also added a new test file `tests/test_pyproject_inline_triple.py` to verify the fix and prevent regressions.
* **Why:** `pyproject.toml` is a key manifest for Python projects. Tools like PDM and Poe the Poet use inline tables for task definitions, which often contain complex, multi-line, or nested-quote commands that require triple quotes. Supporting this ensures better coverage of potentially malicious scripts in build manifests.

---
*PR created automatically by Jules for task [6385450359221542687](https://jules.google.com/task/6385450359221542687) started by @RainRat*