### PR TITLE
[FEAT] Scan Recent Commits from Git History

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -364,7 +364,7 @@ class Config:
             if content.startswith(b'{') and b'"cells"' in content:
                 return True
             # Detect Unified Diffs by content (e.g. for clipboard scans)
-            if content.startswith(b'--- ') or content.startswith(b'Index: ') or content.startswith(b'diff --git '):
+            if content.startswith(b'--- ') or content.startswith(b'Index: ') or content.startswith(b'diff --git ') or content.startswith(b'commit '):
                 return True
 
         # 2. Check by extension or basename
@@ -1696,6 +1696,29 @@ def get_git_stash_snippets(path: str = ".") -> List[Tuple[str, bytes]]:
     return snippets
 
 
+def get_git_history_snippets(path: str = ".", count: int = 5) -> List[Tuple[str, bytes]]:
+    """Collect patches from the last N commits in Git history."""
+    snippets = []
+    toplevel, _ = _get_git_info(path)
+    if toplevel is None:
+        return []
+
+    try:
+        # Get the full diff for the last N commits
+        output = subprocess.check_output(
+            ["git", "log", "-p", f"-n{count}", "--no-color"],
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+        if output.strip():
+            snippets.append(("[Git History]", output.encode('utf-8')))
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    return snippets
+
+
 def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
     """Collect command lines of all scheduled tasks (Cron on Linux/macOS, schtasks on Windows)."""
     tasks = []
@@ -2824,6 +2847,26 @@ def scan_git_stash_click():
         messagebox.showwarning("Git Stash Error", f"Could not scan Git stashes: {e}")
 
 
+def scan_git_history_click():
+    """Scan patches from recent Git commits."""
+    try:
+        target_path = textbox.get().strip() if textbox else "."
+        if not target_path:
+            target_path = "."
+
+        count = simpledialog.askinteger("Scan Recent Commits", "Enter the number of recent commits to scan:", initialvalue=5, minvalue=1)
+        if count is None:
+            return
+
+        snippets = get_git_history_snippets(target_path, count=count)
+        if snippets:
+            button_click(extra_snippets=snippets)
+        else:
+            messagebox.showinfo("Git History", "No Git history found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Git History Error", f"Could not scan Git history: {e}")
+
+
 def scan_git_revision_click():
     """Scan files changed in a specific Git revision."""
     try:
@@ -3193,6 +3236,7 @@ def get_system_audit_data() -> Tuple[List[str], List[Tuple[str, bytes]]]:
     all_snippets.extend(get_system_service_commands())
     all_snippets.extend(get_git_config_snippets())
     all_snippets.extend(get_git_stash_snippets())
+    all_snippets.extend(get_git_history_snippets())
 
     return all_paths, all_snippets
 
@@ -4254,13 +4298,14 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
 
     # 9. Check for Unified Diff (.diff, .patch, or by content)
     if check_name.lower().endswith(('.diff', '.patch')) or \
-       (content.startswith(b'--- ') or content.startswith(b'Index: ') or content.startswith(b'diff --git ')):
+       (content.startswith(b'--- ') or content.startswith(b'Index: ') or content.startswith(b'diff --git ') or content.startswith(b'commit ')):
         try:
             text = content.decode('utf-8', errors='ignore')
             lines = text.splitlines()
             current_file = None
             hunk_info = None
             hunk_lines = []
+            commit_hash = ""
 
             has_additions = False
 
@@ -4268,11 +4313,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
                 nonlocal has_additions
                 if current_file and hunk_info and hunk_lines and has_additions:
                     hunk_text = "\n".join(hunk_lines)
-                    yield (f"{name} [{current_file} @ {hunk_info}]", hunk_text.encode('utf-8'))
+                    label = f"{name} [{current_file} @ {hunk_info}]"
+                    if commit_hash:
+                        label = f"{name} [{commit_hash}: {current_file} @ {hunk_info}]"
+                    yield (label, hunk_text.encode('utf-8'))
                 has_additions = False
 
             for line in lines:
-                if line.startswith('+++ '):
+                if line.startswith('commit '):
+                    yield from finalize_hunk()
+                    commit_hash = line[7:14].strip()
+                    current_file = None
+                    hunk_info = None
+                    hunk_lines = []
+                elif line.startswith('+++ '):
                     yield from finalize_hunk()
                     path_part = line[4:].split('\t')[0].strip()
                     if path_part.startswith(('a/', 'b/')) and '/' in path_part:
@@ -7474,6 +7528,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         git_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
         git_menu.add_command(label="Scan Git Hooks", command=scan_git_hooks_click, accelerator="Ctrl+Shift+G")
         git_menu.add_command(label="Scan Git Stashes", command=scan_git_stash_click, accelerator="Ctrl+Shift+Q")
+        git_menu.add_command(label="Scan Recent Commits", command=scan_git_history_click)
         git_menu.add_command(label="Scan Git Configuration", command=scan_git_config_click)
         git_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
         parent.add_cascade(label="Git Integration", menu=git_menu)
@@ -8168,6 +8223,13 @@ def main():
         action='store_true',
         help='Scan all Git stashes.'
     )
+    git_group.add_argument(
+        '--git-history',
+        nargs='?',
+        type=int,
+        const=5,
+        help='Scan patches from recent Git commits. Optionally provide the number of commits (default: 5).'
+    )
 
     system_group = parser.add_argument_group("System Scans")
     system_group.add_argument(
@@ -8338,7 +8400,7 @@ def main():
         if not any([
             args.target, args.path, args.stdin, args.import_results, args.files,
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
-            args.git_stash, args.shell_profiles, args.shell_history, args.system_path,
+            args.git_stash, args.git_history, args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
             args.system_services, args.audit, args.modified, args.downloads, args.desktop,
             args.python_packages, args.nodejs_packages, args.ruby_gems, args.php_packages,
@@ -8433,7 +8495,13 @@ def main():
             for root_dir in git_roots:
                 extra_snippets.extend(get_git_stash_snippets(root_dir))
 
-        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not args.git_stash and not extra_snippets:
+        if args.git_history:
+            # Use specified targets as git roots, or current folder if none.
+            git_roots = scan_targets if scan_targets else ["."]
+            for root_dir in git_roots:
+                extra_snippets.extend(get_git_history_snippets(root_dir, count=args.git_history))
+
+        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not args.git_stash and not args.git_history and not extra_snippets:
             # Default to current folder if no targets provided and NOT using git-changes
             scan_targets = ["."]
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Diff (Ctrl+Shift+D):** Scan your current project changes as a diff.
 *   **Scan Git Hooks (Ctrl+Shift+G):** Scan your local and global Git hooks for suspicious scripts.
 *   **Scan Git Stashes (Ctrl+Shift+Q):** Scan all Git stashes for suspicious code changes.
+*   **Scan Recent Commits:** Scan patches from recent Git commits for suspicious changes.
 *   **Scan Git Configuration:** Scan Git settings for dangerous aliases or editors.
 *   **Scan Git Revision...:** Scan files from a specific Git branch or commit.
 
@@ -309,6 +310,11 @@ python3 gptscan.py --git-config --cli
 Scan all Git stashes:
 ```bash
 python3 gptscan.py --git-stash --cli
+```
+
+Scan recent Git commits:
+```bash
+python3 gptscan.py --git-history 10 --cli
 ```
 
 #### Advanced Scans

--- a/tests/test_git_history.py
+++ b/tests/test_git_history.py
@@ -1,0 +1,109 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import gptscan
+import subprocess
+import os
+
+def test_get_git_history_snippets(monkeypatch):
+    # Mock _get_git_info to return a fake toplevel
+    monkeypatch.setattr("gptscan._get_git_info", lambda path: ("/fake/repo", "rel/path"))
+
+    def mock_check_output(cmd, cwd=None, **kwargs):
+        if "log" in cmd:
+            return "commit 1234567890abcdef\nAuthor: User <user@example.com>\nDate:   Mon Jan 1 00:00:00 2024 +0000\n\n    Initial commit\n\ndiff --git a/test.py b/test.py\nnew file mode 100644\nindex 0000000..e69de29\n"
+        return ""
+
+    monkeypatch.setattr(subprocess, "check_output", mock_check_output)
+
+    snippets = gptscan.get_git_history_snippets()
+    assert len(snippets) == 1
+    assert snippets[0][0] == "[Git History]"
+    assert b"commit 1234567890abcdef" in snippets[0][1]
+
+def test_unpack_content_git_log():
+    content = b"commit abcdef1234567890\nAuthor: User\nDate: Mon Jan 1\n\n    Msg\n\ndiff --git a/script.py b/script.py\n--- a/script.py\n+++ b/script.py\n@@ -1,1 +1,2 @@\n+print('hello')\n+os.system('id')\n"
+
+    snippets = list(gptscan.unpack_content("history", content))
+
+    # It should extract one snippet for script.py with the commit hash
+    assert len(snippets) == 1
+    name, snippet_content = snippets[0]
+    assert "abcdef1" in name
+    assert "script.py" in name
+    assert b"print('hello')" in snippet_content
+    assert b"os.system('id')" in snippet_content
+
+def test_scan_git_history_click(monkeypatch):
+    monkeypatch.setattr("gptscan.get_git_history_snippets", lambda path, count: [("[Git History]", b"patch content")])
+
+    # Mock GUI variables
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "."
+    monkeypatch.setattr("gptscan.textbox", mock_textbox)
+
+    # Mock simpledialog
+    monkeypatch.setattr("tkinter.simpledialog.askinteger", lambda title, prompt, **kwargs: 5)
+
+    clicked = False
+    def mock_button_click(extra_snippets=None):
+        nonlocal clicked
+        clicked = True
+        assert extra_snippets == [("[Git History]", b"patch content")]
+
+    monkeypatch.setattr("gptscan.button_click", mock_button_click)
+
+    gptscan.scan_git_history_click()
+    assert clicked
+
+def test_cli_git_history_flag(monkeypatch):
+    monkeypatch.setattr("gptscan.get_git_history_snippets", lambda path, count: [("[Git History]", b"patch")])
+
+    cli_args = []
+    def mock_run_cli(targets, *args, **kwargs):
+        # The snippets are passed to run_cli via extra_snippets kwarg
+        extra = kwargs.get("extra_snippets", [])
+        assert ("[Git History]", b"patch") in extra
+        return 0
+
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+
+    import sys
+    test_args = ["gptscan.py", "--git-history", "3", "--cli"]
+    with patch.object(sys, 'argv', test_args):
+        gptscan.main()
+
+def test_system_audit_includes_git_history(monkeypatch):
+    # Mock all discovery functions except git history
+    monkeypatch.setattr("gptscan.get_shell_profile_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_shell_history_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_path_directories", lambda: [])
+    monkeypatch.setattr("gptscan.get_ssh_config_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_running_process_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_environment_variable_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_scheduled_task_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_startup_item_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_system_service_commands", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_hooks_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_config_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_git_stash_snippets", lambda: [])
+    monkeypatch.setattr("gptscan.get_python_package_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_nodejs_package_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_ruby_gems_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_php_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_rust_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_go_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_java_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_dotnet_packages_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_browser_extensions_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_editor_extensions_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_documents_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_downloads_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_desktop_paths", lambda: [])
+    monkeypatch.setattr("gptscan.get_temp_paths", lambda: [])
+
+    # Mock git history to return something
+    monkeypatch.setattr("gptscan.get_git_history_snippets", lambda: [("[Git History]", b"audit patch")])
+
+    paths, snippets = gptscan.get_system_audit_data()
+    assert ("[Git History]", b"audit patch") in snippets

--- a/tests/test_system_audit.py
+++ b/tests/test_system_audit.py
@@ -22,6 +22,7 @@ def test_scan_system_audit_click(monkeypatch):
     monkeypatch.setattr("gptscan.get_rust_packages_paths", lambda: ["/rust1"])
     monkeypatch.setattr("gptscan.get_go_packages_paths", lambda: ["/go1"])
     monkeypatch.setattr("gptscan.get_documents_paths", lambda: ["/docs1"])
+    monkeypatch.setattr("gptscan.get_git_history_snippets", lambda: [])
 
     target_paths = []
     def mock_set_target(paths):


### PR DESCRIPTION
This PR introduces the "Scan Recent Commits" feature, allowing users to audit patches from their Git history for potential security threats.

### Key Changes:
- **Core Logic:** Added `get_git_history_snippets` to collect patches from the last N commits.
- **Improved Parsing:** Updated the internal diff parser to recognize `commit` lines, enabling it to process `git log` output and include commit hashes in the result labels for better traceability.
- **GUI Integration:** Added "Scan Recent Commits" to the Scan menu and Browse dropdown, with a user-friendly dialog to specify the commit count.
- **CLI Support:** New `--git-history` flag (defaults to 5 commits) for automation.
- **System Audit:** Recent commits are now automatically audited as part of the "System Audit" command.
- **Documentation:** Updated the README with instructions and updated command-line examples.
- **Testing:** Added new tests verifying the extraction of snippets from Git log output and the integration across CLI/GUI.

---
*PR created automatically by Jules for task [4528697234627144923](https://jules.google.com/task/4528697234627144923) started by @RainRat*