### PR TITLE
[UI/UX] Consolidate Intel actions in result details

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6748,13 +6748,14 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     if not Config.GPT_ENABLED:
         analyze_btn.config(state='disabled')
 
-    vt_btn = ttk.Button(btn_frame, text="VirusTotal", width=12, command=lambda: check_virustotal(path_entry.get()))
-    vt_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(vt_btn, "Check this file's hash on VirusTotal.", label=status_bar)
+    intel_menu_btn = ttk.Menubutton(btn_frame, text="Intel", width=12)
+    intel_menu_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(intel_menu_btn, "Threat intelligence for this item (VirusTotal, online repository).", label=status_bar)
 
-    view_online_btn = ttk.Button(btn_frame, text="View Online", width=14, command=lambda: view_online(path_entry.get(), line=line_label.cget("text")))
-    view_online_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(view_online_btn, "View this file in its online repository. (Ctrl+L)", label=status_bar)
+    intel_menu_details = tk.Menu(intel_menu_btn, tearoff=0)
+    intel_menu_details.add_command(label="Check on VirusTotal", command=lambda: check_virustotal(path_entry.get()), accelerator="Ctrl+T")
+    intel_menu_details.add_command(label="View Online", command=lambda: view_online(path_entry.get(), line=line_label.cget("text")), accelerator="Ctrl+L")
+    intel_menu_btn["menu"] = intel_menu_details
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -6816,8 +6817,12 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         analyze_btn.config(state='disabled' if is_scanning or not Config.GPT_ENABLED else 'normal')
         exclude_btn.config(state='disabled' if is_scanning or is_virtual else 'normal')
         open_btn.config(state='disabled' if is_virtual else 'normal')
-        vt_btn.config(state='normal')
-        view_online_btn.config(state='disabled' if is_non_url_virtual else 'normal')
+
+        try:
+            intel_menu_details.entryconfig("Check on VirusTotal", state='normal')
+            intel_menu_details.entryconfig("View Online", state='disabled' if is_non_url_virtual else 'normal')
+        except tk.TclError:
+            pass
         path_copy_btn.config(state='normal')
         reveal_btn.config(state='disabled' if is_virtual else 'normal')
 

--- a/tests/test_details_intel_menu.py
+++ b/tests/test_details_intel_menu.py
@@ -1,0 +1,71 @@
+import pytest
+from unittest.mock import MagicMock, patch, ANY
+import gptscan
+import tkinter as tk
+import json
+
+@pytest.fixture
+def mock_details_gui(monkeypatch):
+    # Mocking necessary components within view_details scope or related
+    mock_tree = MagicMock()
+    mock_tree.get_children.return_value = ["item1"]
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+
+    # We need to mock _get_item_raw_values as it's used in view_details
+    monkeypatch.setattr(gptscan, '_get_item_raw_values', MagicMock(return_value=["test.py", "50%", "admin", "user", "80%", "print(1)", "1"]))
+
+    # Mock other GUI globals
+    monkeypatch.setattr(gptscan, 'root', MagicMock())
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
+
+    return mock_tree
+
+def test_view_details_intel_menu_creation(mock_details_gui, monkeypatch):
+    """Test that the Intel Menubutton and its menu are created in the details window."""
+    # We need to intercept the creation of Menubutton and Menu
+    mock_menubutton = MagicMock()
+    mock_menu = MagicMock()
+
+    with patch('tkinter.ttk.Menubutton', return_value=mock_menubutton), \
+         patch('tkinter.Menu', return_value=mock_menu), \
+         patch('tkinter.Toplevel'), \
+         patch('tkinter.ttk.Separator'), \
+         patch('tkinter.ttk.Button'), \
+         patch('tkinter.Label'), \
+         patch('tkinter.ttk.Label'), \
+         patch('tkinter.ttk.Entry'), \
+         patch('tkinter.ttk.Frame'), \
+         patch('tkinter.ttk.LabelFrame'), \
+         patch('tkinter.ttk.Panedwindow'), \
+         patch('tkinter.scrolledtext.ScrolledText'):
+
+        gptscan.view_details(item_id="item1")
+
+        # Verify menu items were added
+        mock_menu.add_command.assert_any_call(label="Check on VirusTotal", command=ANY, accelerator="Ctrl+T")
+        mock_menu.add_command.assert_any_call(label="View Online", command=ANY, accelerator="Ctrl+L")
+
+def test_view_details_intel_menu_states_virtual(mock_details_gui, monkeypatch):
+    """Test that View Online in details Intel menu is disabled for virtual paths."""
+    mock_menu = MagicMock()
+
+    # Return [Clipboard] virtual path
+    gptscan._get_item_raw_values.return_value = ["[Clipboard]", "0%", "", "", "", "snippet", "-"]
+
+    with patch('tkinter.Menu', return_value=mock_menu), \
+         patch('tkinter.Toplevel'), \
+         patch('tkinter.ttk.Menubutton'), \
+         patch('tkinter.ttk.Separator'), \
+         patch('tkinter.ttk.Button'), \
+         patch('tkinter.Label'), \
+         patch('tkinter.ttk.Label'), \
+         patch('tkinter.ttk.Entry'), \
+         patch('tkinter.ttk.Frame'), \
+         patch('tkinter.ttk.LabelFrame'), \
+         patch('tkinter.ttk.Panedwindow'), \
+         patch('tkinter.scrolledtext.ScrolledText'):
+
+        gptscan.view_details(item_id="item1")
+
+        # The refresh_content is called inside view_details
+        mock_menu.entryconfig.assert_any_call("View Online", state='disabled')


### PR DESCRIPTION
**PR Title:** [UI/UX] Consolidate Intel actions in result details
 
**Description:** 
* **Context:** GUI 
* **Problem:** The result details window was becoming cluttered with multiple separate buttons for external intelligence actions ("VirusTotal" and "View Online"), leading to visual noise.
* **Solution:** Reorganized these related actions into a single "Intel" dropdown menu. This improves visual hierarchy, reduces clutter, and ensures consistency with the consolidated "Intel" menu in the main application's footer.
 
**Changes:** 
- Modified `view_details` in `gptscan.py` to replace `vt_btn` and `view_online_btn` with a `ttk.Menubutton` labeled "Intel".
- Implemented a `tk.Menu` for the "Intel" button with appropriate commands and accelerators.
- Updated the `refresh_content` inner function to correctly manage the `state` of the "Intel" menu items based on the selection context (e.g., disabling "View Online" for non-URL virtual paths).
- Added `tests/test_details_intel_menu.py` to verify the creation and behavior of the new menu.

---
*PR created automatically by Jules for task [5982430443001755954](https://jules.google.com/task/5982430443001755954) started by @RainRat*