### PR TITLE
[UI/UX] Consolidate Scan and Cancel into a single dynamic button

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -48,7 +48,6 @@ filter_var: Optional[tk.StringVar] = None
 filter_entry: Optional[ttk.Entry] = None
 tree: Optional[ttk.Treeview] = None
 scan_button: Optional[ttk.Button] = None
-cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
 open_button: Optional[ttk.Button] = None
@@ -809,7 +808,12 @@ def toggle_dry_run() -> None:
 
     is_scanning = current_cancel_event is not None
     if not is_scanning:
-        scan_button.config(text="Dry Run" if dry_var.get() else "Scan Now")
+        if dry_var.get():
+            scan_button.config(text="Dry Run")
+            bind_hover_message(scan_button, "Preview which files would be scanned. (Enter)")
+        else:
+            scan_button.config(text="Scan Now")
+            bind_hover_message(scan_button, "Start the scan. (Enter)")
 
 
 def toggle_ai_controls() -> None:
@@ -2772,14 +2776,17 @@ def set_scanning_state(is_scanning: bool) -> None:
         update_button_states()
 
     if scan_button:
-        new_state = "disabled" if is_scanning else "normal"
         if is_scanning:
-            scan_button.config(text="Scanning...", state=new_state)
+            if current_cancel_event and current_cancel_event.is_set():
+                scan_button.config(text="Stopping...", state="disabled")
+                bind_hover_message(scan_button, "Stopping the scan...")
+            else:
+                scan_button.config(text="Stop Scan", state="normal")
+                bind_hover_message(scan_button, "Stop the current scan. (Esc)")
         else:
-            scan_button.config(text="Scan Now", state=new_state)
+            scan_button.config(text="Scan Now", state="normal")
+            bind_hover_message(scan_button, "Start the scan. (Enter)")
             toggle_dry_run()
-    if cancel_button:
-        cancel_button.config(state="normal" if is_scanning else "disabled")
 
     # Disable/Enable configuration widgets during scan
     config_widgets = [
@@ -3503,6 +3510,14 @@ def scan_system_audit_click():
         messagebox.showwarning("System Audit Error", f"Could not perform system audit: {e}")
 
 
+def on_scan_button_click() -> None:
+    """Handle scan button click to either start or stop a scan."""
+    if current_cancel_event is not None:
+        cancel_scan()
+    else:
+        button_click()
+
+
 def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_threshold: Optional[int] = None, modified_since: Optional[float] = None) -> None:
     """Trigger a scan in a background thread using the selected path.
 
@@ -3584,6 +3599,8 @@ def cancel_scan() -> None:
 
     if current_cancel_event:
         current_cancel_event.set()
+        # Update UI to show "Stopping..." state immediately
+        set_scanning_state(True)
 
 
 def rescan_selected() -> None:
@@ -7700,7 +7717,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     Returns:
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7845,13 +7862,9 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     browse_button.pack(side=tk.LEFT, padx=(5, 2), ipady=5)
     bind_hover_message(browse_button, "Select scan targets or perform system audits.")
 
-    scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
+    scan_button = ttk.Button(button_box, text="Scan Now", command=on_scan_button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(scan_button, "Start the scan. (Enter)")
-
-    cancel_button = ttk.Button(button_box, text="Cancel", command=cancel_scan, state="disabled", width=10)
-    cancel_button.pack(side=tk.LEFT, padx=(2, 0), ipady=5)
-    bind_hover_message(cancel_button, "Stop the current scan. (Esc)")
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")

--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -33,7 +33,6 @@ def test_button_click_with_git_changes_enabled(monkeypatch):
 
     # Mock buttons
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
 
     # Mock get_git_changed_files
     mock_get_git = MagicMock(return_value=["/some/repo/file1.py", "/some/repo/file2.py"])

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -79,28 +79,32 @@ def test_browse_file_click_selects_file(monkeypatch):
 def test_set_scanning_state_updates_buttons(monkeypatch):
     # Setup mocks
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
+
+    mock_event = MagicMock()
+    mock_event.is_set.return_value = False
+    monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
 
     # Test scanning=True
     gptscan.set_scanning_state(True)
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
-    mock_cancel_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
+
+    # Test scanning=True but stopping
+    mock_event.is_set.return_value = True
+    gptscan.set_scanning_state(True)
+    mock_scan_button.config.assert_called_with(text="Stopping...", state="disabled")
 
     # Test scanning=False
+    monkeypatch.setattr(gptscan, 'current_cancel_event', None)
     gptscan.set_scanning_state(False)
     mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
 
 def test_finish_scan_state_resets_state(monkeypatch):
     # Setup
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Mock status_label
     mock_status_label = MagicMock()
@@ -116,18 +120,21 @@ def test_finish_scan_state_resets_state(monkeypatch):
     mock_status_label.config.assert_not_called()
     assert gptscan.current_cancel_event is None
     mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
 
 def test_cancel_scan_triggers_event(monkeypatch):
     # Setup
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
+    mock_scan_button = MagicMock()
+    monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
     # Action
     gptscan.cancel_scan()
 
     # Assert
     mock_event.set.assert_called_once()
+    # verify it updates the button to "Stopping..."
+    mock_scan_button.config.assert_called_with(text="Stopping...", state="disabled")
 
 def test_cancel_scan_does_nothing_if_no_event(monkeypatch):
     monkeypatch.setattr(gptscan, 'current_cancel_event', None)
@@ -178,9 +185,7 @@ def test_button_click_starts_scan(monkeypatch):
     monkeypatch.setattr(gptscan, 'current_cancel_event', None)
 
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Mock vars
     mock_deep = MagicMock()
@@ -223,7 +228,7 @@ def test_button_click_starts_scan(monkeypatch):
     # Assert
     mock_status_label.config.assert_called_with(text="Starting scan...")
     assert gptscan.current_cancel_event is not None
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
 
     # Check thread creation
     mock_thread_cls.assert_called_once()

--- a/tests/test_intel_menu_ui.py
+++ b/tests/test_intel_menu_ui.py
@@ -65,7 +65,7 @@ def test_intel_button_disabled_during_scan(mock_gui, monkeypatch):
         'textbox', 'clear_target_btn', 'browse_button',
         'git_checkbox', 'deep_checkbox', 'scan_all_checkbox', 'dry_checkbox',
         'gpt_checkbox', 'provider_combo', 'model_combo', 'api_entry', 'show_key_btn',
-        'copy_cmd_button', 'scan_button', 'cancel_button'
+        'copy_cmd_button', 'scan_button'
     ]
     for name in monkeypatch_config:
         monkeypatch.setattr(gptscan, name, MagicMock())

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -18,7 +18,6 @@ def test_open_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -10,9 +10,6 @@ def test_scan_summary_gui(monkeypatch):
     monkeypatch.setattr(gptscan, 'status_label', mock_status_label, raising=False)
     monkeypatch.setattr(gptscan, 'root', MagicMock(), raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
-
-    # 1 suspicious file (singular)
     gptscan.finish_scan_state(total_scanned=10, threats_found=1, high_risk=0, medium_risk=0)
     mock_status_label.config.assert_called_with(text="Scan complete: 10 files scanned, 1 suspicious file found (0 high risk, 0 medium risk).")
 

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -17,7 +17,6 @@ def test_reveal_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)


### PR DESCRIPTION
This change improves the GUI usability by consolidating the primary action and its cancellation into a single, dynamic button. 

**Context:** GUI
**Problem:** The interface featured two separate buttons for 'Scan Now' and 'Cancel', where the 'Scan Now' button would become disabled during a scan, and the user had to move their mouse to the 'Cancel' button to stop it. This created visual clutter and required unnecessary mouse movement for a common lifecycle action.
**Solution:** A single dynamic button now manages the entire scan lifecycle. 
- When idle, it shows **'Scan Now'** (or **'Dry Run'**).
- When a scan starts, it immediately changes to **'Stop Scan'** and remains enabled, allowing the user to cancel from the same location.
- When cancellation is initiated, it changes to a disabled **'Stopping...'** state to provide immediate feedback that the request is being processed.

This follows "Invisible Design" principles by reducing the number of controls without sacrificing functionality, and improves "Feedback & Clarity" by using descriptive labels for current states.

**Changes:**
- `gptscan.py`: Removed `cancel_button`, updated `scan_button` logic.
- `tests/test_gui_logic.py`: Updated assertions for button states and removed legacy mocks.
- Multiple other test files: Cleaned up `cancel_button` mocks to match the new UI structure.

---
*PR created automatically by Jules for task [6089312204187225033](https://jules.google.com/task/6089312204187225033) started by @RainRat*