### PR TITLE
[UI/UX] Consolidate Scan and Cancel buttons into a dynamic unified button

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -48,7 +48,6 @@ filter_var: Optional[tk.StringVar] = None
 filter_entry: Optional[ttk.Entry] = None
 tree: Optional[ttk.Treeview] = None
 scan_button: Optional[ttk.Button] = None
-cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
 open_button: Optional[ttk.Button] = None
@@ -2772,14 +2771,13 @@ def set_scanning_state(is_scanning: bool) -> None:
         update_button_states()
 
     if scan_button:
-        new_state = "disabled" if is_scanning else "normal"
         if is_scanning:
-            scan_button.config(text="Scanning...", state=new_state)
+            scan_button.config(text="Stop Scan")
+            bind_hover_message(scan_button, "Stop the current scan. (Esc)")
         else:
-            scan_button.config(text="Scan Now", state=new_state)
+            scan_button.config(text="Scan Now")
+            bind_hover_message(scan_button, "Start the scan. (Enter)")
             toggle_dry_run()
-    if cancel_button:
-        cancel_button.config(state="normal" if is_scanning else "disabled")
 
     # Disable/Enable configuration widgets during scan
     config_widgets = [
@@ -7700,7 +7698,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     Returns:
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7845,13 +7843,16 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
     bind_hover_message(browse_button, "Select scan targets or perform system audits.")
 
-    scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
-    scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
-    bind_hover_message(scan_button, "Start the scan. (Enter)")
+    def on_scan_action():
+        """Handle the unified scan/stop button action."""
+        if current_cancel_event is not None:
+            cancel_scan()
+        else:
+            button_click()
 
-    cancel_button = ttk.Button(button_box, text="Cancel", command=cancel_scan, state="disabled", width=10)
-    cancel_button.pack(side=tk.LEFT, padx=(2, 0), ipady=5)
-    bind_hover_message(cancel_button, "Stop the current scan. (Esc)")
+    scan_button = ttk.Button(button_box, text="Scan Now", command=on_scan_action, style='Primary.TButton', default='active', width=15)
+    scan_button.pack(side=tk.LEFT, padx=(5, 0), ipady=5)
+    bind_hover_message(scan_button, "Start the scan. (Enter)")
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -85,13 +85,11 @@ def test_set_scanning_state_updates_buttons(monkeypatch):
 
     # Test scanning=True
     gptscan.set_scanning_state(True)
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
-    mock_cancel_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Stop Scan")
 
     # Test scanning=False
     gptscan.set_scanning_state(False)
-    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(text="Scan Now")
 
 def test_finish_scan_state_resets_state(monkeypatch):
     # Setup
@@ -115,8 +113,7 @@ def test_finish_scan_state_resets_state(monkeypatch):
     # because it avoids overwriting a possible "Scan cancelled" status set by _consume_scan_events.
     mock_status_label.config.assert_not_called()
     assert gptscan.current_cancel_event is None
-    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(text="Scan Now")
 
 def test_cancel_scan_triggers_event(monkeypatch):
     # Setup
@@ -223,7 +220,7 @@ def test_button_click_starts_scan(monkeypatch):
     # Assert
     mock_status_label.config.assert_called_with(text="Starting scan...")
     assert gptscan.current_cancel_event is not None
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
+    mock_scan_button.config.assert_called_with(text="Stop Scan")
 
     # Check thread creation
     mock_thread_cls.assert_called_once()

--- a/tests/test_intel_menu_ui.py
+++ b/tests/test_intel_menu_ui.py
@@ -65,7 +65,7 @@ def test_intel_button_disabled_during_scan(mock_gui, monkeypatch):
         'textbox', 'clear_target_btn', 'browse_button',
         'git_checkbox', 'deep_checkbox', 'scan_all_checkbox', 'dry_checkbox',
         'gpt_checkbox', 'provider_combo', 'model_combo', 'api_entry', 'show_key_btn',
-        'copy_cmd_button', 'scan_button', 'cancel_button'
+        'copy_cmd_button', 'scan_button'
     ]
     for name in monkeypatch_config:
         monkeypatch.setattr(gptscan, name, MagicMock())

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -18,7 +18,6 @@ def test_open_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -17,7 +17,6 @@ def test_reveal_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)


### PR DESCRIPTION
### Context
(GUI)

### Problem
The interface featured separate "Scan Now" and "Cancel" buttons in the input area. This created visual clutter and required users to track two different targets for related actions. Additionally, the "Cancel" button remained disabled and greyed-out during idle states, adding unnecessary visual noise without providing utility.

### Solution
Consolidated the scanning and cancellation actions into a single, dynamic primary button. 
- When idle, the button displays **"Scan Now"** and initiates the scan.
- During an active scan, the button transforms into **"Stop Scan"**, providing an immediate and intuitive way to halt the process using the same visual focal point.

This change adheres to **Friction Reduction** and **Visual Hierarchy** principles by simplifying the primary call-to-action and reclaiming interface space.

### Changes
- **gptscan.py**: 
    - Removed the `cancel_button` widget and its global declaration.
    - Introduced `on_scan_action()` in `create_gui` to handle context-aware clicks.
    - Updated `set_scanning_state()` to manage dynamic text and hover messages for `scan_button`.
- **tests/**:
    - Updated `test_gui_logic.py`, `test_intel_menu_ui.py`, `test_open_button.py`, and `test_reveal_button.py` to remove `cancel_button` mocks and verify the new unified button state transitions.

---
*PR created automatically by Jules for task [12668165244619445914](https://jules.google.com/task/12668165244619445914) started by @RainRat*