### PR TITLE
[TEST] Improve online URL restoration and SSH remote normalization

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -2111,7 +2111,19 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
 
         # GitLab Raw: https://gitlab.com/user/repo/-/raw/rev/path
         if '/-/raw/' in url.lower():
-            url = url.replace('/-/raw/', '/-/blob/')
+            url = url.replace('/-/raw/', '/-/blob/', 1)
+
+        # Bitbucket Raw: https://bitbucket.org/user/repo/raw/rev/path
+        if '/raw/' in url.lower() and 'bitbucket.org' in url.lower():
+            url = url.replace('/raw/', '/src/', 1)
+
+        # Pastebin Raw: https://pastebin.com/raw/id
+        if '/raw/' in url.lower() and 'pastebin.com' in url.lower():
+            url = url.replace('/raw/', '/', 1)
+
+        # Hugging Face Raw: https://huggingface.co/user/repo/raw/rev/path
+        if '/raw/' in url.lower() and 'huggingface.co' in url.lower():
+            url = url.replace('/raw/', '/blob/', 1)
 
         # Append line fragment
         if line_val:
@@ -2154,7 +2166,8 @@ def get_online_url(path: str, line: Union[int, str] = 1) -> Optional[str]:
 
     # Normalize Remote URL (Convert SSH to HTTPS, remove .git suffix)
     # git@host:user/repo.git -> https://host/user/repo
-    remote = re.sub(r'^git@([^:]+):', r'https://\1/', remote)
+    # Also handle ssh://git@host/user/repo.git or ssh://git@host:user/repo.git
+    remote = re.sub(r'^(?:ssh://)?git@([^:/]+)[:/]', r'https://\1/', remote)
     remote = re.sub(r'\.git$', '', remote)
     remote = remote.rstrip('/')
 

--- a/tests/test_get_online_url_robustness.py
+++ b/tests/test_get_online_url_robustness.py
@@ -1,0 +1,58 @@
+import pytest
+from gptscan import get_online_url
+from unittest.mock import patch
+
+def test_get_online_url_remote_restoration():
+    """Verify that [URL] targets are correctly restored from raw to view links."""
+    # GitHub: already tested in test_view_online.py but good to keep here
+    assert get_online_url("[URL] https://raw.githubusercontent.com/u/r/m/f.py", 10) == "https://github.com/u/r/blob/m/f.py#L10"
+
+    # GitLab
+    assert get_online_url("[URL] https://gitlab.com/u/r/-/raw/m/f.py", 10) == "https://gitlab.com/u/r/-/blob/m/f.py#L10"
+
+    # Bitbucket
+    assert get_online_url("[URL] https://bitbucket.org/u/r/raw/m/f.py", 10) == "https://bitbucket.org/u/r/src/m/f.py#lines-10"
+
+    # Pastebin
+    assert get_online_url("[URL] https://pastebin.com/raw/abcdef", 1) == "https://pastebin.com/abcdef#L1"
+
+    # Hugging Face
+    assert get_online_url("[URL] https://huggingface.co/u/r/raw/m/f.py", 10) == "https://huggingface.co/u/r/blob/m/f.py#L10"
+
+@patch('gptscan._get_git_info')
+@patch('gptscan.subprocess.check_output')
+def test_get_online_url_ssh_normalization(mock_check_output, mock_info):
+    """Verify normalization of various SSH remote formats."""
+    mock_info.return_value = ("/app", "file.py")
+
+    # Test cases: (remote_url, expected_base)
+    test_cases = [
+        ("git@github.com:user/repo.git", "https://github.com/user/repo"),
+        ("ssh://git@github.com/user/repo.git", "https://github.com/user/repo"),
+        ("ssh://git@gitlab.com:group/sub/repo.git", "https://gitlab.com/group/sub/repo"),
+        ("git@bitbucket.org:user/repo", "https://bitbucket.org/user/repo"),
+    ]
+
+    for remote, expected_base in test_cases:
+        def side_effect(cmd, **kwargs):
+            if cmd == ["git", "remote", "get-url", "origin"]:
+                return remote
+            if cmd == ["git", "rev-parse", "HEAD"]:
+                return "rev"
+            return ""
+        mock_check_output.side_effect = side_effect
+
+        url = get_online_url("/app/file.py", 5)
+
+        if "github.com" in expected_base:
+            assert url == f"{expected_base}/blob/rev/file.py#L5"
+        elif "gitlab.com" in expected_base:
+            assert url == f"{expected_base}/-/blob/rev/file.py#L5"
+        elif "bitbucket.org" in expected_base:
+            assert url == f"{expected_base}/src/rev/file.py#lines-5"
+
+def test_get_online_url_no_line():
+    """Verify behavior when line is None or 0."""
+    assert get_online_url("[URL] https://github.com/u/r/blob/m/f.py", None) == "https://github.com/u/r/blob/m/f.py"
+    assert get_online_url("[URL] https://github.com/u/r/blob/m/f.py", 0) == "https://github.com/u/r/blob/m/f.py"
+    assert get_online_url("[URL] https://github.com/u/r/blob/m/f.py", "abc") == "https://github.com/u/r/blob/m/f.py"


### PR DESCRIPTION
### Type: New Coverage / Bug Fix

### What:
- Improved the `get_online_url` function in `gptscan.py` to be more robust.
- Updated the SSH remote normalization regex to correctly parse `ssh://git@host/repo` and other common variations.
- Added restoration logic for Bitbucket, Pastebin, and Hugging Face "raw" URLs, ensuring they are converted back to user-friendly "view" links when opening in a browser.
- Created `tests/test_get_online_url_robustness.py` to verify these changes across all supported providers.

### Why:
- The previous implementation failed to resolve some common SSH remote formats and lacked restoration support for several supported web sources.
- These improvements ensure that the "View Online" feature works reliably regardless of whether the user is scanning a local Git repo or a remote web link, significantly improving the security triage workflow.

---
*PR created automatically by Jules for task [17239824270553558524](https://jules.google.com/task/17239824270553558524) started by @RainRat*