### PR TITLE
[UI/UX] Consolidate details window intelligence actions into an Intel menu

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6748,13 +6748,14 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     if not Config.GPT_ENABLED:
         analyze_btn.config(state='disabled')
 
-    vt_btn = ttk.Button(btn_frame, text="VirusTotal", width=12, command=lambda: check_virustotal(path_entry.get()))
-    vt_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(vt_btn, "Check this file's hash on VirusTotal.", label=status_bar)
+    intel_btn = ttk.Menubutton(btn_frame, text="Intel", width=12)
+    intel_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    bind_hover_message(intel_btn, "Threat intelligence for this item (VirusTotal, online repository).", label=status_bar)
 
-    view_online_btn = ttk.Button(btn_frame, text="View Online", width=14, command=lambda: view_online(path_entry.get(), line=line_label.cget("text")))
-    view_online_btn.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(view_online_btn, "View this file in its online repository. (Ctrl+L)", label=status_bar)
+    intel_menu = tk.Menu(intel_btn, tearoff=0)
+    intel_menu.add_command(label="Check on VirusTotal", command=lambda: check_virustotal(path_entry.get()), accelerator="Ctrl+T")
+    intel_menu.add_command(label="View Online", command=lambda: view_online(path_entry.get(), line=line_label.cget("text")), accelerator="Ctrl+L")
+    intel_btn["menu"] = intel_menu
 
     ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
 
@@ -6816,8 +6817,12 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
         analyze_btn.config(state='disabled' if is_scanning or not Config.GPT_ENABLED else 'normal')
         exclude_btn.config(state='disabled' if is_scanning or is_virtual else 'normal')
         open_btn.config(state='disabled' if is_virtual else 'normal')
-        vt_btn.config(state='normal')
-        view_online_btn.config(state='disabled' if is_non_url_virtual else 'normal')
+        intel_btn.config(state='disabled' if is_scanning else 'normal')
+        try:
+            intel_menu.entryconfig("Check on VirusTotal", state='normal')
+            intel_menu.entryconfig("View Online", state='disabled' if is_non_url_virtual else 'normal')
+        except tk.TclError:
+            pass
         path_copy_btn.config(state='normal')
         reveal_btn.config(state='disabled' if is_virtual else 'normal')
 
@@ -6949,6 +6954,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     details_win.bind('<Command-h>', lambda e: copy_sha256_details())
     details_win.bind('<Control-g>', lambda e: on_analyze_now())
     details_win.bind('<Command-g>', lambda e: on_analyze_now())
+    details_win.bind('<Control-t>', lambda e: check_virustotal(path_entry.get()))
+    details_win.bind('<Command-t>', lambda e: check_virustotal(path_entry.get()))
     details_win.bind('<Control-l>', lambda e: view_online(path_entry.get(), line=line_label.cget("text")))
     details_win.bind('<Command-l>', lambda e: view_online(path_entry.get(), line=line_label.cget("text")))
     details_win.bind('<Control-Shift-C>', lambda e: copy_analysis())

--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,10 @@ The scanner includes shortcuts for faster navigation.
 | `Ctrl+U` | Toggle Full Source |
 | `Ctrl+S` | Copy Code Snippet |
 | `Ctrl+Shift+C` | Copy AI Analysis |
+| `Ctrl+H` | Copy SHA-256 Hash |
 | `Ctrl+J` | Copy JSON Data |
+| `Ctrl+Shift+R` | Copy as Triage Report |
+| `Ctrl+T` | Check on VirusTotal |
 | `Ctrl+L` | View Online |
 | `Shift+Enter` | Open File |
 | `Ctrl+Enter` | Reveal in Folder |

--- a/tests/test_details_intel_menu.py
+++ b/tests/test_details_intel_menu.py
@@ -1,0 +1,61 @@
+import pytest
+import json
+import tkinter as tk
+from unittest.mock import MagicMock, patch
+import gptscan
+from tests.test_view_details import mock_view_details_env, setup_details
+
+def test_details_intel_menu_init(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    # Setup a result
+    raw = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1]
+    mock_tree._item_values["item1"] = ["test.py", "90%", "Admin", "User", "80%", "print('hello')", 1, json.dumps(raw)]
+    mock_tree.get_children.return_value = ["item1"]
+    mock_tree.selection.return_value = ["item1"]
+
+    gptscan.view_details(item_id="item1")
+
+    # Check if Intel Menubutton exists
+    assert "menubtn_Intel" in captured
+    intel_btn_mock, intel_btn_menu = captured["menubtn_Intel"]
+
+    # Check menu items
+    menu_items = captured.get("menu_items_" + str(id(intel_btn_menu)), [])
+    labels = [item[0] for item in menu_items]
+    assert "Check on VirusTotal" in labels
+    assert "View Online" in labels
+
+def test_details_intel_menu_state_virtual(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    # Setup a virtual result (inside archive)
+    raw = ["[ZIP] test.py", "90%", "Admin", "User", "80%", "print('hello')", 1]
+    mock_tree._item_values["item1"] = ["[ZIP] test.py", "90%", "Admin", "User", "80%", "print('hello')", 1, json.dumps(raw)]
+    mock_tree.get_children.return_value = ["item1"]
+    mock_tree.selection.return_value = ["item1"]
+
+    gptscan.view_details(item_id="item1")
+
+    intel_btn_mock, intel_btn_menu = captured["menubtn_Intel"]
+
+    # Check if 'View Online' is disabled for non-URL virtual paths
+    # We need to find the entryconfig calls for this menu
+    entryconfigs = captured.get("menu_entryconfigs_" + str(id(intel_btn_menu)), {})
+    assert entryconfigs.get("View Online", {}).get("state") == "disabled"
+    assert entryconfigs.get("Check on VirusTotal", {}).get("state") == "normal"
+
+def test_details_intel_menu_state_url(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    # Setup a URL result
+    raw = ["[URL] https://github.com/user/repo/file.py", "90%", "Admin", "User", "80%", "print('hello')", 1]
+    mock_tree._item_values["item1"] = ["[URL] https://github.com/user/repo/file.py", "90%", "Admin", "User", "80%", "print('hello')", 1, json.dumps(raw)]
+    mock_tree.get_children.return_value = ["item1"]
+    mock_tree.selection.return_value = ["item1"]
+
+    gptscan.view_details(item_id="item1")
+
+    intel_btn_mock, intel_btn_menu = captured["menubtn_Intel"]
+
+    # Check if 'View Online' is enabled for URL paths
+    entryconfigs = captured.get("menu_entryconfigs_" + str(id(intel_btn_menu)), {})
+    assert entryconfigs.get("View Online", {}).get("state") == "normal"
+    assert entryconfigs.get("Check on VirusTotal", {}).get("state") == "normal"

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -117,9 +117,17 @@ def mock_view_details_env(monkeypatch):
             if label:
                 self.items[label] = kwargs.get('command')
                 captured[f"menu_{label}"] = kwargs.get('command')
+                if f"menu_items_{id(self)}" not in captured:
+                    captured[f"menu_items_{id(self)}"] = []
+                captured[f"menu_items_{id(self)}"].append((label, kwargs.get('command')))
         def add_separator(self): pass
         def add_cascade(self, **kwargs): pass
-        def entryconfig(self, index, **kwargs): pass
+        def entryconfig(self, index, **kwargs):
+            if f"menu_entryconfigs_{id(self)}" not in captured:
+                captured[f"menu_entryconfigs_{id(self)}"] = {}
+            if index not in captured[f"menu_entryconfigs_{id(self)}"]:
+                captured[f"menu_entryconfigs_{id(self)}"][index] = {}
+            captured[f"menu_entryconfigs_{id(self)}"][index].update(kwargs)
 
     monkeypatch.setattr(gptscan.tk, 'Menu', MockMenu)
 
@@ -127,7 +135,11 @@ def mock_view_details_env(monkeypatch):
         mb = MagicMock()
         text = kwargs.get('text', '')
         if text:
-            captured[f"mb_{text}"] = mb
+            captured[f"menubtn_{text}"] = (mb, None)
+            def setitem(key, value):
+                if key == "menu":
+                    captured[f"menubtn_{text}"] = (mb, value)
+            mb.__setitem__.side_effect = setitem
         return mb
     monkeypatch.setattr(gptscan.ttk, 'Menubutton', mock_menubutton_init)
 


### PR DESCRIPTION
This PR improves the UI/UX of the result details window by consolidating related external intelligence actions into a single "Intel" menu. This reduces visual clutter in the footer and provides a more organized experience for power users.

Changes:
- Replaced separate 'VirusTotal' and 'View Online' buttons with a `ttk.Menubutton`.
- Integrated `Ctrl+T` / `Command+T` as a new shortcut for VirusTotal.
- Maintained context-sensitive logic (disabling 'View Online' for non-URL virtual paths).
- Updated `readme.md` with new keyboard shortcuts and expanded the 'Details Window' section.
- Added and verified new tests for the consolidated menu and its dynamic states.

---
*PR created automatically by Jules for task [6403318086715171189](https://jules.google.com/task/6403318086715171189) started by @RainRat*