### PR TITLE
Remove redundant path validation in gptscan.py

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1135,7 +1135,7 @@ def get_shell_profile_paths() -> List[str]:
 
         # /etc/profile.d/*.sh scripts
         profile_d = Path('/etc/profile.d')
-        if profile_d.exists() and profile_d.is_dir():
+        if profile_d.is_dir():
             for script in profile_d.glob('*.sh'):
                 paths.append(str(script))
 
@@ -1736,7 +1736,7 @@ def get_scheduled_task_commands() -> List[Tuple[str, bytes]]:
             # 2. System crontabs
             cron_files = ["/etc/crontab"]
             cron_d = Path("/etc/cron.d")
-            if cron_d.exists() and cron_d.is_dir():
+            if cron_d.is_dir():
                 try:
                     for p in cron_d.iterdir():
                         if p.is_file():


### PR DESCRIPTION
This PR removes redundant path validation logic in `gptscan.py`. Specifically, it identifies and eliminates instances where `pathlib.Path.exists()` was called immediately before `pathlib.Path.is_dir()`. Since `is_dir()` implicitly verifies existence, the explicit check was unnecessary.

Key changes:
- In `get_shell_profile_paths`, simplified the check for `/etc/profile.d`.
- In `get_scheduled_task_commands`, simplified the check for `/etc/cron.d`.

These changes are atomic, non-breaking, and improve code hygiene without altering the application's behavior. Relevant tests in `tests/test_shell_profiles.py`, `tests/test_scheduled_tasks.py`, and `tests/test_system_audit.py` have been run and passed.

---
*PR created automatically by Jules for task [15718617952236140309](https://jules.google.com/task/15718617952236140309) started by @RainRat*