### PR TITLE
[DOCS] Improve core scanning API docstrings in gptscan.py

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4709,16 +4709,18 @@ def scan_files(
     """Scan files for dangerous content and optionally use AI for analysis.
 
     Args:
-        scan_targets: Folder path or list of file/folder paths to search.
-        deep_scan: Whether to scan overlapping 1024-byte windows beyond the first block.
-        show_all: Whether to yield all scanned files regardless of threat level threshold.
-        use_gpt: Whether to request GPT analysis when the local model is confident.
-        rate_limit: Maximum number of GPT requests permitted per minute.
-        max_concurrent_requests: Maximum number of GPT requests executed concurrently.
-        dry_run: Whether to list files that would be scanned without running the model or API.
-        exclude_patterns: List of glob patterns to exclude from the scan.
+        scan_targets: Folder path, file path, or list of paths to scan.
+        deep_scan: Scan the whole file. This is slower but more thorough.
+        show_all: Show all scanned files, even safe ones.
+        use_gpt: Use AI to analyze suspicious files.
+        cancel_event: Event used to stop the scan.
+        rate_limit: Maximum number of AI requests per minute.
+        max_concurrent_requests: Maximum number of AI requests to run at once.
+        dry_run: Preview which files would be scanned without actually checking them.
+        exclude_patterns: Ignore files or folders matching these patterns.
         extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
-        modified_since: A timestamp. If provided, only files modified after this time are scanned.
+        fail_threshold: Stop the scan if a file's threat level is at or above this number.
+        modified_since: Only scan files changed since this Unix timestamp.
 
     Yields:
         Tuples indicating events:
@@ -5336,12 +5338,17 @@ def run_scan(
     """Read scan results and send them to the UI window.
 
     Args:
-        scan_targets: Folder path or list of files to scan.
-        deep_scan: Whether to evaluate all 1024-byte windows.
-        show_all: Whether to display all results regardless of threat level.
-        use_gpt: Whether to enrich suspicious files with GPT output.
-        rate_limit: Maximum allowed GPT requests per minute.
-        dry_run: Whether to simulate the scan.
+        scan_targets: Folder path, file path, or list of paths to scan.
+        deep_scan: Scan the whole file. This is slower but more thorough.
+        show_all: Show all scanned files, even safe ones.
+        use_gpt: Use AI to analyze suspicious files.
+        cancel_event: Event used to stop the scan.
+        rate_limit: Maximum number of AI requests per minute.
+        dry_run: Preview which files would be scanned without actually checking them.
+        exclude_patterns: Ignore files or folders matching these patterns.
+        extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
+        fail_threshold: Stop the scan if a file's threat level is at or above this number.
+        modified_since: Only scan files changed since this Unix timestamp.
     """
     event_gen = scan_files(
         scan_targets,


### PR DESCRIPTION
This PR improves the internal documentation of the core scanning API in `gptscan.py`.

### Changes:
- Updated the docstrings for `scan_files` and `run_scan` to follow the standard `Args:`/`Returns:`/`Yields:` format.
- Added missing documentation for several parameters, including `cancel_event`, `fail_threshold`, `modified_since`, `exclude_patterns`, and `extra_snippets`.
- Simplified technical descriptions to use Plain English (e.g., changing "overlapping 1024-byte windows" to "Scan the whole file. This is slower but more thorough").
- Ensured terminology matches the user-facing documentation in the README (e.g., using "AI Analysis" instead of "GPT analysis").

These improvements make the scanning logic more accessible to developers and ensure the documentation accurately reflects the actual code behavior. All 969 relevant tests in the suite passed after these changes.

---
*PR created automatically by Jules for task [15916146301526499178](https://jules.google.com/task/15916146301526499178) started by @RainRat*