### PR TITLE
[FEAT] Scan Git Conflicts

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2818,6 +2818,60 @@ def scan_git_stash_click():
         messagebox.showwarning("Git Stash Error", f"Could not scan Git stashes: {e}")
 
 
+def scan_git_conflicts_click():
+    """Scan files with Git merge conflicts."""
+    try:
+        # Get path from textbox or default to current directory
+        target_path = textbox.get().strip() if textbox else "."
+        if not target_path:
+            target_path = "."
+
+        snippets = get_git_conflict_snippets(target_path)
+        if snippets:
+            button_click(extra_snippets=snippets)
+        else:
+            messagebox.showinfo("Git Conflicts", "No Git merge conflicts found to scan.")
+    except Exception as e:
+        messagebox.showwarning("Git Conflicts Error", f"Could not scan Git conflicts: {e}")
+
+
+def get_git_conflict_snippets(path: str = ".") -> List[Tuple[str, bytes]]:
+    """Get the Git changes for files with merge conflicts.
+
+    Args:
+        path: The folder or file path.
+    """
+    toplevel, _ = _get_git_info(path)
+    if toplevel is None:
+        return []
+
+    try:
+        # Find unmerged files (U filter)
+        cmd_files = ["git", "diff", "--name-only", "--diff-filter=U"]
+        output_files = subprocess.check_output(
+            cmd_files,
+            cwd=toplevel,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+        unmerged_files = output_files.splitlines()
+
+        snippets = []
+        for file_path in unmerged_files:
+            # Get the conflict diff for each file as raw bytes
+            cmd_diff = ["git", "diff", "--no-color", "--", file_path]
+            output_diff = subprocess.check_output(
+                cmd_diff,
+                cwd=toplevel,
+                stderr=subprocess.PIPE
+            )
+            if output_diff.strip():
+                snippets.append((f"[Git Conflict] {file_path}", output_diff))
+        return snippets
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return []
+
+
 def get_git_history_snippets(path: str = ".", count: int = 5) -> List[Tuple[str, bytes]]:
     """Get diffs for the last N commits in the Git repository.
 
@@ -7542,6 +7596,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         git_menu.add_command(label="Scan Git Diff", command=scan_git_diff_click, accelerator="Ctrl+Shift+D")
         git_menu.add_command(label="Scan Git Hooks", command=scan_git_hooks_click, accelerator="Ctrl+Shift+G")
         git_menu.add_command(label="Scan Git Stashes", command=scan_git_stash_click, accelerator="Ctrl+Shift+Q")
+        git_menu.add_command(label="Scan Git Conflicts", command=scan_git_conflicts_click)
         git_menu.add_command(label="Scan Recent Commits...", command=scan_git_history_click)
         git_menu.add_command(label="Scan Git Configuration", command=scan_git_config_click)
         git_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
@@ -8243,6 +8298,11 @@ def main():
         help='Scan all Git stashes.'
     )
     git_group.add_argument(
+        '--git-conflicts',
+        action='store_true',
+        help='Scan files with Git merge conflicts.'
+    )
+    git_group.add_argument(
         '--git-history',
         type=int,
         nargs='?',
@@ -8419,7 +8479,7 @@ def main():
         if not any([
             args.target, args.path, args.stdin, args.import_results, args.files,
             args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
-            args.git_stash, args.git_history, args.shell_profiles, args.shell_history, args.system_path,
+            args.git_stash, args.git_conflicts, args.git_history, args.shell_profiles, args.shell_history, args.system_path,
             args.running_processes, args.scheduled_tasks, args.startup_items,
             args.system_services, args.audit, args.modified, args.downloads, args.desktop,
             args.python_packages, args.nodejs_packages, args.ruby_gems, args.php_packages,
@@ -8514,13 +8574,19 @@ def main():
             for root_dir in git_roots:
                 extra_snippets.extend(get_git_stash_snippets(root_dir))
 
+        if args.git_conflicts:
+            # Use specified targets as git roots, or current folder if none.
+            git_roots = scan_targets if scan_targets else ["."]
+            for root_dir in git_roots:
+                extra_snippets.extend(get_git_conflict_snippets(root_dir))
+
         if args.git_history:
             # Use specified targets as git roots, or current folder if none.
             git_roots = scan_targets if scan_targets else ["."]
             for root_dir in git_roots:
                 extra_snippets.extend(get_git_history_snippets(root_dir, count=args.git_history))
 
-        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not args.git_stash and not args.git_history and not extra_snippets:
+        if not scan_targets and not args.git_changes and not args.git_diff and not args.git_hooks and not args.git_config and not args.git_stash and not args.git_conflicts and not args.git_history and not extra_snippets:
             # Default to current folder if no targets provided and NOT using git-changes
             scan_targets = ["."]
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Access these options from the **Browse** menu:
 *   **Scan Git Diff (Ctrl+Shift+D):** Scan your current project changes as a diff.
 *   **Scan Git Hooks (Ctrl+Shift+G):** Scan your local and global Git hooks for suspicious scripts.
 *   **Scan Git Stashes (Ctrl+Shift+Q):** Scan all Git stashes for suspicious code changes.
+*   **Scan Git Conflicts:** Scan files with Git merge conflicts for suspicious code introduced during merging.
 *   **Scan Git Configuration:** Scan Git settings for dangerous aliases or editors.
 *   **Scan Git Revision...:** Scan files from a specific Git branch or commit.
 
@@ -321,6 +322,11 @@ python3 gptscan.py --git-config --cli
 Scan all Git stashes:
 ```bash
 python3 gptscan.py --git-stash --cli
+```
+
+Scan all files with Git merge conflicts:
+```bash
+python3 gptscan.py --git-conflicts --cli
 ```
 
 #### Advanced Scans

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import subprocess
+import os
+from gptscan import get_git_conflict_snippets
+
+def test_get_git_conflict_snippets_no_git():
+    """Test that it returns empty list if not in a Git repository."""
+    with patch("gptscan._get_git_info", return_value=(None, None)):
+        assert get_git_conflict_snippets() == []
+
+def test_get_git_conflict_snippets_no_conflicts():
+    """Test that it returns empty list if no conflicts are found."""
+    with patch("gptscan._get_git_info", return_value=("/repo", ".")):
+        with patch("subprocess.check_output") as mock_run:
+            # Mock git diff --name-only --diff-filter=U returning nothing
+            mock_run.return_value = ""
+            assert get_git_conflict_snippets("/repo") == []
+            mock_run.assert_called_with(
+                ["git", "diff", "--name-only", "--diff-filter=U"],
+                cwd="/repo",
+                stderr=subprocess.PIPE,
+                universal_newlines=True
+            )
+
+def test_get_git_conflict_snippets_with_conflicts():
+    """Test that it returns snippets for unmerged files."""
+    with patch("gptscan._get_git_info", return_value=("/repo", ".")):
+        with patch("subprocess.check_output") as mock_run:
+            # First call: get unmerged files (universal_newlines=True)
+            # Second and third calls: get diff for each file (raw bytes)
+            mock_run.side_effect = [
+                "file1.py\nfile2.js\n",
+                b"diff content for file1",
+                b"diff content for file2"
+            ]
+
+            snippets = get_git_conflict_snippets("/repo")
+
+            assert len(snippets) == 2
+            assert snippets[0] == ("[Git Conflict] file1.py", b"diff content for file1")
+            assert snippets[1] == ("[Git Conflict] file2.js", b"diff content for file2")
+
+def test_get_git_conflict_snippets_error():
+    """Test that it handles subprocess errors gracefully."""
+    with patch("gptscan._get_git_info", return_value=("/repo", ".")):
+        with patch("subprocess.check_output") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+            assert get_git_conflict_snippets("/repo") == []


### PR DESCRIPTION
This PR introduces a new 'Scan Git Conflicts' feature to the GPT Virus Scanner. 

Merge conflicts are high-risk areas where malicious code or backdoors can be accidentally (or intentionally) introduced during manual resolution. By specifically targeting conflict markers and the associated changes as snippets, we provide developers with a focused safety check during one of the most error-prone phases of the development workflow.

Key changes:
- New helper `get_git_conflict_snippets` identifies unmerged files using `git diff --name-only --diff-filter=U` and extracts conflict hunks using `git diff` (working with raw bytes for binary safety).
- GUI integration: A new "Scan Git Conflicts" option in the Git Integration menu.
- CLI integration: A new `--git-conflicts` flag.
- Documentation: Updated `readme.md` to include the new feature.
- Testing: Comprehensive unit tests in `tests/test_git_conflicts.py`.

---
*PR created automatically by Jules for task [14864209257005522243](https://jules.google.com/task/14864209257005522243) started by @RainRat*