### PR TITLE
Refactor get_wrapped_values to robustly handle generators

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1067,10 +1067,12 @@ def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optio
     measure = measure or (default_font_measure or tkinter.font.Font(font='TkDefaultFont').measure)
     col_widths = col_widths or [tree.column(cid)['width'] for cid in tree['columns']]
 
+    values_list = list(values)
+
     # Only wrap the first 6 columns, leave the rest (including line and hidden orig_json) as is
-    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(list(values)[:6], col_widths[:6])]
-    if len(values) > 6:
-        wrapped.extend(list(values)[6:])
+    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(values_list[:6], col_widths[:6])]
+    if len(values_list) > 6:
+        wrapped.extend(values_list[6:])
     return wrapped
 
 

--- a/tests/test_get_wrapped_values_robustness.py
+++ b/tests/test_get_wrapped_values_robustness.py
@@ -1,0 +1,44 @@
+import pytest
+from gptscan import get_wrapped_values
+
+def test_get_wrapped_values_with_generator():
+    """Verify that get_wrapped_values correctly handles a generator and doesn't exhaust it prematurely."""
+
+    def my_generator():
+        yield "path/to/file.py"
+        yield "80%"
+        yield "Admin notes"
+        yield "User notes"
+        yield "90%"
+        yield "print('hello')"
+        yield "10"
+        yield '{"some": "json"}'
+
+    # We provide col_widths and measure so the function doesn't need a real Treeview or Tkinter font
+    col_widths = [100, 50, 150, 150, 50, 200, 30]
+    measure = lambda x: len(x) * 7 # Dummy measure function
+
+    # Act
+    # Tree can be None if col_widths and measure are provided
+    result = get_wrapped_values(None, my_generator(), measure=measure, col_widths=col_widths)
+
+    # Assert
+    assert len(result) == 8
+    assert result[0] == "path/to/file.py"
+    assert result[4] == "90%"
+    assert result[5] == "print('hello')"
+    assert result[6] == "10"
+    assert result[7] == '{"some": "json"}'
+
+def test_get_wrapped_values_short_iterable():
+    """Verify it handles iterables shorter than 6 elements."""
+    def short_gen():
+        yield "only"
+        yield "two"
+
+    col_widths = [100, 100]
+    measure = lambda x: len(x) * 7
+
+    result = get_wrapped_values(None, short_gen(), measure=measure, col_widths=col_widths)
+    assert len(result) == 2
+    assert result == ["only", "two"]


### PR DESCRIPTION
This pull request improves the robustness of the `get_wrapped_values` function in `gptscan.py`. 

The original implementation had two issues when handling non-list iterables (like generators):
1. It attempted to call `len(values)`, which raises a `TypeError` for generators.
2. It called `list(values)` in one place and then iterated over `values` again later, which would result in an empty list if `values` was a generator (iterator exhaustion).

The refactor converts `values` to a list once at the beginning of the function and uses that list for all subsequent operations. 

Verification:
- Added `tests/test_get_wrapped_values_robustness.py` which passes generators and short iterables to the function.
- Verified that all related tests in `tests/test_path_wrapping_fix.py`, `tests/test_raw_values_logic.py`, and `tests/test_motion_handler.py` continue to pass.


---
*PR created automatically by Jules for task [15249437677124713689](https://jules.google.com/task/15249437677124713689) started by @RainRat*