### PR TITLE
Refactor redundant list conversions in path discovery

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1165,7 +1165,7 @@ def get_shell_profile_paths() -> List[str]:
         except Exception:
             pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_shell_history_paths() -> List[str]:
@@ -1453,7 +1453,7 @@ def get_system_service_paths() -> List[str]:
             except Exception:
                 pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_python_package_paths() -> List[str]:
@@ -1917,7 +1917,7 @@ def get_ssh_config_paths() -> List[str]:
             if p.exists():
                 paths.append(str(p))
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_network_config_paths() -> List[str]:
@@ -1948,7 +1948,7 @@ def get_network_config_paths() -> List[str]:
                 except OSError:
                     pass
 
-    return sorted(list(set(str(Path(p).absolute()) for p in paths if os.path.isfile(p))))
+    return sorted(set(str(Path(p).absolute()) for p in paths if os.path.isfile(p)))
 
 
 def get_startup_item_commands() -> List[Tuple[str, bytes]]:
@@ -2069,7 +2069,7 @@ def get_git_hooks_paths(path: str = ".") -> List[str]:
         except OSError:
             pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_git_config_snippets() -> List[Tuple[str, bytes]]:


### PR DESCRIPTION
* **What:** Removed redundant `list()` constructor calls from `sorted(list(set(paths)))` patterns across multiple path-discovery functions in `gptscan.py`.
* **Why:** The `sorted()` function in Python accepts any iterable (including sets) and returns a new list. Wrapping the intermediate `set` in a `list` is redundant and adds unnecessary overhead. This change improves code idiomaticity without altering behavior.

---
*PR created automatically by Jules for task [105545396053946557](https://jules.google.com/task/105545396053946557) started by @RainRat*