### PR TITLE
[UI/UX] Consolidate Scan and Cancel buttons into a dynamic toggle

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -48,7 +48,6 @@ filter_var: Optional[tk.StringVar] = None
 filter_entry: Optional[ttk.Entry] = None
 tree: Optional[ttk.Treeview] = None
 scan_button: Optional[ttk.Button] = None
-cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
 open_button: Optional[ttk.Button] = None
@@ -2772,14 +2771,13 @@ def set_scanning_state(is_scanning: bool) -> None:
         update_button_states()
 
     if scan_button:
-        new_state = "disabled" if is_scanning else "normal"
         if is_scanning:
-            scan_button.config(text="Scanning...", state=new_state)
+            scan_button.config(text="Stop Scan", state="normal")
+            bind_hover_message(scan_button, "Stop the current scan. (Esc)")
         else:
-            scan_button.config(text="Scan Now", state=new_state)
+            scan_button.config(text="Scan Now", state="normal")
             toggle_dry_run()
-    if cancel_button:
-        cancel_button.config(state="normal" if is_scanning else "disabled")
+            bind_hover_message(scan_button, "Start the scan. (Enter)")
 
     # Disable/Enable configuration widgets during scan
     config_widgets = [
@@ -3517,6 +3515,7 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
     global current_cancel_event
 
     if current_cancel_event is not None:
+        cancel_scan()
         return
 
     # Clear previous results
@@ -3584,6 +3583,9 @@ def cancel_scan() -> None:
 
     if current_cancel_event:
         current_cancel_event.set()
+        if scan_button:
+            scan_button.config(text="Stopping...", state="disabled")
+            bind_hover_message(scan_button, "Scan cancellation in progress...")
 
 
 def rescan_selected() -> None:
@@ -7700,7 +7702,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     Returns:
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7848,10 +7850,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(scan_button, "Start the scan. (Enter)")
-
-    cancel_button = ttk.Button(button_box, text="Cancel", command=cancel_scan, state="disabled", width=10)
-    cancel_button.pack(side=tk.LEFT, padx=(2, 0), ipady=5)
-    bind_hover_message(cancel_button, "Stop the current scan. (Esc)")
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")

--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -33,7 +33,6 @@ def test_button_click_with_git_changes_enabled(monkeypatch):
 
     # Mock buttons
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
 
     # Mock get_git_changed_files
     mock_get_git = MagicMock(return_value=["/some/repo/file1.py", "/some/repo/file2.py"])

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -79,28 +79,35 @@ def test_browse_file_click_selects_file(monkeypatch):
 def test_set_scanning_state_updates_buttons(monkeypatch):
     # Setup mocks
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
+    # Mock toggle_dry_run as it's called in set_scanning_state(False)
+    mock_toggle_dry_run = MagicMock()
+    monkeypatch.setattr(gptscan, 'toggle_dry_run', mock_toggle_dry_run)
+    # Mock bind_hover_message
+    mock_bind_hover = MagicMock()
+    monkeypatch.setattr(gptscan, 'bind_hover_message', mock_bind_hover)
 
     # Test scanning=True
     gptscan.set_scanning_state(True)
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
-    mock_cancel_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
+    mock_bind_hover.assert_called_with(mock_scan_button, "Stop the current scan. (Esc)")
 
     # Test scanning=False
     gptscan.set_scanning_state(False)
     mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
+    mock_toggle_dry_run.assert_called_once()
+    mock_bind_hover.assert_called_with(mock_scan_button, "Start the scan. (Enter)")
 
 def test_finish_scan_state_resets_state(monkeypatch):
     # Setup
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
+    # Mock toggle_dry_run
+    monkeypatch.setattr(gptscan, 'toggle_dry_run', MagicMock())
+    # Mock bind_hover_message
+    monkeypatch.setattr(gptscan, 'bind_hover_message', MagicMock())
 
     # Mock status_label
     mock_status_label = MagicMock()
@@ -116,18 +123,20 @@ def test_finish_scan_state_resets_state(monkeypatch):
     mock_status_label.config.assert_not_called()
     assert gptscan.current_cancel_event is None
     mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
 
 def test_cancel_scan_triggers_event(monkeypatch):
     # Setup
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
+    mock_scan_button = MagicMock()
+    monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
     # Action
     gptscan.cancel_scan()
 
     # Assert
     mock_event.set.assert_called_once()
+    mock_scan_button.config.assert_called_with(text="Stopping...", state="disabled")
 
 def test_cancel_scan_does_nothing_if_no_event(monkeypatch):
     monkeypatch.setattr(gptscan, 'current_cancel_event', None)
@@ -178,9 +187,7 @@ def test_button_click_starts_scan(monkeypatch):
     monkeypatch.setattr(gptscan, 'current_cancel_event', None)
 
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Mock vars
     mock_deep = MagicMock()
@@ -223,7 +230,7 @@ def test_button_click_starts_scan(monkeypatch):
     # Assert
     mock_status_label.config.assert_called_with(text="Starting scan...")
     assert gptscan.current_cancel_event is not None
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
 
     # Check thread creation
     mock_thread_cls.assert_called_once()
@@ -240,9 +247,11 @@ def test_button_click_starts_scan(monkeypatch):
 
     mock_thread_instance.start.assert_called_once()
 
-def test_button_click_ignored_if_already_running(monkeypatch):
+def test_button_click_cancels_if_already_running(monkeypatch):
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
+    mock_scan_button = MagicMock()
+    monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
     mock_thread_cls = MagicMock()
     monkeypatch.setattr(gptscan.threading, 'Thread', mock_thread_cls)
@@ -250,3 +259,5 @@ def test_button_click_ignored_if_already_running(monkeypatch):
     gptscan.button_click()
 
     mock_thread_cls.assert_not_called()
+    mock_event.set.assert_called_once()
+    mock_scan_button.config.assert_called_with(text="Stopping...", state="disabled")

--- a/tests/test_intel_menu_ui.py
+++ b/tests/test_intel_menu_ui.py
@@ -65,7 +65,7 @@ def test_intel_button_disabled_during_scan(mock_gui, monkeypatch):
         'textbox', 'clear_target_btn', 'browse_button',
         'git_checkbox', 'deep_checkbox', 'scan_all_checkbox', 'dry_checkbox',
         'gpt_checkbox', 'provider_combo', 'model_combo', 'api_entry', 'show_key_btn',
-        'copy_cmd_button', 'scan_button', 'cancel_button'
+        'copy_cmd_button', 'scan_button'
     ]
     for name in monkeypatch_config:
         monkeypatch.setattr(gptscan, name, MagicMock())

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -18,7 +18,6 @@ def test_open_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -10,7 +10,6 @@ def test_scan_summary_gui(monkeypatch):
     monkeypatch.setattr(gptscan, 'status_label', mock_status_label, raising=False)
     monkeypatch.setattr(gptscan, 'root', MagicMock(), raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
 
     # 1 suspicious file (singular)
     gptscan.finish_scan_state(total_scanned=10, threats_found=1, high_risk=0, medium_risk=0)

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -17,7 +17,6 @@ def test_reveal_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)


### PR DESCRIPTION
**PR Title:** [UI/UX] Consolidate Scan and Cancel buttons into a dynamic toggle 
 
**Description:** 
* **Context:** GUI 
* **Problem:** The interface featured separate "Scan Now" and "Cancel" buttons, which added unnecessary visual clutter to the primary input area. Furthermore, during an active scan, the "Scan Now" button became a disabled "Scanning..." label, forcing users to move their cursor to the separate "Cancel" button to stop the operation. 
* **Solution:** Both actions have been consolidated into a single, context-aware `scan_button`. This button now acts as a toggle: 
    * **Idle:** Displays "Scan Now" (or "Dry Run" if enabled) and starts a scan. 
    * **Scanning:** Displays "Stop Scan" and allows immediate cancellation. 
    * **Stopping:** Displays "Stopping..." and disables itself to provide clear feedback during the transition back to idle. 
    Hover messages are dynamically updated to match the button's current function, improving clarity and accessibility. 
 
**Changes:** 
`gptscan.py`: 
- Refactored `button_click`, `set_scanning_state`, and `cancel_scan` to handle the new dynamic button logic. 
- Removed `cancel_button` variable, its creation in `create_gui`, and all global references. 
- Ensured `scan_button` text correctly resets to "Scan Now" and hover tooltips update accurately during state transitions. 
 
`tests/`: 
- Updated `test_gui_logic.py`, `test_intel_menu_ui.py`, `test_open_button.py`, `test_reveal_button.py`, `test_git_gui_integration.py`, and `test_reporting_features.py` to reflect the removal of the separate cancel button and verify the new toggle behavior. 
- Confirmed all 946 tests pass.

---
*PR created automatically by Jules for task [15540655022983284932](https://jules.google.com/task/15540655022983284932) started by @RainRat*