### PR TITLE
[DOCS] Clarify model naming requirements for gptscan.py compatibility

### DIFF
--- a/train.md
+++ b/train.md
@@ -111,7 +111,7 @@ python3 train.py --config config.yml --mode predict
 #### Override settings:
 
 ```bash
-# Use a different model name
+# Use a different model name. Note: gptscan.py expects a file named scripts.h5.
 python3 train.py --config config.yml --model-name my_model
 
 # Change training parameters
@@ -177,7 +177,7 @@ python3 train.py --config config.yml \
 ## Output Files
 
 **Training mode produces:**
-- `{model_name}.h5` - The trained detection model.
+- `{model_name}.h5` - The trained detection model. (To use it with gptscan.py, rename it to scripts.h5 and keep it in the project folder.)
 - `{model_name}_best_hp.yml` - The best settings found during training.
 
 **Prediction mode produces:**


### PR DESCRIPTION
This pull request improves the documentation in `train.md` by clarifying a critical integration step: renaming custom-trained models to `scripts.h5`.

While the training script allows users to specify custom names via the `--model-name` flag, the main scanner tool (`gptscan.py`) is hardcoded to look for `scripts.h5` in the project folder. 

**Changes:**
- Added a note to the "Advanced Options" section in the model naming example.
- Updated the "Output Files" section to explicitly mention the renaming requirement for scanner compatibility.

These changes help users avoid "Model Not Found" errors and provide a smoother transition from model training to active scanning.

---
*PR created automatically by Jules for task [3317699563690313329](https://jules.google.com/task/3317699563690313329) started by @RainRat*