### PR TITLE
[UI/UX] Consolidate VirusTotal and View Online into Intel Menubutton

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -54,8 +54,8 @@ open_button: Optional[ttk.Button] = None
 analyze_button: Optional[ttk.Button] = None
 exclude_button: Optional[ttk.Button] = None
 reveal_button: Optional[ttk.Button] = None
-vt_button: Optional[ttk.Button] = None
-view_online_button: Optional[ttk.Button] = None
+intel_button: Optional[ttk.Menubutton] = None
+intel_menu: Optional[tk.Menu] = None
 results_button: Optional[ttk.Menubutton] = None
 browse_button: Optional[ttk.Menubutton] = None
 show_key_btn: Optional[ttk.Button] = None
@@ -2700,7 +2700,7 @@ def set_scanning_state(is_scanning: bool) -> None:
 
     # Disable specific footer buttons during a scan
     footer_buttons = [
-        rescan_button, analyze_button, exclude_button, results_button
+        rescan_button, analyze_button, exclude_button, intel_button, results_button
     ]
     for btn in footer_buttons:
         if btn:
@@ -7256,10 +7256,14 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
         exclude_button.config(state=mod_local_state)
     if reveal_button:
         reveal_button.config(state=safe_local_state)
-    if vt_button:
-        vt_button.config(state=safe_base_state)
-    if view_online_button:
-        view_online_button.config(state=safe_online_state)
+    if intel_button:
+        intel_button.config(state=safe_base_state)
+        if intel_menu:
+            try:
+                intel_menu.entryconfig("Check on VirusTotal", state=safe_base_state)
+                intel_menu.entryconfig("View Online", state=safe_online_state)
+            except tk.TclError:
+                pass
 
     if analyze_button:
         ai_available = Config.GPT_ENABLED
@@ -7447,7 +7451,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, vt_button, view_online_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7837,7 +7841,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     # --- Footer Frame ---
     footer_frame = ttk.Frame(root)
     footer_frame.grid(row=4, column=0, sticky="ew", padx=10, pady=(0, 5))
-    footer_frame.columnconfigure(11, weight=1)
+    footer_frame.columnconfigure(10, weight=1)
 
     view_button = ttk.Button(footer_frame, text="View", width=10, command=view_details, style='Primary.TButton')
     view_button.grid(row=0, column=0, padx=2, ipady=5)
@@ -7867,21 +7871,22 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     reveal_button.grid(row=0, column=7, padx=2, ipady=5)
     bind_hover_message(reveal_button, "Show the selected file in the system file manager. (Ctrl+Enter)")
 
-    vt_button = ttk.Button(footer_frame, text="VirusTotal", width=12, command=check_virustotal)
-    vt_button.grid(row=0, column=8, padx=2, ipady=5)
-    bind_hover_message(vt_button, "Check the selected files on VirusTotal. (Ctrl+T)")
+    intel_button = ttk.Menubutton(footer_frame, text="Intel", width=12)
+    intel_button.grid(row=0, column=8, padx=2, ipady=5)
+    bind_hover_message(intel_button, "Access threat intelligence and online repository links.")
 
-    view_online_button = ttk.Button(footer_frame, text="View Online", width=14, command=view_online)
-    view_online_button.grid(row=0, column=9, padx=2, ipady=5)
-    bind_hover_message(view_online_button, "View the selected file in its online repository. (Ctrl+L)")
+    intel_menu = tk.Menu(intel_button, tearoff=0)
+    intel_menu.add_command(label="Check on VirusTotal", command=check_virustotal, accelerator="Ctrl+T")
+    intel_menu.add_command(label="View Online", command=view_online, accelerator="Ctrl+L")
+    intel_button["menu"] = intel_menu
 
-    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=10, sticky="ns", padx=10)
+    ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=9, sticky="ns", padx=10)
 
     # Spacer
-    ttk.Frame(footer_frame).grid(row=0, column=11, sticky="ew")
+    ttk.Frame(footer_frame).grid(row=0, column=10, sticky="ew")
 
     results_button = ttk.Menubutton(footer_frame, text="Results", width=12)
-    results_button.grid(row=0, column=12, padx=(2, 0), ipady=5)
+    results_button.grid(row=0, column=11, padx=(2, 0), ipady=5)
 
     # --- Status Bar Frame ---
     status_bar_frame = ttk.Frame(root)


### PR DESCRIPTION
### Context
GUI

### Problem
The GUI footer was becoming cluttered with multiple separate buttons for secondary actions like "VirusTotal" and "View Online", which were taking up significant horizontal space and breaking the visual hierarchy of the main scan actions.

### Solution
Consolidated the "VirusTotal" and "View Online" buttons into a single "Intel" Menubutton with a dropdown menu. This reorganization groups related intelligence-gathering actions together, reducing visual noise while maintaining quick access to these features. The "Intel" button is correctly managed by the application's state logic, ensuring it is disabled during scans and its menu items are only available when a valid selection is made in the results list.

### Changes
- Replaced separate global variables `vt_button` and `view_online_button` with `intel_button` and `intel_menu`.
- Updated `set_scanning_state` to include `intel_button` in the list of buttons disabled during active scans.
- Modified `update_button_states` to dynamically enable or disable "Check on VirusTotal" and "View Online" menu entries based on whether the selected item is a local file or a remote web link.
- Updated the footer grid layout in `create_gui` to place the "Intel" button at column 8, followed by a separator and a spacer, moving the "Results" button to column 11.

---
*PR created automatically by Jules for task [7893193738757394133](https://jules.google.com/task/7893193738757394133) started by @RainRat*