### PR TITLE
[UI/UX] Consolidate threat intelligence actions into a single 'Intel' menu

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -54,8 +54,8 @@ open_button: Optional[ttk.Button] = None
 analyze_button: Optional[ttk.Button] = None
 exclude_button: Optional[ttk.Button] = None
 reveal_button: Optional[ttk.Button] = None
-vt_button: Optional[ttk.Button] = None
-view_online_button: Optional[ttk.Button] = None
+intel_button: Optional[ttk.Menubutton] = None
+intel_menu: Optional[tk.Menu] = None
 results_button: Optional[ttk.Menubutton] = None
 browse_button: Optional[ttk.Menubutton] = None
 show_key_btn: Optional[ttk.Button] = None
@@ -2692,7 +2692,7 @@ def set_scanning_state(is_scanning: bool) -> None:
         textbox, clear_target_btn, browse_button,
         git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox,
         gpt_checkbox, provider_combo, model_combo, api_entry, show_key_btn,
-        copy_cmd_button
+        copy_cmd_button, intel_button
     ]
     for widget in config_widgets:
         if widget:
@@ -7256,10 +7256,15 @@ def update_button_states(event: Optional[tk.Event] = None) -> None:
         exclude_button.config(state=mod_local_state)
     if reveal_button:
         reveal_button.config(state=safe_local_state)
-    if vt_button:
-        vt_button.config(state=safe_base_state)
-    if view_online_button:
-        view_online_button.config(state=safe_online_state)
+    if intel_button:
+        intel_button.config(state=safe_base_state)
+
+    if intel_menu:
+        try:
+            intel_menu.entryconfig("Check on VirusTotal", state=safe_base_state)
+            intel_menu.entryconfig("View Online", state=safe_online_state)
+        except tk.TclError:
+            pass
 
     if analyze_button:
         ai_available = Config.GPT_ENABLED
@@ -7447,7 +7452,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     tk.Tk
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, vt_button, view_online_button, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7867,13 +7872,14 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     reveal_button.grid(row=0, column=7, padx=2, ipady=5)
     bind_hover_message(reveal_button, "Show the selected file in the system file manager. (Ctrl+Enter)")
 
-    vt_button = ttk.Button(footer_frame, text="VirusTotal", width=12, command=check_virustotal)
-    vt_button.grid(row=0, column=8, padx=2, ipady=5)
-    bind_hover_message(vt_button, "Check the selected files on VirusTotal. (Ctrl+T)")
+    intel_button = ttk.Menubutton(footer_frame, text="Intel", width=12)
+    intel_button.grid(row=0, column=8, padx=2, ipady=5)
+    bind_hover_message(intel_button, "Threat intelligence for selected items (VirusTotal, online repository).")
 
-    view_online_button = ttk.Button(footer_frame, text="View Online", width=14, command=view_online)
-    view_online_button.grid(row=0, column=9, padx=2, ipady=5)
-    bind_hover_message(view_online_button, "View the selected file in its online repository. (Ctrl+L)")
+    intel_menu = tk.Menu(intel_button, tearoff=0)
+    intel_menu.add_command(label="Check on VirusTotal", command=check_virustotal, accelerator="Ctrl+T")
+    intel_menu.add_command(label="View Online", command=view_online, accelerator="Ctrl+L")
+    intel_button["menu"] = intel_menu
 
     ttk.Separator(footer_frame, orient=tk.VERTICAL).grid(row=0, column=10, sticky="ns", padx=10)
 

--- a/tests/test_intel_menu_ui.py
+++ b/tests/test_intel_menu_ui.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import tkinter as tk
+import json
+
+@pytest.fixture
+def mock_gui(monkeypatch):
+    mock_tree = MagicMock()
+    mock_intel_button = MagicMock()
+    mock_intel_menu = MagicMock()
+
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    monkeypatch.setattr(gptscan, 'intel_button', mock_intel_button)
+    monkeypatch.setattr(gptscan, 'intel_menu', mock_intel_menu)
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+
+    return mock_tree, mock_intel_button, mock_intel_menu
+
+def test_intel_menu_states_no_selection(mock_gui):
+    """Test that Intel menu and button are disabled when nothing is selected."""
+    mock_tree, mock_intel_button, mock_intel_menu = mock_gui
+    mock_tree.selection.return_value = []
+
+    gptscan.update_button_states()
+
+    mock_intel_button.config.assert_called_with(state="disabled")
+    mock_intel_menu.entryconfig.assert_any_call("Check on VirusTotal", state="disabled")
+    mock_intel_menu.entryconfig.assert_any_call("View Online", state="disabled")
+
+def test_intel_menu_states_with_selection(mock_gui, monkeypatch):
+    """Test that Intel menu and button are enabled when a file is selected."""
+    mock_tree, mock_intel_button, mock_intel_menu = mock_gui
+    mock_tree.selection.return_value = ["item1"]
+
+    # Mock _get_item_raw_values to return a standard local path
+    monkeypatch.setattr(gptscan, '_get_item_raw_values', lambda item_id: ["test.py", "50%"])
+
+    gptscan.update_button_states()
+
+    mock_intel_button.config.assert_called_with(state="normal")
+    mock_intel_menu.entryconfig.assert_any_call("Check on VirusTotal", state="normal")
+    mock_intel_menu.entryconfig.assert_any_call("View Online", state="normal")
+
+def test_intel_menu_states_virtual_path(mock_gui, monkeypatch):
+    """Test that View Online is disabled for non-URL virtual paths (like [Clipboard])."""
+    mock_tree, mock_intel_button, mock_intel_menu = mock_gui
+    mock_tree.selection.return_value = ["item1"]
+
+    # Mock _get_item_raw_values to return a virtual path
+    monkeypatch.setattr(gptscan, '_get_item_raw_values', lambda item_id: ["[Clipboard]", "0%"])
+
+    gptscan.update_button_states()
+
+    mock_intel_button.config.assert_called_with(state="normal")
+    mock_intel_menu.entryconfig.assert_any_call("Check on VirusTotal", state="normal")
+    mock_intel_menu.entryconfig.assert_any_call("View Online", state="disabled")
+
+def test_intel_button_disabled_during_scan(mock_gui, monkeypatch):
+    """Test that the Intel button is disabled when a scan is active."""
+    mock_tree, mock_intel_button, mock_intel_menu = mock_gui
+
+    # Setup scan state widgets
+    monkeypatch_config = [
+        'textbox', 'clear_target_btn', 'browse_button',
+        'git_checkbox', 'deep_checkbox', 'scan_all_checkbox', 'dry_checkbox',
+        'gpt_checkbox', 'provider_combo', 'model_combo', 'api_entry', 'show_key_btn',
+        'copy_cmd_button', 'scan_button', 'cancel_button'
+    ]
+    for name in monkeypatch_config:
+        monkeypatch.setattr(gptscan, name, MagicMock())
+
+    gptscan.set_scanning_state(True)
+
+    mock_intel_button.config.assert_called_with(state="disabled")


### PR DESCRIPTION
**PR Title:** [UI/UX] Consolidate threat intelligence actions into a single 'Intel' menu

**Description:**
* **Context:** GUI (Tkinter)
* **Problem:** The GUI footer was becoming cluttered with multiple individual buttons for secondary actions like "VirusTotal" and "View Online", making the primary actions less prominent and increasing visual noise.
* **Solution:** Reorganized the threat intelligence actions into a single "Intel" `ttk.Menubutton`. This improves the visual hierarchy by grouping related but less frequently used actions into a single, clearly labeled dropdown menu. This reduces horizontal "button fatigue" and reserves more space for future footer additions while maintaining the same level of accessibility for power users (accelerators like Ctrl+T and Ctrl+L are preserved).

**Changes:**
- Removed `vt_button` and `view_online_button` from `gptscan.py`.
- Introduced `intel_button` (Menubutton) and `intel_menu` (Menu) in the GUI footer.
- Updated `update_button_states` to manage the sensitivity of individual menu entries based on the current selection's metadata (e.g., ensuring "View Online" remains disabled for non-URL virtual paths).
- Ensured the "Intel" button is disabled during active scans in `set_scanning_state`.
- Added `tests/test_intel_menu_ui.py` to verify state management of the new UI components.

---
*PR created automatically by Jules for task [15039906966269346571](https://jules.google.com/task/15039906966269346571) started by @RainRat*