### PR TITLE
Fix `get_wrapped_values` to robustly handle generators and iterables

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1064,13 +1064,14 @@ def adjust_newlines(val: Any, width: int, pad: int = 10, measure: Optional[Calla
 
 def get_wrapped_values(tree: ttk.Treeview, values: Iterable[Any], measure: Optional[Callable[[str], int]] = None, col_widths: Optional[List[int]] = None) -> List[Any]:
     """Wrap a list of values to fit the current Treeview column widths."""
+    values_list = list(values)
     measure = measure or (default_font_measure or tkinter.font.Font(font='TkDefaultFont').measure)
     col_widths = col_widths or [tree.column(cid)['width'] for cid in tree['columns']]
 
     # Only wrap the first 6 columns, leave the rest (including line and hidden orig_json) as is
-    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(list(values)[:6], col_widths[:6])]
-    if len(values) > 6:
-        wrapped.extend(list(values)[6:])
+    wrapped = [adjust_newlines(v, w, measure=measure) for v, w in zip(values_list[:6], col_widths[:6])]
+    if len(values_list) > 6:
+        wrapped.extend(values_list[6:])
     return wrapped
 
 

--- a/tests/test_get_wrapped_values_robustness.py
+++ b/tests/test_get_wrapped_values_robustness.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import MagicMock
+from gptscan import get_wrapped_values
+
+def test_get_wrapped_values_with_list():
+    tree = MagicMock()
+    tree.column.return_value = {'width': 100}
+    tree.__getitem__.return_value = ['col1', 'col2', 'col3', 'col4', 'col5', 'col6', 'col7']
+
+    values = ["val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8"]
+
+    # Mock measure to just return the value as is (no wrapping)
+    measure = lambda x: len(x)
+
+    result = get_wrapped_values(tree, values, measure=measure)
+
+    assert result == values
+    assert len(result) == 8
+
+def test_get_wrapped_values_with_generator():
+    tree = MagicMock()
+    tree.column.return_value = {'width': 100}
+    tree.__getitem__.return_value = ['col1', 'col2', 'col3', 'col4', 'col5', 'col6', 'col7']
+
+    def gen():
+        yield from ["val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8"]
+
+    measure = lambda x: len(x)
+
+    # This would fail before the fix with "TypeError: object of type 'generator' has no len()"
+    result = get_wrapped_values(tree, gen(), measure=measure)
+
+    assert result == ["val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8"]
+    assert len(result) == 8
+
+def test_get_wrapped_values_short_iterable():
+    tree = MagicMock()
+    tree.column.return_value = {'width': 100}
+    tree.__getitem__.return_value = ['col1', 'col2', 'col3', 'col4', 'col5', 'col6', 'col7']
+
+    values = ["val1", "val2"]
+    measure = lambda x: len(x)
+
+    result = get_wrapped_values(tree, values, measure=measure)
+
+    assert result == ["val1", "val2"]
+    assert len(result) == 2


### PR DESCRIPTION
**What:** Modified the `get_wrapped_values` function in `gptscan.py` to convert the `values` argument into a list at the beginning of the function. Added a new unit test suite `tests/test_get_wrapped_values_robustness.py` to verify this behavior.

**Why:** The previous implementation would raise a `TypeError` when `values` was a generator (because it called `len()` on it) and would also partially exhaust the iterator if it was not already a list. This change ensures that any `Iterable` can be safely processed without data loss or crashes, improving the robustness of the Treeview UI updates. No breaking changes were introduced as the behavior for list inputs remains identical.

---
*PR created automatically by Jules for task [15945095332929993834](https://jules.google.com/task/15945095332929993834) started by @RainRat*