### PR TITLE
[TEST] Fix TypeError and iterator exhaustion in get_wrapped_values

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1064,13 +1064,15 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
 
 def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optional[Callable[[str], int]] = None, col_widths: Optional[List[int]] = None) -> List[Any]:
     """Wrap a list of values to fit the current Treeview column widths."""
+    # Convert to list once to support generators and avoid multiple traversals
+    values_list = list(values)
     measure = measure or (default_font_measure or tkinter.font.Font(font='TkDefaultFont').measure)
     col_widths = col_widths or [tree.column(cid)['width'] for cid in tree['columns']]
 
     # Only wrap the first 6 columns, leave the rest (including line and hidden orig_json) as is
-    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(list(values)[:6], col_widths[:6])]
-    if len(values) > 6:
-        wrapped.extend(list(values)[6:])
+    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(values_list[:6], col_widths[:6])]
+    if len(values_list) > 6:
+        wrapped.extend(values_list[6:])
     return wrapped
 
 

--- a/tests/test_get_wrapped_values_robustness.py
+++ b/tests/test_get_wrapped_values_robustness.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import Iterable, Any
+from gptscan import get_wrapped_values
+import json
+
+def test_get_wrapped_values_with_generator(monkeypatch):
+    """Verify that get_wrapped_values handles generators correctly without raising TypeError."""
+    mock_tree = MagicMock()
+    # Mock tree['columns'] to return a list of 7 column names
+    mock_tree.__getitem__.side_effect = lambda key: ("c1", "c2", "c3", "c4", "c5", "c6", "orig_json") if key == "columns" else MagicMock()
+    mock_tree.column.return_value = {"width": 100}
+
+    # Mock font measurement
+    monkeypatch.setattr("tkinter.font.Font", MagicMock())
+
+    # Create a generator for input values
+    raw_data = ["path/to/file", "50%", "admin", "user", "40%", "snippet", '{"key": "value"}']
+    gen_values = (v for v in raw_data)
+
+    # This should not raise TypeError: object of type 'generator' has no len()
+    try:
+        result = get_wrapped_values(mock_tree, gen_values)
+    except TypeError as e:
+        pytest.fail(f"get_wrapped_values raised TypeError with generator: {e}")
+
+    assert len(result) == 7
+    # Verify content (assuming adjust_newlines might have modified them, but they should be present)
+    assert "path/to/file" in result[0]
+    assert result[6] == '{"key": "value"}'
+
+def test_get_wrapped_values_preserves_extra_values(monkeypatch):
+    """Verify that values beyond index 6 are preserved correctly when using a generator."""
+    mock_tree = MagicMock()
+    mock_tree.__getitem__.side_effect = lambda key: ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8") if key == "columns" else MagicMock()
+    mock_tree.column.return_value = {"width": 100}
+    monkeypatch.setattr("tkinter.font.Font", MagicMock())
+
+    raw_data = ["v1", "v2", "v3", "v4", "v5", "v6", "extra1", "extra2"]
+    gen_values = (v for v in raw_data)
+
+    result = get_wrapped_values(mock_tree, gen_values)
+
+    assert len(result) == 8
+    assert result[6] == "extra1"
+    assert result[7] == "extra2"


### PR DESCRIPTION
This PR addresses a bug in the `get_wrapped_values` function where passing a generator as the `values` argument would cause a `TypeError` due to an attempt to call `len()` on the generator. Additionally, the original code traversed the iterable multiple times, which would result in empty data after the first pass for generators.

### Changes:
- **Bug Fix**: In `gptscan.py`, `get_wrapped_values` now converts its `values` argument to a list immediately.
- **New Test**: Added `tests/test_get_wrapped_values_robustness.py` which specifically tests the function with generators and verifies that data is not lost.

### Verification:
- Ran the new tests: `tests/test_get_wrapped_values_robustness.py` (Passed).
- Ran existing related tests: `tests/test_utility_gaps.py`, `tests/test_motion_handler.py` (Passed).
- Ran the full suite (948 tests passed).
- Verified that no temporary log files or reproduction scripts are included in the commit.

---
*PR created automatically by Jules for task [9444077161570774031](https://jules.google.com/task/9444077161570774031) started by @RainRat*