### PR TITLE
Remove redundant list conversions in sorted()

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1165,7 +1165,7 @@ def get_shell_profile_paths() -> List[str]:
         except Exception:
             pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_shell_history_paths() -> List[str]:
@@ -1453,7 +1453,7 @@ def get_system_service_paths() -> List[str]:
             except Exception:
                 pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_python_package_paths() -> List[str]:
@@ -1917,7 +1917,7 @@ def get_ssh_config_paths() -> List[str]:
             if p.exists():
                 paths.append(str(p))
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_network_config_paths() -> List[str]:
@@ -1948,7 +1948,7 @@ def get_network_config_paths() -> List[str]:
                 except OSError:
                     pass
 
-    return sorted(list(set(str(Path(p).absolute()) for p in paths if os.path.isfile(p))))
+    return sorted(set(str(Path(p).absolute()) for p in paths if os.path.isfile(p)))
 
 
 def get_startup_item_commands() -> List[Tuple[str, bytes]]:
@@ -2069,7 +2069,7 @@ def get_git_hooks_paths(path: str = ".") -> List[str]:
         except OSError:
             pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_git_config_snippets() -> List[Tuple[str, bytes]]:


### PR DESCRIPTION
* **What:** Removed redundant `list()` constructor calls within `sorted(list(set(paths)))` in several path discovery functions in `gptscan.py`.
* **Why:** The `sorted()` function accepts any iterable, including sets, and always returns a list. Removing the intermediate `list()` conversion makes the code more idiomatic and slightly more efficient by avoiding unnecessary object creation. This is a safe, non-breaking refactor.
* **Verification:** Verified that the return type and deduplication logic remain identical. Ran the full test suite (969 tests) and confirmed that all tests passed, matching the baseline.

---
*PR created automatically by Jules for task [17579897336016214829](https://jules.google.com/task/17579897336016214829) started by @RainRat*