### PR TITLE
Fix TypeError and iterator exhaustion in get_wrapped_values

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1064,13 +1064,14 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
 
 def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optional[Callable[[str], int]] = None, col_widths: Optional[List[int]] = None) -> List[Any]:
     """Wrap a list of values to fit the current Treeview column widths."""
+    values_list = list(values)
     measure = measure or (default_font_measure or tkinter.font.Font(font='TkDefaultFont').measure)
     col_widths = col_widths or [tree.column(cid)['width'] for cid in tree['columns']]
 
     # Only wrap the first 6 columns, leave the rest (including line and hidden orig_json) as is
-    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(list(values)[:6], col_widths[:6])]
-    if len(values) > 6:
-        wrapped.extend(list(values)[6:])
+    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(values_list[:6], col_widths[:6])]
+    if len(values_list) > 6:
+        wrapped.extend(values_list[6:])
     return wrapped
 
 

--- a/tests/test_get_wrapped_values_bug.py
+++ b/tests/test_get_wrapped_values_bug.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import MagicMock
+from gptscan import get_wrapped_values
+
+def test_get_wrapped_values_with_generator():
+    """Verify that get_wrapped_values correctly handles a generator without TypeError or exhaustion."""
+    mock_tree = MagicMock()
+    # Mock tree['columns']
+    mock_tree.__getitem__.return_value = ["c1", "c2", "c3", "c4", "c5", "c6", "c7"]
+    # Mock tree.column(cid)['width']
+    mock_tree.column.return_value = {'width': 100}
+
+    def mock_measure(text):
+        return len(str(text)) * 10
+
+    # Generator with 8 items
+    def gen():
+        for i in range(1, 9):
+            yield f"item{i}"
+
+    # This is expected to FAIL before the fix
+    result = get_wrapped_values(mock_tree, gen(), measure=mock_measure)
+
+    # If it didn't raise TypeError, it might still fail due to exhaustion
+    assert len(result) == 8
+    assert result[0].startswith("item1") # adjust_newlines might add wrap markers
+    assert result[7] == "item8"


### PR DESCRIPTION
* **What:** Modified `get_wrapped_values` in `gptscan.py` to convert the `values` iterable into a list once at the beginning of the function. Added a regression test in `tests/test_get_wrapped_values_bug.py`.
* **Why:** The previous implementation attempted to call `len()` on the `values` iterable and iterated over it multiple times using `list(values)`. This caused a `TypeError` when passed a generator and led to iterator exhaustion, resulting in incorrect data or crashes when processing non-list iterables. This change ensures robustness across all iterable types used in the GUI.

---
*PR created automatically by Jules for task [165000890097648330](https://jules.google.com/task/165000890097648330) started by @RainRat*