### PR TITLE
Expand system scans to include Ruby, PHP, Rust, Go, and Documents

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1228,6 +1228,138 @@ def get_temp_paths() -> List[str]:
     return sorted(_normalize_and_filter_dirs(paths))
 
 
+def get_ruby_gems_paths() -> List[str]:
+    """Find all folders containing installed Ruby gems."""
+    paths = []
+    # 1. Check GEM_HOME environment variable
+    gem_home = os.environ.get("GEM_HOME")
+    if gem_home:
+        paths.append(gem_home)
+
+    # 2. Ask gem for the home directory
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['gem', 'env', 'home'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            paths.append(output)
+    except Exception:
+        pass
+
+    # 3. Common fallback paths
+    if sys.platform != "win32":
+        paths.extend([
+            "/usr/local/lib/ruby/gems",
+            "/usr/lib/ruby/gems"
+        ])
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_php_packages_paths() -> List[str]:
+    """Find all folders containing global PHP Composer packages."""
+    paths = []
+    # 1. Ask composer for the global vendor directory
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['composer', 'global', 'config', 'vendor-dir', '--absolute'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            paths.append(output)
+    except Exception:
+        pass
+
+    # 2. Common fallback paths
+    home = Path.home()
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            paths.append(os.path.join(appdata, "Composer", "vendor"))
+    else:
+        paths.append(str(home / ".composer" / "vendor"))
+        paths.append(str(home / ".config" / "composer" / "vendor"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_rust_packages_paths() -> List[str]:
+    """Find all folders containing global Rust Cargo packages."""
+    paths = []
+    # 1. Check CARGO_HOME environment variable
+    cargo_home = os.environ.get("CARGO_HOME")
+    if cargo_home:
+        paths.append(os.path.join(cargo_home, "registry", "src"))
+        paths.append(os.path.join(cargo_home, "git", "checkouts"))
+
+    # 2. Default home directory location
+    home = Path.home()
+    cargo_default = home / ".cargo"
+    paths.append(str(cargo_default / "registry" / "src"))
+    paths.append(str(cargo_default / "git" / "checkouts"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_go_packages_paths() -> List[str]:
+    """Find all folders containing Go packages (GOPATH)."""
+    paths = []
+    # 1. Check GOPATH environment variable
+    gopath = os.environ.get("GOPATH")
+    if gopath:
+        for p in gopath.split(os.pathsep):
+            if p:
+                paths.append(os.path.join(p, "pkg", "mod"))
+                paths.append(os.path.join(p, "src"))
+
+    # 2. Ask go for the GOPATH
+    try:
+        is_win = sys.platform == "win32"
+        output = subprocess.check_output(['go', 'env', 'GOPATH'],
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        shell=is_win).strip()
+        if output:
+            for p in output.split(os.pathsep):
+                if p:
+                    paths.append(os.path.join(p, "pkg", "mod"))
+                    paths.append(os.path.join(p, "src"))
+    except Exception:
+        pass
+
+    # 3. Default location
+    home = Path.home()
+    paths.append(str(home / "go" / "pkg" / "mod"))
+    paths.append(str(home / "go" / "src"))
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
+def get_documents_paths() -> List[str]:
+    """Find the user's Documents folder."""
+    paths = []
+    home = Path.home()
+    docs = home / "Documents"
+    if docs.exists():
+        paths.append(str(docs))
+
+    # Windows specific (might be redirected)
+    if sys.platform == "win32":
+        try:
+            import winreg
+            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders")
+            docs_path, _ = winreg.QueryValueEx(key, "Personal")
+            if docs_path:
+                paths.append(docs_path)
+        except Exception:
+            pass
+
+    return sorted(_normalize_and_filter_dirs(paths))
+
+
 def get_running_process_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all running processes."""
     processes = []
@@ -2902,6 +3034,71 @@ def scan_temp_click():
         messagebox.showwarning("Temporary Folders Error", f"Could not scan temporary folders: {e}")
 
 
+def scan_ruby_gems_click():
+    """Scan all folders containing installed Ruby gems."""
+    try:
+        paths = get_ruby_gems_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Ruby Gems", "No Ruby gems folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Ruby Gems Error", f"Could not scan Ruby gems: {e}")
+
+
+def scan_php_packages_click():
+    """Scan all folders containing global PHP Composer packages."""
+    try:
+        paths = get_php_packages_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("PHP Packages", "No global PHP package folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("PHP Packages Error", f"Could not scan PHP packages: {e}")
+
+
+def scan_rust_packages_click():
+    """Scan all folders containing global Rust Cargo packages."""
+    try:
+        paths = get_rust_packages_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Rust Packages", "No global Rust package folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Rust Packages Error", f"Could not scan Rust packages: {e}")
+
+
+def scan_go_packages_click():
+    """Scan all folders containing Go packages (GOPATH)."""
+    try:
+        paths = get_go_packages_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Go Packages", "No Go package folders were found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Go Packages Error", f"Could not scan Go packages: {e}")
+
+
+def scan_documents_click():
+    """Scan the user's Documents folder."""
+    try:
+        paths = get_documents_paths()
+        if paths:
+            _set_scan_target(paths)
+            button_click()
+        else:
+            messagebox.showinfo("Documents", "The standard Documents folder was not found on this system.")
+    except Exception as e:
+        messagebox.showwarning("Documents Error", f"Could not scan Documents: {e}")
+
+
 def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     """Collect all paths and snippets for a comprehensive system audit."""
     all_paths = []
@@ -2913,8 +3110,13 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_paths.extend(get_git_hooks_paths())
     all_paths.extend(get_python_package_paths())
     all_paths.extend(get_nodejs_package_paths())
+    all_paths.extend(get_ruby_gems_paths())
+    all_paths.extend(get_php_packages_paths())
+    all_paths.extend(get_rust_packages_paths())
+    all_paths.extend(get_go_packages_paths())
     all_paths.extend(get_browser_extensions_paths())
     all_paths.extend(get_editor_extensions_paths())
+    all_paths.extend(get_documents_paths())
     all_paths.extend(get_downloads_paths())
     all_paths.extend(get_desktop_paths())
     all_paths.extend(get_temp_paths())
@@ -7258,8 +7460,13 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     system_menu.add_command(label="Scan SSH Configuration", command=scan_ssh_config_click, accelerator="Ctrl+Shift+R")
     system_menu.add_command(label="Scan Python Packages", command=scan_python_packages_click, accelerator="Ctrl+Shift+Y")
     system_menu.add_command(label="Scan Node.js Packages", command=scan_nodejs_packages_click, accelerator="Ctrl+Shift+M")
+    system_menu.add_command(label="Scan Ruby Gems", command=scan_ruby_gems_click)
+    system_menu.add_command(label="Scan PHP Packages", command=scan_php_packages_click)
+    system_menu.add_command(label="Scan Rust Packages", command=scan_rust_packages_click)
+    system_menu.add_command(label="Scan Go Packages", command=scan_go_packages_click)
     system_menu.add_command(label="Scan Browser Extensions", command=scan_browser_extensions_click, accelerator="Ctrl+Shift+W")
     system_menu.add_command(label="Scan Editor Extensions", command=scan_editor_extensions_click, accelerator="Ctrl+Shift+X")
+    system_menu.add_command(label="Scan Documents", command=scan_documents_click)
     system_menu.add_command(label="Scan Downloads", command=scan_downloads_click, accelerator="Ctrl+Shift+J")
     system_menu.add_command(label="Scan Desktop", command=scan_desktop_click, accelerator="Ctrl+Shift+L")
     system_menu.add_command(label="Scan Temporary Folders", command=scan_temp_click, accelerator="Ctrl+Shift+Z")
@@ -7916,6 +8123,31 @@ def main():
         help='Scan all non-empty environment variables.'
     )
     system_group.add_argument(
+        '--ruby-gems',
+        action='store_true',
+        help='Scan all folders containing installed Ruby gems.'
+    )
+    system_group.add_argument(
+        '--php-packages',
+        action='store_true',
+        help='Scan all folders containing global PHP Composer packages.'
+    )
+    system_group.add_argument(
+        '--rust-packages',
+        action='store_true',
+        help='Scan all folders containing global Rust Cargo packages.'
+    )
+    system_group.add_argument(
+        '--go-packages',
+        action='store_true',
+        help='Scan all folders containing Go packages.'
+    )
+    system_group.add_argument(
+        '--documents',
+        action='store_true',
+        help="Scan the user's Documents folder."
+    )
+    system_group.add_argument(
         '--temp',
         action='store_true',
         help='Scan common temporary folders.'
@@ -7980,7 +8212,11 @@ def main():
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
             args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
-            args.system_services, args.audit, args.modified
+            args.system_services, args.audit, args.modified, args.git_stash,
+            args.downloads, args.desktop, args.python_packages, args.nodejs_packages,
+            args.ruby_gems, args.php_packages, args.rust_packages, args.go_packages,
+            args.documents, args.browser_extensions, args.editor_extensions,
+            args.ssh_config, args.temp
         ]):
             sys.exit(0)
 
@@ -8198,6 +8434,37 @@ def main():
                 scan_targets.extend(ssh_paths)
             else:
                 print("No SSH configuration or authorized_keys files were found.", file=sys.stderr)
+
+        if args.ruby_gems:
+            gem_paths = get_ruby_gems_paths()
+            if gem_paths:
+                scan_targets.extend(gem_paths)
+            else:
+                print("No Ruby gems folders were found.", file=sys.stderr)
+
+        if args.php_packages:
+            php_paths = get_php_packages_paths()
+            if php_paths:
+                scan_targets.extend(php_paths)
+            else:
+                print("No global PHP package folders were found.", file=sys.stderr)
+
+        if args.rust_packages:
+            rust_paths = get_rust_packages_paths()
+            if rust_paths:
+                scan_targets.extend(rust_paths)
+            else:
+                print("No global Rust package folders were found.", file=sys.stderr)
+
+        if args.go_packages:
+            go_paths = get_go_packages_paths()
+            if go_paths:
+                scan_targets.extend(go_paths)
+            else:
+                print("No Go package folders were found.", file=sys.stderr)
+
+        if args.documents:
+            scan_targets.extend(get_documents_paths())
 
         if args.env_vars:
             snippets = get_environment_variable_snippets()

--- a/readme.md
+++ b/readme.md
@@ -80,8 +80,13 @@ Access these options from the **Browse** menu:
 *   **Scan SSH Configuration (Ctrl+Shift+R):** Scan all common SSH configuration and authorized_keys files.
 *   **Scan Python Packages (Ctrl+Shift+Y):** Scan your installed Python packages for malicious code.
 *   **Scan Node.js Packages (Ctrl+Shift+M):** Scan your global Node.js packages.
+*   **Scan Ruby Gems:** Scan all folders containing installed Ruby gems.
+*   **Scan PHP Packages:** Scan all folders containing global PHP Composer packages.
+*   **Scan Rust Packages:** Scan all folders containing global Rust Cargo packages.
+*   **Scan Go Packages:** Scan all folders containing Go packages.
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
+*   **Scan Documents:** Scan your standard Documents folder for suspicious files.
 *   **Scan Downloads (Ctrl+Shift+J):** Scan your standard Downloads folder for suspicious files.
 *   **Scan Desktop (Ctrl+Shift+L):** Scan your standard Desktop folder for suspicious files.
 *   **Scan Temporary Folders (Ctrl+Shift+Z):** Scan common temporary folders for suspicious files.
@@ -190,6 +195,26 @@ Scan all folders containing global Node.js packages:
 python3 gptscan.py --nodejs-packages --cli
 ```
 
+Scan all folders containing installed Ruby gems:
+```bash
+python3 gptscan.py --ruby-gems --cli
+```
+
+Scan all folders containing global PHP Composer packages:
+```bash
+python3 gptscan.py --php-packages --cli
+```
+
+Scan all folders containing global Rust Cargo packages:
+```bash
+python3 gptscan.py --rust-packages --cli
+```
+
+Scan all folders containing Go packages:
+```bash
+python3 gptscan.py --go-packages --cli
+```
+
 Scan all common browser extension folders:
 ```bash
 python3 gptscan.py --browser-extensions --cli
@@ -248,6 +273,11 @@ python3 gptscan.py --system-services --cli
 Scan SSH configuration and authorized keys:
 ```bash
 python3 gptscan.py --ssh-config --cli
+```
+
+Scan your standard Documents folder:
+```bash
+python3 gptscan.py --documents --cli
 ```
 
 Scan common temporary folders:

--- a/tests/test_system_audit.py
+++ b/tests/test_system_audit.py
@@ -17,6 +17,11 @@ def test_scan_system_audit_click(monkeypatch):
     monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: ["/hook1"])
     monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [("git", b"conf")])
     monkeypatch.setattr("gptscan.get_python_package_paths", lambda: ["/pkg1"])
+    monkeypatch.setattr("gptscan.get_ruby_gems_paths", lambda: ["/ruby1"])
+    monkeypatch.setattr("gptscan.get_php_packages_paths", lambda: ["/php1"])
+    monkeypatch.setattr("gptscan.get_rust_packages_paths", lambda: ["/rust1"])
+    monkeypatch.setattr("gptscan.get_go_packages_paths", lambda: ["/go1"])
+    monkeypatch.setattr("gptscan.get_documents_paths", lambda: ["/docs1"])
 
     target_paths = []
     def mock_set_target(paths):
@@ -44,6 +49,11 @@ def test_scan_system_audit_click(monkeypatch):
     assert "/ser1" in target_paths
     assert "/hook1" in target_paths
     assert "/pkg1" in target_paths
+    assert "/ruby1" in target_paths
+    assert "/php1" in target_paths
+    assert "/rust1" in target_paths
+    assert "/go1" in target_paths
+    assert "/docs1" in target_paths
 
     assert clicked
     assert snippets_count == 6
@@ -62,6 +72,11 @@ def test_cli_audit_flag(monkeypatch):
     monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: [])
     monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [])
     monkeypatch.setattr("gptscan.get_python_package_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_ruby_gems_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_php_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_rust_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_go_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_documents_paths", lambda: [])
 
     cli_args = []
     def mock_run_cli(targets, *args, **kwargs):


### PR DESCRIPTION
Expanded the scanner's reach by adding support for several new system-level targets. Users can now scan their installed Ruby gems, PHP (Composer) packages, Rust (Cargo) packages, Go packages, and their standard Documents folder. These new targets have been integrated into both the GUI and CLI, and are included in the comprehensive System Audit. Documentation and tests have been updated to reflect these additions.

---
*PR created automatically by Jules for task [16295307039435984859](https://jules.google.com/task/16295307039435984859) started by @RainRat*