### PR TITLE
[DOCS] Standardize terminology for accessibility and clarity

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -8053,7 +8053,7 @@ def main():
                "  python3 gptscan.py --git-changes --cli --fail-threshold 50\n\n"
                "  # Scan current Git changes as a diff\n"
                "  python3 gptscan.py --git-diff --cli\n\n"
-               "  # Scan a link (GitHub, GitLab, Pastebin, etc.)\n"
+               "  # Scan a web link (GitHub, GitLab, Pastebin, etc.)\n"
                "  python3 gptscan.py https://github.com/user/repo --cli\n\n"
                "  # Run a full system audit\n"
                "  python3 gptscan.py --audit --cli\n\n"
@@ -8067,15 +8067,15 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {Config.VERSION}')
-    parser.add_argument('target', nargs='?', help='The folder, file, pattern, or link to scan.')
+    parser.add_argument('target', nargs='?', help='The folder, file, pattern, or web link to scan.')
     parser.add_argument(
         'files',
         nargs='*',
-        help='Other folders, files, patterns, or links to scan.'
+        help='Other folders, files, patterns, or web links to scan.'
     )
 
     scan_group = parser.add_argument_group("Scan Options")
-    scan_group.add_argument('-p', '--path', type=str, help='A folder, file, or link to scan.')
+    scan_group.add_argument('-p', '--path', type=str, help='A folder, file, or web link to scan.')
     scan_group.add_argument('-d', '--deep', action='store_true', help='Scan the whole file. This is slower but more thorough.')
     scan_group.add_argument('--dry-run', action='store_true', help='Preview which files would be scanned without actually checking them.')
     scan_group.add_argument(
@@ -8178,7 +8178,7 @@ def main():
     system_group.add_argument(
         '--shell-profiles',
         action='store_true',
-        help='Scan common shell profile and RC files, including system-wide profiles.'
+        help='Scan common shell profile and configuration files (like .bashrc or .zshrc), including system-wide profiles.'
     )
     system_group.add_argument(
         '--shell-history',

--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ Scan all folders containing editor extensions:
 python3 gptscan.py --editor-extensions --cli
 ```
 
-Scan all common shell profile and RC files:
+Scan all common shell profile and configuration files (like .bashrc or .zshrc):
 ```bash
 python3 gptscan.py --shell-profiles --cli
 ```

--- a/train.md
+++ b/train.md
@@ -48,7 +48,7 @@ prediction:
 weights:
   positive_sample_weight: 1.0 # Importance of dangerous examples during training
 
-# Optimization settings (Hyperparameters) for the local model.
+# Optimization settings for the local model.
 # These values (0.0 to 1.0) control how the model is built.
 # The script will automatically adjust and improve these over time.
 hyperparameters:
@@ -178,7 +178,7 @@ python3 train.py --config config.yml \
 
 **Training mode produces:**
 - `{model_name}.h5` - The trained detection model.
-- `{model_name}_best_hp.yml` - The best settings found during training.
+- `{model_name}_best_hp.yml` - The best optimization settings found during training.
 
 **Prediction mode produces:**
 - Copies of suspicious files (those with high threat levels) to your output folder.
@@ -206,7 +206,7 @@ python3 train.py --config config.yml \
 3. **Assigns Scores:** It calculates the threat level for each file.
 4. **Filters Results:** Any file that crosses your "threat" threshold is copied to the output folder for you to review.
 
-## Automatic Setting Optimization
+## Automatic Optimization of Settings
 
 The trainer automatically tries different ways to build and train the model:
 

--- a/train.py
+++ b/train.py
@@ -35,7 +35,7 @@ class ModelConfig:
 
 @dataclass
 class Hyperparameters:
-    """Contains settings that control how the AI model is built and trained."""
+    """Contains optimization settings that control how the AI model is built and trained."""
     embedding_scale: float
     rnn_scale: float
     pooling_type: float
@@ -147,9 +147,9 @@ class DataLoader:
             np.array(sample_weights)
         )
     
-    def load_prediction_files(self, directory: Path) -> Tuple[List[Path], np.ndarray]:
+    def load_prediction_files(self, folder: Path) -> Tuple[List[Path], np.ndarray]:
         """Loads files for analysis from a folder."""
-        file_paths = sorted([f for f in directory.iterdir() if f.is_file()])
+        file_paths = sorted([f for f in folder.iterdir() if f.is_file()])
         data = np.array([self.load_file(f) for f in file_paths])
         return file_paths, data
 
@@ -446,7 +446,7 @@ class Predictor:
 
 
 def load_config(config_path: str) -> Tuple[ModelConfig, Optional[Hyperparameters]]:
-    """Loads the training and model settings from a YAML file."""
+    """Loads the training, model, and optimization settings from a YAML file."""
     with open(config_path, 'r') as f:
         data = yaml.safe_load(f)
     
@@ -609,12 +609,12 @@ def main():
         
         hp_file = f'{config.model_name}_best_hp.yml'
         if Path(hp_file).exists():
-            print(f"Loading existing hyperparameters from {hp_file}")
+            print(f"Loading existing optimization settings from {hp_file}")
             initial_hp = Trainer.load_hyperparameters(hp_file)
         
         if initial_hp is None:
             raise ValueError(
-                "No hyperparameters found. Please provide 'hyperparameters' section in config.yml"
+                "No optimization settings found. Please provide 'hyperparameters' section in config.yml"
             )
         
         print("Starting training with an automatic improvement process...")


### PR DESCRIPTION
Standardized project terminology across documentation, CLI help strings, and internal code comments to improve accessibility for a global audience. Key changes include:
- Replaced technical jargon like "Hyperparameters" with "optimization settings" (while preserving the YAML key name).
- Replaced "RC files" with more descriptive "configuration files (like .bashrc or .zshrc)".
- Unified the use of "folder" instead of "directory" and "web link" instead of "link" or "URL".
- Updated `gptscan.py`, `train.py`, `readme.md`, and `train.md` to reflect these standards.
- Verified all changes via CLI help output and ran 15 relevant tests to ensure no regressions.

---
*PR created automatically by Jules for task [7347319444857153676](https://jules.google.com/task/7347319444857153676) started by @RainRat*