### PR TITLE
[UI/UX] Improve Git history and reflog scanning efficiency with presets

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2916,10 +2916,11 @@ def get_git_reflog_snippets(path: str = ".", count: int = 5) -> List[Tuple[str, 
         return []
 
 
-def scan_git_history_click():
+def scan_git_history_click(count=None):
     """Scan recent Git commits."""
     try:
-        count = simpledialog.askinteger("Scan Recent Commits", "Enter number of recent commits to scan:", initialvalue=5, minvalue=1, maxvalue=100)
+        if count is None:
+            count = simpledialog.askinteger("Scan Recent Commits", "Enter number of recent commits to scan:", initialvalue=5, minvalue=1, maxvalue=100)
         if count is None:
             return
 
@@ -2938,10 +2939,11 @@ def scan_git_history_click():
         messagebox.showwarning("Git History Error", f"Could not scan Git history: {e}")
 
 
-def scan_git_reflog_click():
+def scan_git_reflog_click(count=None):
     """Scan recent entries in the Git reflog."""
     try:
-        count = simpledialog.askinteger("Scan Git Reflog", "Enter number of recent reflog entries to scan:", initialvalue=5, minvalue=1, maxvalue=100)
+        if count is None:
+            count = simpledialog.askinteger("Scan Git Reflog", "Enter number of recent reflog entries to scan:", initialvalue=5, minvalue=1, maxvalue=100)
         if count is None:
             return
 
@@ -7572,8 +7574,23 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
         git_menu.add_command(label="Scan Git Hooks", command=scan_git_hooks_click, accelerator="Ctrl+Shift+G")
         git_menu.add_command(label="Scan Git Stashes", command=scan_git_stash_click, accelerator="Ctrl+Shift+Q")
         git_menu.add_command(label="Scan Git Conflicts", command=scan_git_conflicts_click)
-        git_menu.add_command(label="Scan Recent Commits...", command=scan_git_history_click)
-        git_menu.add_command(label="Scan Git Reflog...", command=scan_git_reflog_click)
+
+        history_menu = tk.Menu(git_menu, tearoff=0)
+        history_menu.add_command(label="Last 5 Commits", command=lambda: scan_git_history_click(5))
+        history_menu.add_command(label="Last 10 Commits", command=lambda: scan_git_history_click(10))
+        history_menu.add_command(label="Last 25 Commits", command=lambda: scan_git_history_click(25))
+        history_menu.add_separator()
+        history_menu.add_command(label="Custom...", command=scan_git_history_click)
+        git_menu.add_cascade(label="Scan Recent Commits", menu=history_menu)
+
+        reflog_menu = tk.Menu(git_menu, tearoff=0)
+        reflog_menu.add_command(label="Last 5 Entries", command=lambda: scan_git_reflog_click(5))
+        reflog_menu.add_command(label="Last 10 Entries", command=lambda: scan_git_reflog_click(10))
+        reflog_menu.add_command(label="Last 25 Entries", command=lambda: scan_git_reflog_click(25))
+        reflog_menu.add_separator()
+        reflog_menu.add_command(label="Custom...", command=scan_git_reflog_click)
+        git_menu.add_cascade(label="Scan Git Reflog", menu=reflog_menu)
+
         git_menu.add_command(label="Scan Git Configuration", command=scan_git_config_click)
         git_menu.add_command(label="Scan Git Revision...", command=scan_git_revision_click)
         parent.add_cascade(label="Git Integration", menu=git_menu)
@@ -7687,8 +7704,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_menu.add_command(label="Scan Web Link...", command=select_url_click, accelerator="Ctrl+Shift+U")
     browse_menu.add_command(label="Scan File List...", command=browse_file_list_click)
     browse_menu.add_command(label="Scan Clipboard", command=scan_clipboard_click, accelerator="Ctrl+Shift+V")
-    browse_menu.add_command(label="Scan Recent Commits...", command=scan_git_history_click)
-    browse_menu.add_command(label="Scan Git Reflog...", command=scan_git_reflog_click)
     browse_menu.add_separator()
     add_scan_submenus(browse_menu)
     browse_button["menu"] = browse_menu

--- a/tests/test_git_history_presets.py
+++ b/tests/test_git_history_presets.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter before importing gptscan
+import sys
+import tkinter as tk
+sys.modules['tkinter'] = MagicMock()
+sys.modules['tkinter.ttk'] = MagicMock()
+sys.modules['tkinter.filedialog'] = MagicMock()
+sys.modules['tkinter.messagebox'] = MagicMock()
+sys.modules['tkinter.simpledialog'] = MagicMock()
+
+import gptscan
+
+# Mock the global textbox object
+gptscan.textbox = MagicMock()
+
+def test_scan_git_history_click_with_count():
+    with patch('gptscan.simpledialog.askinteger') as mock_ask:
+        with patch('gptscan.get_git_history_snippets', return_value=['snippet1']) as mock_get:
+            with patch('gptscan.button_click') as mock_click:
+                gptscan.textbox.get.return_value = '.'
+                gptscan.scan_git_history_click(count=10)
+                mock_ask.assert_not_called()
+                mock_get.assert_called_with('.', count=10)
+                mock_click.assert_called_once()
+
+def test_scan_git_history_click_without_count():
+    with patch('gptscan.simpledialog.askinteger', return_value=5) as mock_ask:
+        with patch('gptscan.get_git_history_snippets', return_value=['snippet1']) as mock_get:
+            with patch('gptscan.button_click') as mock_click:
+                gptscan.textbox.get.return_value = '.'
+                gptscan.scan_git_history_click()
+                mock_ask.assert_called_once()
+                mock_get.assert_called_with('.', count=5)
+                mock_click.assert_called_once()
+
+def test_scan_git_reflog_click_with_count():
+    with patch('gptscan.simpledialog.askinteger') as mock_ask:
+        with patch('gptscan.get_git_reflog_snippets', return_value=['snippet1']) as mock_get:
+            with patch('gptscan.button_click') as mock_click:
+                gptscan.textbox.get.return_value = '.'
+                gptscan.scan_git_reflog_click(count=15)
+                mock_ask.assert_not_called()
+                mock_get.assert_called_with('.', count=15)
+                mock_click.assert_called_once()


### PR DESCRIPTION
### [UI/UX] Improve Git history and reflog scanning efficiency with presets

**Context:** GUI

**Problem:** 
Scanning recent Git history or the reflog previously required answering a modal dialog every time, even for common tasks like checking the last 5 commits. This created friction in a high-frequency workflow. Furthermore, these actions were redundantly placed at the top level of the "Browse" menu, cluttering the interface and lacking consistency with the "Scan" menu's structure.

**Solution:**
This change introduces nested submenus for **Scan Recent Commits** and **Scan Git Reflog** containing sensible presets ("Last 5", "Last 10", "Last 25") and a "Custom..." option. The underlying handlers were refactored to support optional count parameters, allowing the presets to trigger scans instantly while preserving the ability to specify a custom range. Redundant entries were removed from the Browse menu, streamlining the interface and adhering to "Invisible Design" principles by making common power-user actions more accessible without adding visual noise.

**Changes:**
- **gptscan.py**:
    - Updated `scan_git_history_click` and `scan_git_reflog_click` to bypass the `simpledialog` when a `count` is provided.
    - Updated `add_scan_submenus` to create the new cascading preset menus.
    - Cleaned up the `Browse` button menu in `create_gui` to remove redundant entries.
- **tests/test_git_history_presets.py**: Added new tests to verify the preset logic and dialog bypassing.

---
*PR created automatically by Jules for task [8163244013106417475](https://jules.google.com/task/8163244013106417475) started by @RainRat*