### PR TITLE
[UI/UX] Improve CLI report visual hierarchy and readability

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5217,7 +5217,7 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             risk_label = f"{GRAY}LOW RISK{RESET}"
 
         location = f"{path}:{line_num}" if line_num != "-" else path
-        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")
+        lines.append(f"{GRAY}[{i}]{RESET} {risk_label} - {BOLD}{location}{RESET}")
 
         # Consolidate scores and links
         meta_parts = [f"{GRAY}Local:{RESET} {color_conf(own_conf)}"]
@@ -5248,11 +5248,13 @@ def generate_console_report(results: List[Dict[str, Any]], use_color: bool = Fal
             lines.append("")
 
         # Snippet preview (up to 3 lines)
+        cols = shutil.get_terminal_size((80, 20)).columns
+        max_snippet_len = max(20, cols - 8)
         snippet_lines = snippet.strip().split('\n')[:3]
         for sl in snippet_lines:
-            if len(sl) > 100:
-                sl = sl[:97] + "..."
-            lines.append(f"    {GRAY}> {sl}{RESET}")
+            if len(sl) > max_snippet_len:
+                sl = sl[:max_snippet_len - 3] + "..."
+            lines.append(f"    {GRAY}>{RESET} {sl}")
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -145,10 +145,13 @@ def test_generate_console_report():
     assert "\033[0;90mLOW RISK\033[0m" in report_color
     # Verify dimmed index
     assert "\033[0;90m[1]\033[0m" in report_color
+    # Verify location is bolded
+    assert "\033[1msuspicious.py:10\033[0m" in report_color
     # Verify dimmed labels and emphasized values (scores >= 50%)
     assert "\033[0;90mLocal:\033[0m \033[1;91m\033[1m90%\033[0m" in report_color
     assert "\033[0;90mAI:\033[0m \033[1;91m\033[1m95%\033[0m" in report_color
-    # Verify AI notes and snippets are NOT bolded
+    # Verify AI notes are NOT bolded
     assert "\033[0;90mAdmin:\033[0m Admin note" in report_color
     assert "\033[0;90mUser:\033[0m User note" in report_color
-    assert "\033[0;90m> dangerous_code()\033[0m" in report_color
+    # Verify snippet has dimmed prefix but default color for content
+    assert "\033[0;90m>\033[0m dangerous_code()" in report_color


### PR DESCRIPTION
### PR Title: [UI/UX] Improve CLI report visual hierarchy and readability

### Description
* **Context:** CLI
* **Problem:** The console triage report had a suboptimal visual hierarchy. The risk label was bolded instead of the file location, making it harder for users to quickly identify the source of the issue. Additionally, code snippets were dimmed in gray, which reduced legibility and could clash with certain terminal themes. Finally, snippet truncation was hardcoded to 100 characters, which might not fit well on smaller terminal windows.
* **Solution:**
    * **Visual Hierarchy:** Shifted the `BOLD` emphasis from the risk label to the file location (`path:line_num`). This ensures the most actionable information stands out.
    * **Legibility:** Updated the code snippet preview to only dim the `>` prefix, keeping the actual code content in the default terminal color. This improves readability and respects user-defined syntax highlighting/themes.
    * **Responsiveness:** Integrated `shutil.get_terminal_size()` to dynamically calculate the maximum snippet width based on the current terminal window, ensuring a polished look across different environments.

### Changes
```python
# gptscan.py

<<<<<<< SEARCH
        location = f"{path}:{line_num}" if line_num != "-" else path
        lines.append(f"{GRAY}[{i}]{RESET} {BOLD}{risk_label} - {location}{RESET}")

        # Consolidate scores and links
=======
        location = f"{path}:{line_num}" if line_num != "-" else path
        lines.append(f"{GRAY}[{i}]{RESET} {risk_label} - {BOLD}{location}{RESET}")

        # Consolidate scores and links
>>>>>>> REPLACE

...

<<<<<<< SEARCH
        # Snippet preview (up to 3 lines)
        snippet_lines = snippet.strip().split('\n')[:3]
        for sl in snippet_lines:
            if len(sl) > 100:
                sl = sl[:97] + "..."
            lines.append(f"    {GRAY}> {sl}{RESET}")
        lines.append("")
=======
        # Snippet preview (up to 3 lines)
        cols = shutil.get_terminal_size((80, 20)).columns
        max_snippet_len = max(20, cols - 8)
        snippet_lines = snippet.strip().split('\n')[:3]
        for sl in snippet_lines:
            if len(sl) > max_snippet_len:
                sl = sl[:max_snippet_len - 3] + "..."
            lines.append(f"    {GRAY}>{RESET} {sl}")
        lines.append("")
>>>>>>> REPLACE
```

```python
# tests/test_reporting_features.py

<<<<<<< SEARCH
    # Verify location is bolded (This was missing in the previous test version)
    # Verify AI notes and snippets are NOT bolded
    assert "\033[0;90mAdmin:\033[0m Admin note" in report_color
    assert "\033[0;90mUser:\033[0m User note" in report_color
    assert "\033[0;90m> dangerous_code()\033[0m" in report_color
=======
    # Verify location is bolded
    assert "\033[1msuspicious.py:10\033[0m" in report_color
    # Verify AI notes are NOT bolded
    assert "\033[0;90mAdmin:\033[0m Admin note" in report_color
    assert "\033[0;90mUser:\033[0m User note" in report_color
    # Verify snippet has dimmed prefix but default color for content
    assert "\033[0;90m>\033[0m dangerous_code()" in report_color
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [12370931298285342744](https://jules.google.com/task/12370931298285342744) started by @RainRat*