### PR TITLE
[UI/UX] Consolidate 'Scan Now' and 'Cancel' into a dynamic multi-state button

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -48,7 +48,6 @@ filter_var: Optional[tk.StringVar] = None
 filter_entry: Optional[ttk.Entry] = None
 tree: Optional[ttk.Treeview] = None
 scan_button: Optional[ttk.Button] = None
-cancel_button: Optional[ttk.Button] = None
 view_button: Optional[ttk.Button] = None
 rescan_button: Optional[ttk.Button] = None
 open_button: Optional[ttk.Button] = None
@@ -2772,14 +2771,13 @@ def set_scanning_state(is_scanning: bool) -> None:
         update_button_states()
 
     if scan_button:
-        new_state = "disabled" if is_scanning else "normal"
         if is_scanning:
-            scan_button.config(text="Scanning...", state=new_state)
+            scan_button.config(text="Stop Scan", state="normal")
+            bind_hover_message(scan_button, "Stop the current scan. (Esc)")
         else:
-            scan_button.config(text="Scan Now", state=new_state)
+            scan_button.config(state="normal")
             toggle_dry_run()
-    if cancel_button:
-        cancel_button.config(state="normal" if is_scanning else "disabled")
+            bind_hover_message(scan_button, "Start the scan. (Enter)")
 
     # Disable/Enable configuration widgets during scan
     config_widgets = [
@@ -3517,6 +3515,7 @@ def button_click(extra_snippets: Optional[List[Tuple[str, bytes]]] = None, fail_
     global current_cancel_event
 
     if current_cancel_event is not None:
+        cancel_scan()
         return
 
     # Clear previous results
@@ -3584,6 +3583,8 @@ def cancel_scan() -> None:
 
     if current_cancel_event:
         current_cancel_event.set()
+        if scan_button:
+            scan_button.config(text="Stopping...", state="disabled")
 
 
 def rescan_selected() -> None:
@@ -7700,7 +7701,7 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     Returns:
         Initialized Tk root instance ready for ``mainloop``.
     """
-    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, cancel_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
+    global root, textbox, progress_bar, status_label, deep_var, all_var, scan_all_var, gpt_var, dry_var, git_var, filter_var, filter_entry, tree, scan_button, view_button, intel_button, intel_menu, rescan_button, open_button, analyze_button, exclude_button, reveal_button, results_button, browse_button, show_key_btn, default_font_measure, copy_cmd_button, clear_target_btn, git_checkbox, deep_checkbox, scan_all_checkbox, dry_checkbox, gpt_checkbox, provider_combo, model_combo, api_key_entry, api_entry, all_checkbox, threshold_spin, provider_var, model_var, api_base_var, api_key_var
 
     root = tk.Tk()
     root.geometry("1000x600")
@@ -7848,10 +7849,6 @@ def create_gui(initial_path: Optional[str] = None) -> tk.Tk:
     scan_button = ttk.Button(button_box, text="Scan Now", command=button_click, style='Primary.TButton', default='active', width=12)
     scan_button.pack(side=tk.LEFT, padx=2, ipady=5)
     bind_hover_message(scan_button, "Start the scan. (Enter)")
-
-    cancel_button = ttk.Button(button_box, text="Cancel", command=cancel_scan, state="disabled", width=10)
-    cancel_button.pack(side=tk.LEFT, padx=(2, 0), ipady=5)
-    bind_hover_message(cancel_button, "Stop the current scan. (Esc)")
 
     browse_menu = tk.Menu(browse_button, tearoff=0)
     browse_menu.add_command(label="Scan File(s)...", command=browse_file_click, accelerator="Ctrl+Shift+O")

--- a/tests/test_git_gui_integration.py
+++ b/tests/test_git_gui_integration.py
@@ -33,7 +33,6 @@ def test_button_click_with_git_changes_enabled(monkeypatch):
 
     # Mock buttons
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
 
     # Mock get_git_changed_files
     mock_get_git = MagicMock(return_value=["/some/repo/file1.py", "/some/repo/file2.py"])

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -79,28 +79,22 @@ def test_browse_file_click_selects_file(monkeypatch):
 def test_set_scanning_state_updates_buttons(monkeypatch):
     # Setup mocks
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Test scanning=True
     gptscan.set_scanning_state(True)
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
-    mock_cancel_button.config.assert_called_with(state="normal")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
 
     # Test scanning=False
     gptscan.set_scanning_state(False)
-    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(state="normal")
 
 def test_finish_scan_state_resets_state(monkeypatch):
     # Setup
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Mock status_label
     mock_status_label = MagicMock()
@@ -115,8 +109,7 @@ def test_finish_scan_state_resets_state(monkeypatch):
     # because it avoids overwriting a possible "Scan cancelled" status set by _consume_scan_events.
     mock_status_label.config.assert_not_called()
     assert gptscan.current_cancel_event is None
-    mock_scan_button.config.assert_called_with(text="Scan Now", state="normal")
-    mock_cancel_button.config.assert_called_with(state="disabled")
+    mock_scan_button.config.assert_called_with(state="normal")
 
 def test_cancel_scan_triggers_event(monkeypatch):
     # Setup
@@ -178,9 +171,7 @@ def test_button_click_starts_scan(monkeypatch):
     monkeypatch.setattr(gptscan, 'current_cancel_event', None)
 
     mock_scan_button = MagicMock()
-    mock_cancel_button = MagicMock()
     monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', mock_cancel_button, raising=False)
 
     # Mock vars
     mock_deep = MagicMock()
@@ -223,7 +214,7 @@ def test_button_click_starts_scan(monkeypatch):
     # Assert
     mock_status_label.config.assert_called_with(text="Starting scan...")
     assert gptscan.current_cancel_event is not None
-    mock_scan_button.config.assert_called_with(text="Scanning...", state="disabled")
+    mock_scan_button.config.assert_called_with(text="Stop Scan", state="normal")
 
     # Check thread creation
     mock_thread_cls.assert_called_once()
@@ -240,13 +231,19 @@ def test_button_click_starts_scan(monkeypatch):
 
     mock_thread_instance.start.assert_called_once()
 
-def test_button_click_ignored_if_already_running(monkeypatch):
+def test_button_click_cancels_if_already_running(monkeypatch):
     mock_event = MagicMock()
     monkeypatch.setattr(gptscan, 'current_cancel_event', mock_event)
+
+    mock_scan_button = MagicMock()
+    monkeypatch.setattr(gptscan, 'scan_button', mock_scan_button, raising=False)
 
     mock_thread_cls = MagicMock()
     monkeypatch.setattr(gptscan.threading, 'Thread', mock_thread_cls)
 
     gptscan.button_click()
 
+    # Should call cancel_scan, which sets event and updates button
+    mock_event.set.assert_called_once()
+    mock_scan_button.config.assert_called_with(text="Stopping...", state="disabled")
     mock_thread_cls.assert_not_called()

--- a/tests/test_intel_menu_ui.py
+++ b/tests/test_intel_menu_ui.py
@@ -65,7 +65,6 @@ def test_intel_button_disabled_during_scan(mock_gui, monkeypatch):
         'textbox', 'clear_target_btn', 'browse_button',
         'git_checkbox', 'deep_checkbox', 'scan_all_checkbox', 'dry_checkbox',
         'gpt_checkbox', 'provider_combo', 'model_combo', 'api_entry', 'show_key_btn',
-        'copy_cmd_button', 'scan_button', 'cancel_button'
     ]
     for name in monkeypatch_config:
         monkeypatch.setattr(gptscan, name, MagicMock())

--- a/tests/test_open_button.py
+++ b/tests/test_open_button.py
@@ -18,7 +18,6 @@ def test_open_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'reveal_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)

--- a/tests/test_reporting_features.py
+++ b/tests/test_reporting_features.py
@@ -10,7 +10,6 @@ def test_scan_summary_gui(monkeypatch):
     monkeypatch.setattr(gptscan, 'status_label', mock_status_label, raising=False)
     monkeypatch.setattr(gptscan, 'root', MagicMock(), raising=False)
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock(), raising=False)
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock(), raising=False)
 
     # 1 suspicious file (singular)
     gptscan.finish_scan_state(total_scanned=10, threats_found=1, high_risk=0, medium_risk=0)

--- a/tests/test_reveal_button.py
+++ b/tests/test_reveal_button.py
@@ -17,7 +17,6 @@ def test_reveal_button_management(monkeypatch):
     monkeypatch.setattr(gptscan, 'exclude_button', MagicMock())
     monkeypatch.setattr(gptscan, 'results_button', MagicMock())
     monkeypatch.setattr(gptscan, 'scan_button', MagicMock())
-    monkeypatch.setattr(gptscan, 'cancel_button', MagicMock())
 
     # Test set_scanning_state(True)
     gptscan.set_scanning_state(True)


### PR DESCRIPTION
Improved the GUI by replacing the separate 'Scan Now' and 'Cancel' buttons with a single, context-aware 'scan_button'.

Changes:
- Removed 'cancel_button' from 'gptscan.py' GUI layout and global scope.
- Updated 'set_scanning_state' to manage 'scan_button' text, state, and hover messages dynamically.
- Modified 'button_click' to act as a toggle: starting a scan if idle, or initiating cancellation if a scan is active.
- Updated 'cancel_scan' to provide visual feedback ('Stopping...') when cancellation is triggered.
- Refactored 'tests/test_gui_logic.py' and other test files to verify the new dynamic button behavior and remove references to the legacy 'cancel_button'.
- Verified all 946 relevant tests pass.

---
*PR created automatically by Jules for task [8516814382259584580](https://jules.google.com/task/8516814382259584580) started by @RainRat*