### PR TITLE
[TEST] Improve Git history scan reliability and add coverage for partial failures

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2842,18 +2842,21 @@ def get_git_history_snippets(path: str = ".", count: int = 5) -> List[Tuple[str,
 
         snippets = []
         for commit_hash in hashes:
-            # Get the diff for each commit
-            cmd_show = ["git", "show", "--no-color", commit_hash]
-            show_output = subprocess.check_output(
-                cmd_show,
-                cwd=toplevel,
-                stderr=subprocess.PIPE,
-                universal_newlines=True
-            )
-            if show_output.strip():
-                # Extract short hash for naming
-                short_hash = commit_hash[:7]
-                snippets.append((f"[Git History] commit {short_hash}", show_output.encode('utf-8')))
+            try:
+                # Get the diff for each commit
+                cmd_show = ["git", "show", "--no-color", commit_hash]
+                show_output = subprocess.check_output(
+                    cmd_show,
+                    cwd=toplevel,
+                    stderr=subprocess.PIPE,
+                    universal_newlines=True
+                )
+                if show_output.strip():
+                    # Extract short hash for naming
+                    short_hash = commit_hash[:7]
+                    snippets.append((f"[Git History] commit {short_hash}", show_output.encode('utf-8')))
+            except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+                continue
         return snippets
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return []

--- a/tests/test_git_history_gap.py
+++ b/tests/test_git_history_gap.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import gptscan
+import subprocess
+
+def test_get_git_history_snippets_partial_failure(monkeypatch):
+    """Verify that a single commit failure doesn't cause the whole history scan to fail."""
+    monkeypatch.setattr("gptscan._get_git_info", lambda p: ("/repo", "."))
+
+    def mock_check_output(cmd, cwd=None, **kwargs):
+        if "rev-list" in cmd:
+            return "hash1\nhash2\nhash3\n"
+        elif "show" in cmd:
+            if "hash2" in cmd:
+                # Simulate failure for the second hash
+                raise subprocess.CalledProcessError(1, cmd)
+            return f"commit {cmd[-1]}\nAuthor: test\n\ndiff --git a/file.py b/file.py\n+new line"
+        return ""
+
+    monkeypatch.setattr("subprocess.check_output", mock_check_output)
+
+    # After fix: should return 2 snippets (hash1 and hash3)
+    snippets = gptscan.get_git_history_snippets(".", count=3)
+    assert len(snippets) == 2
+    assert snippets[0][0] == "[Git History] commit hash1"
+    assert snippets[1][0] == "[Git History] commit hash3"


### PR DESCRIPTION
Modified `get_git_history_snippets` in `gptscan.py` to handle individual commit failures. Previously, if `git show` failed for any one commit hash, the entire function would catch the exception at the top level and return an empty list. Now, it skips the failed commit and continues processing others. A new test `tests/test_git_history_gap.py` was added to verify this partial failure recovery.

---
*PR created automatically by Jules for task [8293620193188351097](https://jules.google.com/task/8293620193188351097) started by @RainRat*