### PR TITLE
[FEAT] Scan requirements.txt dependencies

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4002,9 +4002,10 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
     """Extract scan-ready snippets from various container formats.
 
     This function recursively unpacks archives (ZIP, TAR), Jupyter Notebooks,
-    project and build files (package.json, pyproject.toml), Dockerfiles, Makefiles,
-    automation tasks (YAML), web files (HTML, SVG), and Unified Diffs.
-    It ensures that only relevant code blocks and scripts are processed.
+    project and build files (package.json, pyproject.toml, requirements.txt),
+    Dockerfiles, Makefiles, automation tasks (YAML), web files (HTML, SVG),
+    and Unified Diffs. It ensures that only relevant code blocks and scripts
+    are processed.
 
     Args:
         name: The display name or path of the content.
@@ -4083,12 +4084,20 @@ def unpack_content(name: str, content: bytes, depth: int = 0, hint: Optional[str
         except Exception:
             pass
 
-    # 4. Check for project and build files (package.json, composer.json, deno.json/jsonc, pyproject.toml, tasks.json, launch.json)
+    # 4. Check for project and build files (package.json, composer.json, deno.json/jsonc, pyproject.toml, tasks.json, launch.json, requirements.txt)
     lowered_check = check_name.lower()
     check_basename = os.path.basename(lowered_check)
-    if check_basename.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'tasks.json', 'launch.json')):
+    if check_basename.endswith(('package.json', 'composer.json', 'deno.json', 'deno.jsonc', 'pyproject.toml', 'tasks.json', 'launch.json', 'requirements.txt')):
         try:
             text = content.decode('utf-8', errors='ignore')
+
+            if check_basename.endswith('requirements.txt'):
+                for line in text.splitlines():
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        yield (f"{name} [Dependency]", line.encode('utf-8'))
+                return
+
             if check_basename.endswith('pyproject.toml'):
                 # Parse pyproject.toml using regex to avoid toml dependency
                 lines = text.splitlines()

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Scan your files for dangerous code with AI. This tool uses a quick scan model to
 
 ### File Format Support
 *   **Notebook Support:** Scan cells in `.ipynb` files for dangerous commands.
-*   **Project & Build Files:** Scan `package.json`, `composer.json`, `pyproject.toml`, `deno.json`, `deno.jsonc`, `Dockerfile`, `Makefile`, and Docker Compose.
+*   **Project & Build Files:** Scan `package.json`, `composer.json`, `pyproject.toml`, `requirements.txt`, `deno.json`, `deno.jsonc`, `Dockerfile`, `Makefile`, and Docker Compose.
 *   **Archives:** Open `.zip`, `.tar`, and `.tar.gz` files automatically to scan the contents.
 *   **Automation Tasks:** Scan GitHub Actions, GitLab CI, and other YAML workflows for suspicious commands.
 *   **Web Files:** Scan HTML, SVG, and Markdown files for embedded scripts.

--- a/tests/test_requirements_scan.py
+++ b/tests/test_requirements_scan.py
@@ -1,0 +1,43 @@
+import pytest
+from gptscan import unpack_content
+
+def test_requirements_txt_unpacking():
+    """Test that requirements.txt content is correctly yielded as individual dependency snippets."""
+    content = b"flask==2.0.1\nrequests>=2.25.1\n# A comment\n  \ngit+https://github.com/unsafe/repo.git\n"
+    name = "requirements.txt"
+
+    snippets = list(unpack_content(name, content))
+
+    # We expect 3 snippets (flask, requests, and the git URL), comments and empty lines should be ignored
+    assert len(snippets) == 3
+
+    assert snippets[0][0] == "requirements.txt [Dependency]"
+    assert snippets[0][1] == b"flask==2.0.1"
+
+    assert snippets[1][0] == "requirements.txt [Dependency]"
+    assert snippets[1][1] == b"requests>=2.25.1"
+
+    assert snippets[2][0] == "requirements.txt [Dependency]"
+    assert snippets[2][1] == b"git+https://github.com/unsafe/repo.git"
+
+def test_requirements_txt_in_subdir():
+    """Test that requirements.txt in a subdirectory is correctly identified."""
+    content = b"numpy"
+    name = "subdir/requirements.txt"
+
+    snippets = list(unpack_content(name, content))
+
+    assert len(snippets) == 1
+    assert snippets[0][0] == "subdir/requirements.txt [Dependency]"
+    assert snippets[0][1] == b"numpy"
+
+def test_requirements_txt_variants():
+    """Test that dev-requirements.txt and other variants are also scanned."""
+    content = b"pytest"
+    name = "dev-requirements.txt"
+
+    snippets = list(unpack_content(name, content))
+
+    assert len(snippets) == 1
+    assert snippets[0][0] == "dev-requirements.txt [Dependency]"
+    assert snippets[0][1] == b"pytest"


### PR DESCRIPTION
This PR implements scanning for Python `requirements.txt` files. It follows the "Symmetry" heuristic by adding support for a common dependency format that was previously missing, matching the existing support for `package.json` and `pyproject.toml`.

Technical details:
- Updated the `unpack_content` generator to identify files ending in `requirements.txt`.
- Implemented a parser that strips comments and empty lines, yielding each remaining line as a "Dependency" snippet.
- Verified with a new test suite and updated the project documentation.

---
*PR created automatically by Jules for task [1988740343050815053](https://jules.google.com/task/1988740343050815053) started by @RainRat*