### PR TITLE
[Refactor] Inline redundant path resolution helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6313,28 +6313,6 @@ def _get_item_raw_values(item_id: str) -> Optional[List[Any]]:
     return [str(v).replace('\n', ' ') for v in values[:7]]
 
 
-def _resolve_file_path(event_or_path: Union[tk.Event, str, None], verify: bool = True, show_warning: bool = True) -> Optional[str]:
-    """Retrieve and optionally verify a file path from an event or direct argument."""
-    if isinstance(event_or_path, str):
-        file_path = event_or_path
-    else:
-        if not tree:
-            return None
-        selection = tree.selection()
-        if not selection:
-            return None
-        values = _get_item_raw_values(selection[0])
-        if not values:
-            return None
-        file_path = str(values[0])
-
-    if verify and not file_path.startswith("[") and not file_path.startswith(("http://", "https://")) and not os.path.exists(file_path):
-        if show_warning:
-            messagebox.showwarning("File Not Found", f"The file '{file_path}' could not be located.")
-        return None
-    return file_path
-
-
 def _resolve_file_paths(event_or_path: Union[tk.Event, str, None], verify: bool = True) -> List[str]:
     """Retrieve and optionally verify multiple file paths from an event or direct argument."""
     targets = []
@@ -6351,9 +6329,9 @@ def _resolve_file_paths(event_or_path: Union[tk.Event, str, None], verify: bool 
 
     valid_paths = []
     for path in targets:
-        resolved = _resolve_file_path(path, verify=verify, show_warning=False)
-        if resolved is not None:
-            valid_paths.append(resolved)
+        if verify and not path.startswith("[") and not path.startswith(("http://", "https://")) and not os.path.exists(path):
+            continue
+        valid_paths.append(path)
 
     if verify and targets and not valid_paths:
         messagebox.showwarning("Files Not Found", "The selected file(s) could not be located on disk.")

--- a/temp_test_cli/safe.py
+++ b/temp_test_cli/safe.py
@@ -1,0 +1,1 @@
+print('safe')

--- a/tests/test_resolve_path.py
+++ b/tests/test_resolve_path.py
@@ -20,23 +20,23 @@ def mock_tree(monkeypatch):
     mock_tree.selection.return_value = []
     return mock_tree
 
-def test_resolve_file_path_from_string_exists(tmp_path):
+def test_resolve_file_paths_from_string_exists(tmp_path):
     f = tmp_path / "exists.py"
     f.touch()
 
-    result = gptscan._resolve_file_path(str(f))
-    assert result == str(f)
+    result = gptscan._resolve_file_paths(str(f))
+    assert result == [str(f)]
 
-def test_resolve_file_path_from_string_not_found(monkeypatch):
+def test_resolve_file_paths_from_string_not_found(monkeypatch):
     mock_msgbox = MagicMock()
     monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
 
-    result = gptscan._resolve_file_path("non_existent.py")
+    result = gptscan._resolve_file_paths("non_existent.py")
 
-    assert result is None
-    mock_msgbox.showwarning.assert_called_with("File Not Found", "The file 'non_existent.py' could not be located.")
+    assert result == []
+    mock_msgbox.showwarning.assert_called_with("Files Not Found", "The selected file(s) could not be located on disk.")
 
-def test_resolve_file_path_from_selection_exists(mock_tree, tmp_path):
+def test_resolve_file_paths_from_selection_exists(mock_tree, tmp_path):
     f = tmp_path / "selection.py"
     f.touch()
 
@@ -44,31 +44,31 @@ def test_resolve_file_path_from_selection_exists(mock_tree, tmp_path):
     raw_values = [str(f), "90%", "", "", "", "print('hi')", "1"]
     mock_tree._item_values["item1"] = list(raw_values) + [json.dumps(raw_values)]
 
-    result = gptscan._resolve_file_path(None)
-    assert result == str(f)
+    result = gptscan._resolve_file_paths(None)
+    assert result == [str(f)]
 
-def test_resolve_file_path_no_selection(mock_tree):
+def test_resolve_file_paths_no_selection(mock_tree):
     mock_tree.selection.return_value = []
-    result = gptscan._resolve_file_path(None)
-    assert result is None
+    result = gptscan._resolve_file_paths(None)
+    assert result == []
 
-def test_resolve_file_path_virtual_prefix():
+def test_resolve_file_paths_virtual_prefix():
     # Paths starting with '[' should bypass existence check
     path = "[Clipboard]"
-    result = gptscan._resolve_file_path(path)
-    assert result == path
+    result = gptscan._resolve_file_paths(path)
+    assert result == [path]
 
-def test_resolve_file_path_url_bypass(monkeypatch):
+def test_resolve_file_paths_url_bypass(monkeypatch):
     mock_msgbox = MagicMock()
     monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
 
     url = "https://example.com/script.py"
-    result = gptscan._resolve_file_path(url)
+    result = gptscan._resolve_file_paths(url)
 
-    assert result == url
+    assert result == [url]
     mock_msgbox.showwarning.assert_not_called()
 
-def test_resolve_file_path_no_verify(tmp_path):
+def test_resolve_file_paths_no_verify(tmp_path):
     path = str(tmp_path / "not_there.py")
-    result = gptscan._resolve_file_path(path, verify=False)
-    assert result == path
+    result = gptscan._resolve_file_paths(path, verify=False)
+    assert result == [path]


### PR DESCRIPTION
* **What:** Inlined the private helper function `_resolve_file_path` into its primary caller `_resolve_file_paths` and removed the definition of the former.
* **Why:** This resolves a case of **Premature Abstraction**. Consolidating the path verification and selection logic into `_resolve_file_paths` makes the code cleaner and easier to maintain. verified that external behavior remains identical and all relevant tests pass.

---
*PR created automatically by Jules for task [8367182086747474785](https://jules.google.com/task/8367182086747474785) started by @RainRat*