### PR TITLE
[TEST] Improve get_online_url robustness and coverage

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2113,6 +2113,18 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
         if '/-/raw/' in url.lower():
             url = url.replace('/-/raw/', '/-/blob/')
 
+        # Bitbucket Raw: https://bitbucket.org/user/repo/raw/rev/path
+        if 'bitbucket.org' in url.lower() and '/raw/' in url.lower():
+            url = url.replace('/raw/', '/src/')
+
+        # Hugging Face Raw: https://huggingface.co/user/repo/raw/main/file
+        if 'huggingface.co' in url.lower() and '/raw/' in url.lower():
+            url = url.replace('/raw/', '/blob/')
+
+        # Pastebin Raw: https://pastebin.com/raw/id
+        if 'pastebin.com' in url.lower() and '/raw/' in url.lower():
+            url = url.replace('/raw/', '/')
+
         # Append line fragment
         if line_val:
             if 'bitbucket.org' in url.lower():
@@ -2154,7 +2166,8 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
 
     # Normalize Remote URL (Convert SSH to HTTPS, remove .git suffix)
     # git@host:user/repo.git -> https://host/user/repo
-    remote = re.sub(r'^git@([^:]+):', r'https://\1/', remote)
+    # ssh://git@host/user/repo.git -> https://host/user/repo
+    remote = re.sub(r'^(?:ssh://)?git@([^:/]+)[:/]', r'https://\1/', remote)
     remote = re.sub(r'\.git$', '', remote)
     remote = remote.rstrip('/')
 

--- a/tests/test_get_online_url_robustness.py
+++ b/tests/test_get_online_url_robustness.py
@@ -1,0 +1,60 @@
+import pytest
+from gptscan import get_online_url
+from unittest.mock import patch
+
+def test_get_online_url_remote_target_restoration():
+    # GitHub (Existing)
+    url = get_online_url("[URL] https://raw.githubusercontent.com/user/repo/main/file.py", 10)
+    assert url == "https://github.com/user/repo/blob/main/file.py#L10"
+
+    # GitLab (Existing)
+    url = get_online_url("[URL] https://gitlab.com/user/repo/-/raw/main/file.py", 10)
+    assert url == "https://gitlab.com/user/repo/-/blob/main/file.py#L10"
+
+    # Bitbucket (New)
+    url = get_online_url("[URL] https://bitbucket.org/user/repo/raw/main/file.py", 10)
+    assert url == "https://bitbucket.org/user/repo/src/main/file.py#lines-10"
+
+    # Pastebin (New)
+    url = get_online_url("[URL] https://pastebin.com/raw/abcdefgh", 1)
+    assert url == "https://pastebin.com/abcdefgh#L1"
+
+    # Hugging Face (New)
+    url = get_online_url("[URL] https://huggingface.co/user/repo/raw/main/model.py", 5)
+    assert url == "https://huggingface.co/user/repo/blob/main/model.py#L5"
+
+@patch('gptscan._get_git_info')
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_ssh_formats(mock_check_output, mock_info):
+    mock_info.return_value = ("/app", "src/file.py")
+
+    # Test ssh://git@github.com/user/repo.git
+    def side_effect_ssh_protocol(cmd, **kwargs):
+        if "remote" in cmd: return "ssh://git@github.com/user/repo.git"
+        return "abcdef"
+
+    mock_check_output.side_effect = side_effect_ssh_protocol
+    url = get_online_url("/app/src/file.py", 10)
+    assert url == "https://github.com/user/repo/blob/abcdef/src/file.py#L10"
+
+    # Test git@github.com:user/repo.git (Standard SSH)
+    def side_effect_standard_ssh(cmd, **kwargs):
+        if "remote" in cmd: return "git@github.com:user/repo.git"
+        return "abcdef"
+
+    mock_check_output.side_effect = side_effect_standard_ssh
+    url = get_online_url("/app/src/file.py", 10)
+    assert url == "https://github.com/user/repo/blob/abcdef/src/file.py#L10"
+
+@patch('gptscan._get_git_info')
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_local_bitbucket(mock_check_output, mock_info):
+    mock_info.return_value = ("/app", "src/file.py")
+
+    def side_effect(cmd, **kwargs):
+        if "remote" in cmd: return "https://bitbucket.org/user/repo.git"
+        return "main"
+
+    mock_check_output.side_effect = side_effect
+    url = get_online_url("/app/src/file.py", 10)
+    assert url == "https://bitbucket.org/user/repo/src/main/src/file.py#lines-10"


### PR DESCRIPTION
This PR improves the `get_online_url` function in `gptscan.py` to handle a wider variety of Git remote configurations and remote target URLs.

### Changes:
- **SSH Normalization:** Updated the regex to support both standard `git@host:user/repo.git` and URI-style `ssh://git@host/user/repo.git` formats.
- **URL Restoration:** Added logic to convert raw web links from Bitbucket, Pastebin, and Hugging Face back into their respective web-viewable versions (e.g., changing `/raw/` to `/src/` or `/blob/`). This ensures that when a user clicks "View Online" for a result imported from a raw source, they are taken to a user-friendly page with line highlighting rather than just the raw text.
- **Tests:** Introduced `tests/test_get_online_url_robustness.py` which mocks various Git remote configurations and tests the restoration logic for multiple platforms.

Verified with 42 tests passing across relevant test suites.

---
*PR created automatically by Jules for task [6375975676260250313](https://jules.google.com/task/6375975676260250313) started by @RainRat*