### PR TITLE
[TEST] [Improve Linux system scan command extraction and add systemd service support]

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1422,7 +1422,8 @@ def get_running_process_commands() -> List[Tuple[str, bytes]]:
             lines = output.splitlines()
             for line in lines[1:]:
                 line = line.strip()
-                if line and not line.startswith('[') and not line.endswith(']'): # Filter out kernel threads
+                # Filter out kernel threads, which typically appear as [name] with no spaces
+                if line and not (line.startswith('[') and line.endswith(']') and ' ' not in line):
                     # Use the first part of the command as a name hint
                     name = line.split()[0] if line.split() else "Unknown"
                     processes.append((f"[Process] {os.path.basename(name)}", line.encode('utf-8')))
@@ -1624,7 +1625,7 @@ def get_nodejs_package_paths() -> List[str]:
 
 
 def get_system_service_commands() -> List[Tuple[str, bytes]]:
-    """Collect command lines of all system services (Windows Service PathName)."""
+    """Collect command lines of all system services (Windows Service PathName, Linux systemd Exec)."""
     items = []
     try:
         if sys.platform == "win32":
@@ -1641,6 +1642,31 @@ def get_system_service_commands() -> List[Tuple[str, bytes]]:
                     command = item.get("PathName")
                     if command and command.strip():
                         items.append((f"[Service] {name}", command.encode('utf-8')))
+        elif sys.platform == "linux":
+            # Linux - Scan systemd service files for Exec* commands
+            for p in get_system_service_paths():
+                try:
+                    with open(p, "r", encoding="utf-8", errors="ignore") as f:
+                        current_command = ""
+                        for line in f:
+                            line = line.strip()
+                            if current_command:
+                                if line.endswith("\\"):
+                                    current_command += " " + line[:-1].strip()
+                                else:
+                                    current_command += " " + line
+                                    items.append((f"[Service] {os.path.basename(p)}", current_command.encode('utf-8')))
+                                    current_command = ""
+                            elif line.startswith(("ExecStart=", "ExecStartPre=", "ExecStartPost=", "ExecReload=", "ExecStop=", "ExecStopPost=")):
+                                if line.endswith("\\"):
+                                    val = line.split("=", 1)[1].strip()
+                                    current_command = val[:-1].strip()
+                                else:
+                                    command = line.split("=", 1)[1].strip()
+                                    if command:
+                                        items.append((f"[Service] {os.path.basename(p)}", command.encode('utf-8')))
+                except Exception:
+                    pass
     except Exception:
         pass
     return items
@@ -1750,7 +1776,8 @@ def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
                         with open(cron_path, "r", encoding="utf-8", errors="ignore") as f:
                             for line in f:
                                 line = line.strip()
-                                if line and not line.startswith('#') and '=' not in line:
+                                # Skip comments and environment variable assignments (e.g. PATH=...)
+                                if line and not line.startswith('#') and not re.match(r'^[A-Za-z_][A-Za-z0-9_]*\s*=', line):
                                     # System crontab: min hour day month dow user command
                                     parts = line.split(None, 6)
                                     if len(parts) > 6:

--- a/tests/test_running_processes.py
+++ b/tests/test_running_processes.py
@@ -7,17 +7,19 @@ import os
 from gptscan import get_running_process_commands, scan_running_processes_click
 
 def test_get_running_process_commands_linux():
-    mock_output = "ARGS\n/usr/bin/python3 gptscan.py\n[kthreadd]\n/usr/lib/systemd/systemd --user\n"
+    mock_output = "ARGS\n/usr/bin/python3 gptscan.py\n[kthreadd]\n/usr/lib/systemd/systemd --user\n[ -f /etc/passwd ]\n"
     with patch("sys.platform", "linux"):
         with patch("subprocess.check_output", return_value=mock_output):
             processes = get_running_process_commands()
 
-            # Should have python3 and systemd, but not kthreadd (kernel thread) or header
-            assert len(processes) == 2
+            # Should have python3, systemd, and [, but not kthreadd (kernel thread) or header
+            assert len(processes) == 3
             assert processes[0][0] == "[Process] python3"
             assert processes[0][1] == b"/usr/bin/python3 gptscan.py"
             assert processes[1][0] == "[Process] systemd"
             assert processes[1][1] == b"/usr/lib/systemd/systemd --user"
+            assert processes[2][0] == "[Process] ["
+            assert processes[2][1] == b"[ -f /etc/passwd ]"
 
 def test_get_running_process_commands_windows():
     mock_json = json.dumps([

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -7,8 +7,9 @@ from gptscan import get_scheduled_task_commands, scan_scheduled_tasks_click
 
 def test_get_scheduled_task_commands_linux_all():
     mock_crontab_l = "# Some comment\n* * * * * /usr/bin/python3 /path/to/script.py\n@daily /usr/bin/cleanup.sh\n"
-    mock_etc_crontab = "17 *	* * *	root    cd / && run-parts --report /etc/cron.hourly\n"
-    mock_cron_d_file = "30 4	* * *	user    /usr/local/bin/daily_backup.sh\n@reboot root /usr/bin/reboot_task\n"
+    # System crontab with environmental variables and commands containing '='
+    mock_etc_crontab = "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\n17 *	* * *	root    cd / && run-parts --report /etc/cron.hourly\n"
+    mock_cron_d_file = "30 4	* * *	user    /usr/local/bin/daily_backup.sh --option=value\n@reboot root /usr/bin/reboot_task\n"
 
     with patch("sys.platform", "linux"):
         with patch("subprocess.check_output", return_value=mock_crontab_l):
@@ -55,7 +56,7 @@ def test_get_scheduled_task_commands_linux_all():
                         assert tasks[0] == ("[Cron] User", b"/usr/bin/python3 /path/to/script.py")
                         assert tasks[1] == ("[Cron] User", b"/usr/bin/cleanup.sh")
                         assert tasks[2] == ("[Cron] System (crontab)", b"cd / && run-parts --report /etc/cron.hourly")
-                        assert tasks[3] == ("[Cron] System (test_task)", b"/usr/local/bin/daily_backup.sh")
+                        assert tasks[3] == ("[Cron] System (test_task)", b"/usr/local/bin/daily_backup.sh --option=value")
                         assert tasks[4] == ("[Cron] System (test_task)", b"/usr/bin/reboot_task")
 
 def test_get_scheduled_task_commands_windows():

--- a/tests/test_system_service_commands.py
+++ b/tests/test_system_service_commands.py
@@ -50,7 +50,32 @@ def test_get_system_service_commands_windows_error():
         results = gptscan.get_system_service_commands()
         assert results == []
 
-def test_get_system_service_commands_non_windows():
-    with patch("sys.platform", "linux"):
+def test_get_system_service_commands_linux(tmp_path):
+    # Mock systemd service files
+    service_dir = tmp_path / "systemd"
+    service_dir.mkdir()
+
+    service_file = service_dir / "test.service"
+    service_file.write_text(
+        "[Unit]\nDescription=Test\n"
+        "[Service]\n"
+        "ExecStart=/usr/bin/test-cmd --arg1 \\\n  --arg2\n"
+        "ExecStartPost=/usr/bin/post-cmd\n"
+        "Environment=FOO=BAR\n"
+    )
+
+    with patch("sys.platform", "linux"), \
+         patch("gptscan.get_system_service_paths", return_value=[str(service_file)]):
+
+        results = gptscan.get_system_service_commands()
+
+        assert len(results) == 2
+        # Check multiline command
+        assert results[0] == ("[Service] test.service", b"/usr/bin/test-cmd --arg1 --arg2")
+        # Check single line command
+        assert results[1] == ("[Service] test.service", b"/usr/bin/post-cmd")
+
+def test_get_system_service_commands_non_supported():
+    with patch("sys.platform", "darwin"):
         results = gptscan.get_system_service_commands()
         assert results == []


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** 
    - Added Linux support to `get_system_service_commands` to extract command lines from systemd service files, including support for multiline `Exec*` entries using backslash continuation.
    - Refined the kernel thread filter in `get_running_process_commands` to correctly allow commands like `[` while still excluding standard kernel threads (e.g., `[kthreadd]`).
    - Fixed a bug in `get_scheduled_task_commands` where system crontab entries containing `=` (e.g., long options or commands with flags) were incorrectly skipped as environment variable assignments.
    - Expanded the test suite with new cases for these scenarios in `tests/test_system_service_commands.py`, `tests/test_running_processes.py`, and `tests/test_scheduled_tasks.py`.
* **Why:** 
    - Gap Analysis identified that while Windows services were scanned, Linux systemd services were completely ignored for command-line extraction.
    - Testing revealed logic errors in crontab and process parsing that led to false negatives for legitimate (and potentially suspicious) commands.

---
*PR created automatically by Jules for task [13440300866208314480](https://jules.google.com/task/13440300866208314480) started by @RainRat*