### PR TITLE
[DOCS] Simplify AI report extraction docstring

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -911,19 +911,13 @@ class AsyncRateLimiter:
 
 
 def extract_data_from_gpt_response(response: Any) -> Union[Dict, str]:
-    """Parse and validate the JSON payload returned from the OpenAI API.
+    """Extract and check the AI's report from the server response.
 
-    Parameters
-    ----------
-    response : Any
-        OpenAI response object expected to contain ``choices[0].message.content``
-        with JSON matching ``Config.EXPECTED_KEYS``.
+    Args:
+        response: The raw response from the AI provider.
 
-    Returns
-    -------
-    Union[Dict, str]
-        Parsed JSON dictionary when valid; otherwise, a human-readable error
-        message describing the parsing failure.
+    Returns:
+        A dictionary with the AI's analysis if successful, or an error message string if the report is invalid or missing information.
     """
     content = response.choices[0].message.content
 


### PR DESCRIPTION
### Documentation Improvement

Updated the `extract_data_from_gpt_response` function's docstring in `gptscan.py` to align with the project's simplicity and Plain English guidelines.

*   **Type:** Internal Help (API Docstring)
*   **What:** Updated the docstring for `extract_data_from_gpt_response`.
*   **Why:** The previous docstring used complex SciPy formatting and technical jargon ("JSON payload," "validate," "OpenAI response object"). The new version uses a simple `Args:`/`Returns:` format and Plain English ("AI report," "check") to make the code easier to understand for international developers.

**Verification:**
- Verified with unit tests in `tests/test_gpt_edge_cases.py` and `tests/test_utility_gaps.py`.
- All relevant synchronous tests passed.

---
*PR created automatically by Jules for task [16517135301383229233](https://jules.google.com/task/16517135301383229233) started by @RainRat*