### PR TITLE
Fix logic bug in get_wrapped_values for generator support

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1064,13 +1064,14 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
 
 def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optional[Callable[[str], int]] = None, col_widths: Optional[List[int]] = None) -> List[Any]:
     """Wrap a list of values to fit the current Treeview column widths."""
+    values = list(values)
     measure = measure or (default_font_measure or tkinter.font.Font(font='TkDefaultFont').measure)
     col_widths = col_widths or [tree.column(cid)['width'] for cid in tree['columns']]
 
     # Only wrap the first 6 columns, leave the rest (including line and hidden orig_json) as is
-    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(list(values)[:6], col_widths[:6])]
+    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(values[:6], col_widths[:6])]
     if len(values) > 6:
-        wrapped.extend(list(values)[6:])
+        wrapped.extend(values[6:])
     return wrapped
 
 

--- a/tests/test_get_wrapped_values_robustness.py
+++ b/tests/test_get_wrapped_values_robustness.py
@@ -1,0 +1,25 @@
+import tkinter as tk
+from tkinter import ttk
+from unittest.mock import MagicMock
+import pytest
+import gptscan
+
+def test_get_wrapped_values_with_generator(monkeypatch):
+    # Mock font measure to avoid needing a real display
+    mock_measure = lambda text: len(text) * 10
+    monkeypatch.setattr(gptscan, "default_font_measure", mock_measure)
+
+    # Mock tree
+    mock_tree = MagicMock()
+    mock_tree.column.return_value = {'width': 100}
+    mock_tree.__getitem__.side_effect = lambda key: ("col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8") if key == "columns" else MagicMock()
+
+    # Generator for values
+    def my_gen():
+        for i in range(8):
+            yield f"value {i}"
+
+    # In the unfixed state, this raises TypeError: object of type 'generator' has no len()
+    res = gptscan.get_wrapped_values(mock_tree, my_gen(), measure=mock_measure)
+    assert len(res) == 8
+    assert res[0] == "value 0"


### PR DESCRIPTION
* **What:** Modified the `get_wrapped_values` function in `gptscan.py` to convert the `values` iterable into a list once at the beginning of the function.
* **Why:** The previous implementation called `len(values)` and `list(values)` multiple times, which caused a `TypeError` when passed a generator and would have exhausted one-time iterators. This fix improves robustness and ensures the function works with all types of iterables. No breaking changes were introduced as the final output remains consistent with the previous logic for list inputs.

Verified with a new regression test in `tests/test_get_wrapped_values_robustness.py`.

---
*PR created automatically by Jules for task [16193613549590068785](https://jules.google.com/task/16193613549590068785) started by @RainRat*