### PR TITLE
[DOCS] Improve API docstrings for core scanning functions

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4712,12 +4712,14 @@ def scan_files(
         scan_targets: Folder path or list of file/folder paths to search.
         deep_scan: Whether to scan overlapping 1024-byte windows beyond the first block.
         show_all: Whether to yield all scanned files regardless of threat level threshold.
-        use_gpt: Whether to request GPT analysis when the local model is confident.
-        rate_limit: Maximum number of GPT requests permitted per minute.
-        max_concurrent_requests: Maximum number of GPT requests executed concurrently.
+        use_gpt: Whether to request AI analysis when the local model is confident.
+        cancel_event: Event used to stop the scan prematurely.
+        rate_limit: Maximum number of AI requests permitted per minute.
+        max_concurrent_requests: Maximum number of AI requests executed concurrently.
         dry_run: Whether to list files that would be scanned without running the model or API.
         exclude_patterns: List of glob patterns to exclude from the scan.
         extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
+        fail_threshold: Threat level (0-100) that triggers an early exit if reached.
         modified_since: A timestamp. If provided, only files modified after this time are scanned.
 
     Yields:
@@ -5339,9 +5341,14 @@ def run_scan(
         scan_targets: Folder path or list of files to scan.
         deep_scan: Whether to evaluate all 1024-byte windows.
         show_all: Whether to display all results regardless of threat level.
-        use_gpt: Whether to enrich suspicious files with GPT output.
-        rate_limit: Maximum allowed GPT requests per minute.
+        use_gpt: Whether to enrich suspicious files with AI analysis.
+        cancel_event: Event used to stop the scan prematurely.
+        rate_limit: Maximum allowed AI requests per minute.
         dry_run: Whether to simulate the scan.
+        exclude_patterns: List of glob patterns to exclude from the scan.
+        extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
+        fail_threshold: Threat level (0-100) that triggers an early exit if reached.
+        modified_since: A timestamp. If provided, only files modified after this time are scanned.
     """
     event_gen = scan_files(
         scan_targets,


### PR DESCRIPTION
This PR improves the internal documentation of core scanning functions in `gptscan.py`. 

### Changes:
- **`scan_files`**: Added `cancel_event`, `fail_threshold` to the `Args` section. Standardized 'GPT' to 'AI analysis'.
- **`run_scan`**: Added `cancel_event`, `exclude_patterns`, `extra_snippets`, `fail_threshold`, and `modified_since` to the `Args` section. Standardized 'GPT' to 'AI analysis'.

### Why:
Ensuring that core API functions are fully documented helps maintainability and makes it easier for other developers to understand how to interact with the scanning engine. Using 'AI' instead of 'GPT' is more inclusive and less jargon-heavy.

---
*PR created automatically by Jules for task [2417815766991774346](https://jules.google.com/task/2417815766991774346) started by @RainRat*