### PR TITLE
[DOCS] Document Java and .NET package scanning features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,8 @@ Access these options from the **Browse** menu:
 *   **Scan PHP Packages:** Scan all folders containing global PHP Composer packages.
 *   **Scan Rust Packages:** Scan all folders containing global Rust Cargo packages.
 *   **Scan Go Packages:** Scan all folders containing Go packages.
+*   **Scan Java Packages:** Scan all folders containing Java package caches (Maven and Gradle).
+*   **Scan .NET Packages:** Scan all folders containing global .NET NuGet package caches.
 *   **Scan Browser Extensions (Ctrl+Shift+W):** Scan your browser extension folders for malicious scripts.
 *   **Scan Editor Extensions (Ctrl+Shift+X):** Scan extensions for VS Code, Sublime Text, and Vim.
 *   **Scan Documents:** Scan your standard Documents folder for suspicious files.
@@ -213,6 +215,16 @@ python3 gptscan.py --rust-packages --cli
 Scan all folders containing Go packages:
 ```bash
 python3 gptscan.py --go-packages --cli
+```
+
+Scan all folders containing Java package caches (Maven and Gradle):
+```bash
+python3 gptscan.py --java-packages --cli
+```
+
+Scan all folders containing global .NET NuGet package caches:
+```bash
+python3 gptscan.py --dotnet-packages --cli
 ```
 
 Scan all common browser extension folders:


### PR DESCRIPTION
Updated `readme.md` to include Java and .NET package scanning features. Added these items to the 'System Scans' list under 'Using the Window (GUI)' and added CLI examples under 'Using the Terminal (CLI)'. This ensures users are aware of the scanner's ability to check Maven, Gradle, and NuGet package caches.

---
*PR created automatically by Jules for task [5649565072910316709](https://jules.google.com/task/5649565072910316709) started by @RainRat*