### PR TITLE
[UI/UX] Consolidate threat intel and improve visual hierarchy in details view

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6601,14 +6601,6 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     path_copy_btn.grid(row=1, column=2, padx=2)
     bind_hover_message(path_copy_btn, "Copy the full file path to the clipboard.", label=status_bar)
 
-    reveal_btn = ttk.Button(header_frame, text="Show in Folder", width=14, command=lambda: show_in_folder(path_entry.get()))
-    reveal_btn.grid(row=1, column=3, padx=2)
-    bind_hover_message(reveal_btn, "Show this file in the system file manager. (Ctrl+Enter)", label=status_bar)
-
-    open_btn = ttk.Button(header_frame, text="Open", width=10, command=lambda: open_file(path_entry.get()))
-    open_btn.grid(row=1, column=4, padx=2)
-    bind_hover_message(open_btn, "Open this file in the default application. (Shift+Enter)", label=status_bar)
-
     def on_analyze_now():
         if current_cancel_event is not None:
             return
@@ -6741,20 +6733,12 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
             tree.see(new_item_id)
             refresh_content(new_item_id)
 
-    # Group: Actions
+    # Group: AI Analysis
     analyze_btn = ttk.Button(btn_frame, text="Analyze with AI", width=18, command=on_analyze_now, style='Primary.TButton')
     analyze_btn.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(analyze_btn, "Use AI to analyze this code snippet. (Ctrl+G)", label=status_bar)
     if not Config.GPT_ENABLED:
         analyze_btn.config(state='disabled')
-
-    vt_btn = ttk.Button(btn_frame, text="VirusTotal", width=12, command=lambda: check_virustotal(path_entry.get()))
-    vt_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(vt_btn, "Check this file's hash on VirusTotal.", label=status_bar)
-
-    view_online_btn = ttk.Button(btn_frame, text="View Online", width=14, command=lambda: view_online(path_entry.get(), line=line_label.cget("text")))
-    view_online_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(view_online_btn, "View this file in its online repository. (Ctrl+L)", label=status_bar)
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -6766,6 +6750,26 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     exclude_btn = ttk.Button(btn_frame, text="Exclude", width=10, command=on_exclude)
     exclude_btn.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(exclude_btn, "Exclude this file from future scans. (Delete)", label=status_bar)
+
+    ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
+
+    # Group: Actions
+    open_btn = ttk.Button(btn_frame, text="Open", width=10, command=lambda: open_file(path_entry.get()))
+    open_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(open_btn, "Open this file in the default application. (Shift+Enter)", label=status_bar)
+
+    reveal_btn = ttk.Button(btn_frame, text="Show in Folder", width=14, command=lambda: show_in_folder(path_entry.get()))
+    reveal_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(reveal_btn, "Show this file in the system file manager. (Ctrl+Enter)", label=status_bar)
+
+    intel_menu_details = ttk.Menubutton(btn_frame, text="Intel", width=12)
+    intel_menu_details.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(intel_menu_details, "Threat intelligence for this result (VirusTotal, online repository).", label=status_bar)
+
+    intel_menu_inner = tk.Menu(intel_menu_details, tearoff=0)
+    intel_menu_inner.add_command(label="Check on VirusTotal", command=lambda: check_virustotal(path_entry.get()), accelerator="Ctrl+T")
+    intel_menu_inner.add_command(label="View Online", command=lambda: view_online(path_entry.get(), line=line_label.cget("text")), accelerator="Ctrl+L")
+    intel_menu_details["menu"] = intel_menu_inner
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -6816,10 +6820,15 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         analyze_btn.config(state='disabled' if is_scanning or not Config.GPT_ENABLED else 'normal')
         exclude_btn.config(state='disabled' if is_scanning or is_virtual else 'normal')
         open_btn.config(state='disabled' if is_virtual else 'normal')
-        vt_btn.config(state='normal')
-        view_online_btn.config(state='disabled' if is_non_url_virtual else 'normal')
-        path_copy_btn.config(state='normal')
         reveal_btn.config(state='disabled' if is_virtual else 'normal')
+        intel_menu_details.config(state='normal')
+        try:
+            intel_menu_inner.entryconfig("Check on VirusTotal", state='normal')
+            intel_menu_inner.entryconfig("View Online", state='disabled' if is_non_url_virtual else 'normal')
+        except tk.TclError:
+            pass
+
+        path_copy_btn.config(state='normal')
 
         # vals: (path, own_conf, admin, user, gpt_conf, snippet, line)
         path, own_conf, admin, user, gpt_conf, snippet = vals[:6]
@@ -6949,6 +6958,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     details_win.bind('<Command-h>', lambda e: copy_sha256_details())
     details_win.bind('<Control-g>', lambda e: on_analyze_now())
     details_win.bind('<Command-g>', lambda e: on_analyze_now())
+    details_win.bind('<Control-t>', lambda e: check_virustotal(path_entry.get()))
+    details_win.bind('<Command-t>', lambda e: check_virustotal(path_entry.get()))
     details_win.bind('<Control-l>', lambda e: view_online(path_entry.get(), line=line_label.cget("text")))
     details_win.bind('<Command-l>', lambda e: view_online(path_entry.get(), line=line_label.cget("text")))
     details_win.bind('<Control-Shift-C>', lambda e: copy_analysis())

--- a/tests/test_details_intel_menu.py
+++ b/tests/test_details_intel_menu.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import MagicMock, patch, mock_open
+import gptscan
+import json
+import tkinter as tk
+
+@pytest.fixture
+def mock_details_env(monkeypatch):
+    """Setup a mock environment specifically for testing the new Intel menu in view_details."""
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, 'tree', mock_tree)
+    mock_tree._item_values = {}
+    def mock_item_func(item_id, option=None):
+        vals = mock_tree._item_values.get(item_id, [])
+        if option == "values": return vals
+        return {"values": vals}
+    mock_tree.item.side_effect = mock_item_func
+    mock_tree.exists.side_effect = lambda iid: iid in mock_tree._item_values
+
+    mock_root = MagicMock()
+    monkeypatch.setattr(gptscan, 'root', mock_root)
+    monkeypatch.setattr(gptscan.tk, 'Toplevel', MagicMock())
+
+    captured = {'menus': [], 'buttons': {}, 'menubuttons': {}}
+
+    def mock_button_init(master, **kwargs):
+        btn = MagicMock()
+        text = kwargs.get('text', '')
+        if text: captured['buttons'][text] = (btn, kwargs.get('command'))
+        return btn
+    monkeypatch.setattr(gptscan.ttk, 'Button', mock_button_init)
+
+    def mock_menubutton_init(master, **kwargs):
+        mb = MagicMock()
+        text = kwargs.get('text', '')
+        if text: captured['menubuttons'][text] = mb
+        return mb
+    monkeypatch.setattr(gptscan.ttk, 'Menubutton', mock_menubutton_init)
+
+    class MockMenu:
+        def __init__(self, master=None, **kwargs):
+            self.master = master
+            self.items = {}
+            self.configs = {}
+            captured['menus'].append(self)
+        def add_command(self, **kwargs):
+            label = kwargs.get('label')
+            if label: self.items[label] = kwargs.get('command')
+        def entryconfig(self, label, **kwargs):
+            if label in self.items:
+                self.configs[label] = kwargs
+        def add_separator(self): pass
+    monkeypatch.setattr(gptscan.tk, 'Menu', MockMenu)
+
+    # Mock other necessary widgets
+    monkeypatch.setattr(gptscan.ttk, 'Entry', MagicMock())
+    monkeypatch.setattr(gptscan.tk, 'Label', MagicMock())
+    monkeypatch.setattr(gptscan.ttk, 'Label', MagicMock())
+    monkeypatch.setattr(gptscan.scrolledtext, 'ScrolledText', MagicMock())
+
+    return captured, mock_tree
+
+def test_intel_menu_creation_and_state(mock_details_env, monkeypatch):
+    captured, mock_tree = mock_details_env
+    path = "test.py"
+    raw_vals = [path, "90%", "Admin", "User", "80%", "snippet", 1]
+    mock_tree._item_values["item1"] = raw_vals + [json.dumps(raw_vals)]
+    mock_tree.get_children.return_value = ["item1"]
+
+    gptscan.view_details(item_id="item1")
+
+    # Verify Intel Menubutton exists
+    assert "Intel" in captured['menubuttons']
+
+    # Verify the inner menu was created and has items
+    intel_menu = None
+    for menu in captured['menus']:
+        if "Check on VirusTotal" in menu.items:
+            intel_menu = menu
+            break
+
+    assert intel_menu is not None
+    assert "Check on VirusTotal" in intel_menu.items
+    assert "View Online" in intel_menu.items
+
+    # Verify Open and Show in Folder are now buttons (not just in header)
+    assert "Open" in captured['buttons']
+    assert "Show in Folder" in captured['buttons']
+
+    # Verify states in refresh_content for a local file
+    # We need to find the intel menu again as it might have been updated
+    assert intel_menu.configs["View Online"]["state"] == "normal"
+
+    # Test with a virtual path (e.g. from clipboard)
+    path_v = "[Clipboard]"
+    raw_vals_v = [path_v, "90%", "", "", "", "snippet", 1]
+    mock_tree._item_values["item2"] = raw_vals_v + [json.dumps(raw_vals_v)]
+    mock_tree.get_children.return_value = ["item1", "item2"]
+
+    # Trigger refresh by navigating to item2
+    # In our mock, we can just call view_details again with item2
+    gptscan.view_details(item_id="item2")
+
+    # Check that View Online is disabled for non-URL virtual paths
+    # find the new menu created for the second call
+    # Note: refresh_content uses the menu defined in view_details scope
+    intel_menu_v = None
+    for menu in captured['menus']:
+        if "Check on VirusTotal" in menu.items and "View Online" in menu.configs:
+            intel_menu_v = menu
+            # We want the most recent config
+
+    assert intel_menu_v is not None
+    assert intel_menu_v.configs["View Online"]["state"] == "disabled"
+
+    # Verify Open and Reveal are disabled for virtual paths
+    open_btn, _ = captured['buttons']["Open"]
+    reveal_btn, _ = captured['buttons']["Show in Folder"]
+    # We need to check if config was called with state='disabled'
+    open_btn.config.assert_called_with(state='disabled')
+    reveal_btn.config.assert_called_with(state='disabled')
+
+def test_intel_menu_shortcuts(mock_details_env):
+    captured, mock_tree = mock_details_env
+    mock_toplevel = gptscan.tk.Toplevel.return_value
+    path = "test.py"
+    raw_vals = [path, "90%", "", "", "", "snippet", 1]
+    mock_tree._item_values["item1"] = raw_vals + [json.dumps(raw_vals)]
+    mock_tree.get_children.return_value = ["item1"]
+
+    captured_bindings = {}
+    mock_toplevel.bind.side_effect = lambda event, func: captured_bindings.update({event: func})
+
+    gptscan.view_details(item_id="item1")
+
+    assert '<Control-t>' in captured_bindings
+    assert '<Command-t>' in captured_bindings
+    assert '<Control-l>' in captured_bindings
+    assert '<Command-l>' in captured_bindings


### PR DESCRIPTION
This improvement targets the visual hierarchy and consistency of the 'View Details' window in the gptscan GUI. By moving file-level actions ('Open', 'Show in Folder') to the main button bar and consolidating threat intelligence tools into a dropdown menu, the interface reduces visual clutter and aligns with the main application's design patterns. Accessibility is improved through new keyboard shortcuts and comprehensive hover feedback.

- **Friction Reduction:** Added 'Ctrl+T' shortcut for quick VirusTotal checks.
- **Visual Hierarchy:** Grouped related actions (AI Analysis, Management, File Actions, Metadata Copying) with vertical separators.
- **Consistency:** The 'Intel' menu now mirrors the main window's footer layout.
- **Clarity:** Cleared up the header area to give more horizontal space for long file paths.

---
*PR created automatically by Jules for task [17396287776647105951](https://jules.google.com/task/17396287776647105951) started by @RainRat*