### PR TITLE
[FEAT] Detect Deceptive Content-Extension Mismatches

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -547,18 +547,27 @@ class Config:
 
         file_path = Path(file_path)
 
-        # Check for a script starting line (like #!/bin/bash) for files without a recognized extension
+        # Check for a script starting line (like #!/bin/bash) or binary executable magic bytes
         try:
-            first_line = None
+            header = None
             if content is not None:
-                if content.startswith(b'#!'):
-                    first_line = content[2:].split(b'\n', 1)[0][:126].decode('utf-8', errors='ignore').lower()
+                header = content[:128]
             elif file_path.is_file():
                 with open(file_path, 'rb') as f:
-                    if f.read(2) == b'#!':
-                        first_line = f.readline(126).decode('utf-8', errors='ignore').lower()
+                    header = f.read(128)
 
-            if first_line:
+            if header:
+                # Check for content/extension mismatch
+                deception_score, _ = analyze_content_mismatch(path_str, header)
+                if deception_score >= 0.5:
+                    return True
+
+                # Check for shebang
+                first_line = None
+                if header.startswith(b'#!'):
+                    first_line = header[2:].split(b'\n', 1)[0][:126].decode('utf-8', errors='ignore').lower()
+
+            if header and first_line:
                 interpreters = ['python', 'node', 'nodejs', 'javascript', 'bash', 'sh', 'ash', 'dash', 'zsh', 'perl', 'ruby', 'php', 'pwsh', 'powershell', 'lua', 'osascript', 'ipython']
                 escaped_interpreters = [re.escape(i) for i in interpreters]
                 pattern = r'(?:/|\s|^)(?:' + '|'.join(escaped_interpreters) + r')\d*\b'
@@ -2483,6 +2492,50 @@ def format_bytes(num: float) -> str:
             return f"{num:3.1f} {unit}"
         num /= 1024.0
     return f"{num:.1f} PiB"
+
+
+def analyze_content_mismatch(path: Union[str, Path], content: bytes) -> Tuple[float, str]:
+    """Analyze if the file content matches its extension.
+
+    Detects executable magic bytes or shebangs in files with "safe" extensions.
+
+    Returns:
+        A tuple of (threat_score, message). Score is 0.0 to 1.0.
+    """
+    path_s = str(path).lower()
+    name = os.path.basename(path_s)
+    if not name or not content:
+        return 0.0, ""
+
+    extension = os.path.splitext(name)[1]
+    # "Safe" extensions that shouldn't contain executables or scripts
+    safe_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.pdf', '.docx', '.xlsx', '.pptx', '.mp3', '.mp4', '.txt', '.csv', '.zip', '.rar', '.7z'}
+
+    if extension not in safe_extensions:
+        return 0.0, ""
+
+    # Check for binary executable magic bytes
+    # Windows (MZ)
+    if content.startswith(b'MZ'):
+        return 1.0, f"Deceptive content: Windows executable (MZ) found in '{extension}' file."
+
+    # Linux (ELF)
+    if content.startswith(b'\x7fELF'):
+        return 1.0, f"Deceptive content: Linux executable (ELF) found in '{extension}' file."
+
+    # macOS (Mach-O)
+    if content.startswith((b'\xfe\xed\xfa\xce', b'\xfe\xed\xfa\xcf', b'\xce\xfa\xed\xfe', b'\xcf\xfa\xed\xfe')):
+        return 1.0, f"Deceptive content: macOS executable (Mach-O) found in '{extension}' file."
+
+    # Check for shebangs in non-script files (excluding .txt which might legitimately have them for some reason, though still suspicious)
+    if content.startswith(b'#!') and extension != '.txt':
+        try:
+            first_line = content[:128].split(b'\n', 1)[0].decode('utf-8', errors='ignore')
+            return 0.8, f"Deceptive content: Script shebang '{first_line.strip()}' found in '{extension}' file."
+        except Exception:
+            pass
+
+    return 0.0, ""
 
 
 def analyze_filename(path: Union[str, Path]) -> Tuple[float, str]:
@@ -4856,8 +4909,11 @@ def scan_files(
             # Filename analysis for additional threat indicators
             file_threat, file_msg = analyze_filename(path)
 
-            # Combine threat levels (take the maximum of content and filename threat)
-            effective_maxconf = max(maxconf, file_threat)
+            # Content-extension mismatch analysis
+            mismatch_threat, mismatch_msg = analyze_content_mismatch(path, max_window_bytes)
+
+            # Combine threat levels (take the maximum of content and metadata threats)
+            effective_maxconf = max(maxconf, file_threat, mismatch_threat)
 
             percent = format_percent(effective_maxconf * 100.0)
             snippet = ''.join(map(chr, max_window_bytes)).strip()
@@ -4868,6 +4924,11 @@ def scan_files(
             if file_threat >= 0.5:
                 admin_note = f"[Filename Warning] {file_msg}"
                 user_note = f"Caution: {file_msg}"
+
+            if mismatch_threat >= 0.5:
+                mismatch_warn = f"[Deception Warning] {mismatch_msg}"
+                admin_note = f"{admin_note}\n{mismatch_warn}".strip()
+                user_note = f"{user_note}\nCaution: {mismatch_msg}".strip()
 
             if full_content is not None:
                 _virtual_source_cache[path] = full_content

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ Scan your files for dangerous code with AI. This tool uses a quick scan model to
 *   **Automation Tasks:** Scan GitHub Actions, GitLab CI, and other YAML workflows for suspicious commands.
 *   **Web Files:** Scan HTML, SVG, and Markdown files for embedded scripts.
 *   **Unified Diffs:** Scan `.diff` and `.patch` files to review code changes.
+*   **Deceptive Content Detection:** Detect executables and scripts disguised as images or documents (e.g., a Windows `.exe` renamed to `.jpg`) using content signatures (magic bytes).
 
 ## Installation
 

--- a/tests/test_content_deception.py
+++ b/tests/test_content_deception.py
@@ -1,0 +1,127 @@
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+import gptscan
+from gptscan import Config, analyze_filename, scan_files
+
+@pytest.fixture
+def mock_scan_env(monkeypatch):
+    """Mocks TensorFlow and Model for scan_files tests."""
+    mock_predict = MagicMock(return_value=[[0.1]])
+    mock_model = SimpleNamespace(predict=mock_predict)
+    monkeypatch.setattr(gptscan, "get_model", lambda: mock_model)
+
+    mock_tf = SimpleNamespace(
+        constant=lambda x: x,
+        expand_dims=lambda x, axis: x,
+    )
+    monkeypatch.setattr(gptscan, "_tf_module", mock_tf)
+    return mock_predict
+
+def test_is_supported_file_content_deception(tmp_path):
+    Config.initialize()
+    Config.extensions_set = {".py", ".sh"}
+    Config.scan_all_files = False
+
+    # 1. Create a "JPG" that is actually a Windows Executable (MZ)
+    deceptive_jpg = tmp_path / "normal_image.jpg"
+    deceptive_jpg.write_bytes(b"MZ\x90\x00\x03\x00\x00\x00")
+
+    # Now it SHOULD be True
+    assert Config.is_supported_file(deceptive_jpg) is True
+
+def test_is_supported_file_shebang_deception(tmp_path):
+    Config.initialize()
+    Config.extensions_set = {".py", ".sh"}
+    Config.scan_all_files = False
+
+    # 2. Create a "TXT" that is actually a Shell script
+    deceptive_txt = tmp_path / "readme.txt"
+    deceptive_txt.write_bytes(b"#!/bin/bash\necho 'hello'")
+
+    # This was already True, should remain True
+    assert Config.is_supported_file(deceptive_txt) is True
+
+def test_is_supported_file_elf_deception(tmp_path):
+    Config.initialize()
+    Config.extensions_set = {".py", ".sh"}
+    Config.scan_all_files = False
+
+    # 3. Create a "PDF" that is actually an ELF executable
+    deceptive_pdf = tmp_path / "document.pdf"
+    deceptive_pdf.write_bytes(b"\x7fELF\x02\x01\x01\x00")
+
+    # Now it SHOULD be True
+    assert Config.is_supported_file(deceptive_pdf) is True
+
+def test_analyze_content_mismatch_windows():
+    from gptscan import analyze_content_mismatch
+    score, msg = analyze_content_mismatch("test.jpg", b"MZ\x90\x00")
+    assert score == 1.0
+    assert "Windows executable" in msg
+    assert ".jpg" in msg
+
+def test_analyze_content_mismatch_linux():
+    from gptscan import analyze_content_mismatch
+    score, msg = analyze_content_mismatch("script.pdf", b"\x7fELF\x02")
+    assert score == 1.0
+    assert "Linux executable" in msg
+    assert ".pdf" in msg
+
+def test_analyze_content_mismatch_mac():
+    from gptscan import analyze_content_mismatch
+    # Mach-O 64-bit
+    score, msg = analyze_content_mismatch("data.png", b"\xcf\xfa\xed\xfe")
+    assert score == 1.0
+    assert "macOS executable" in msg
+
+def test_analyze_content_mismatch_shebang():
+    from gptscan import analyze_content_mismatch
+    score, msg = analyze_content_mismatch("notes.docx", b"#!/usr/bin/python\n")
+    assert score == 0.8
+    assert "Script shebang" in msg
+    assert ".docx" in msg
+
+def test_analyze_content_mismatch_benign():
+    from gptscan import analyze_content_mismatch
+    # JPG starting with its real magic
+    score, msg = analyze_content_mismatch("image.jpg", b"\xff\xd8\xff")
+    assert score == 0.0
+
+    # .py file with MZ (we don't flag script extensions for binary mismatch here)
+    score, msg = analyze_content_mismatch("test.py", b"MZ\x90\x00")
+    assert score == 0.0
+
+def test_scan_files_detects_deception(mock_scan_env, tmp_path):
+    """End-to-end test verifying scan_files flags deceptive content."""
+    Config.initialize()
+    Config.extensions_set = {".py"}
+    Config.THRESHOLD = 50
+
+    deceptive_jpg = tmp_path / "evil.jpg"
+    deceptive_jpg.write_bytes(b"MZ\x90\x00\x03\x00")
+
+    cancel_event = SimpleNamespace(is_set=lambda: False)
+
+    events = list(scan_files(
+        str(tmp_path),
+        deep_scan=False,
+        show_all=True,
+        use_gpt=False,
+        cancel_event=cancel_event
+    ))
+
+    # Filter for results
+    results = [data for event_type, data in events if event_type == 'result']
+
+    # Should find our deceptive file
+    found = [r for r in results if "evil.jpg" in r[0]]
+    assert len(found) == 1
+
+    # (path, percent, admin_note, user_note, gpt_conf, snippet, line)
+    data = found[0]
+    assert data[1] == "100%" # Mismatch threat is 1.0
+    assert "Deceptive content" in data[2]
+    assert "Windows executable" in data[2]


### PR DESCRIPTION
### FEAT: Detect Deceptive Content-Extension Mismatches

**What:**
This PR introduces a "Content-Extension Mismatch" detection engine to the scanner. It identifies malicious or deceptive files that have been renamed to appear harmless (e.g., a Windows `.exe` renamed to `.jpg`). 

The scanner now:
1.  **Peeks at file headers** during discovery to identify binary magic bytes (Windows MZ, Linux ELF, macOS Mach-O) and script shebangs.
2.  **Forces inclusion** of these deceptive files in the scan, even if their extension is not in the configured whitelist.
3.  **Flags deceptive content** with a 100% threat level and clear "Deception Warning" labels in the results.

**Why:**
I noticed the scanner's file discovery was primarily extension-driven. A common tactic for delivering malware or bypassing simple filters is renaming an executable to a "safe" extension like `.jpg` or `.pdf`. By implementing signature-based validation (Magic Bytes), we close this security gap and ensure that deceptive files are analyzed and flagged appropriately.

**Technical Changes:**
-   `analyze_content_mismatch`: New utility function for signature validation.
-   `Config.is_supported_file`: Refactored to include header peeking (first 128 bytes) for unrecognized extensions.
-   `handle_scan_result`: Updated to merge mismatch threats and add descriptive alerts.
-   `tests/test_content_deception.py`: New test suite covering various deception scenarios and end-to-end scan logic.
-   `readme.md`: Added "Deceptive Content Detection" to the feature list.

---
*PR created automatically by Jules for task [5592919964353282273](https://jules.google.com/task/5592919964353282273) started by @RainRat*