### PR TITLE
[UI/UX] Refine CLI triage report visual hierarchy and AI analysis formatting

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5017,14 +5017,16 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
 
         # Consolidate AI analysis
         if admin or user:
-            analysis_parts = []
+            lines.append("")
             if admin:
-                clean_admin = admin.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}Admin:{RESET} {clean_admin}")
+                for line in admin.strip().splitlines():
+                    lines.append(f"    {GRAY}Admin:{RESET} {line}")
             if user:
-                clean_user = user.strip().replace('\n', ' ')
-                analysis_parts.append(f"{GRAY}User:{RESET} {clean_user}")
-            lines.append(f"    {'  '.join(analysis_parts)}")
+                if admin:
+                    lines.append("")
+                for line in user.strip().splitlines():
+                    lines.append(f"    {GRAY}User:{RESET} {line}")
+            lines.append("")
 
         # Snippet preview (up to 3 lines)
         snippet_lines = snippet.strip().split('\n')[:3]

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -132,7 +132,8 @@ def test_generate_console_report():
     report = gptscan.generate_console_report(results, use_color=False)
     assert "--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---" in report
     assert "Local: 90%  AI: 95%  VT: https://www.virustotal.com/gui/file/" in report
-    assert "Admin: Admin note  User: User note" in report
+    assert "Admin: Admin note" in report
+    assert "User: User note" in report
     assert "> dangerous_code()" in report
     assert "[2] LOW RISK - safe.py:1" in report
     assert "Local: 10%" in report
@@ -149,4 +150,5 @@ def test_generate_console_report():
     assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color
     # Verify AI notes and snippets are NOT bolded
     assert "\033[0;90mAdmin:\033[0m Admin note" in report_color
+    assert "\033[0;90mUser:\033[0m User note" in report_color
     assert "\033[0;90m> dangerous_code()\033[0m" in report_color


### PR DESCRIPTION
### Context
CLI

### Problem
The CLI triage report previously squashed multi-line AI analysis notes into a single line, making them difficult to read. Additionally, the lack of vertical spacing between different sections (metadata, analysis, snippet) resulted in visual clutter that hindered quick triage.

### Solution
Improved the report structure by preserving newlines in AI notes and rendering each line with a gray label (`Admin:` or `User:`) to maintain context. Strategic blank lines were added to separate the metadata section from the analysis, and the analysis from the code snippet. This creates a clear visual hierarchy that helps users distinguish between local scores, AI feedback, and the actual code.

### Changes
Modified `generate_console_report` in `gptscan.py` and updated `tests/test_reporting_features.py`.

---
*PR created automatically by Jules for task [17414644930945159462](https://jules.google.com/task/17414644930945159462) started by @RainRat*