### PR TITLE
[DOCS] Improve scan_files and run_scan API docstrings

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -4712,12 +4712,14 @@ def scan_files(
         scan_targets: Folder path or list of file/folder paths to search.
         deep_scan: Whether to scan overlapping 1024-byte windows beyond the first block.
         show_all: Whether to yield all scanned files regardless of threat level threshold.
-        use_gpt: Whether to request GPT analysis when the local model is confident.
-        rate_limit: Maximum number of GPT requests permitted per minute.
-        max_concurrent_requests: Maximum number of GPT requests executed concurrently.
+        use_gpt: Whether to request AI analysis when the local model is confident.
+        cancel_event: An event to trigger and signal scan cancellation.
+        rate_limit: Maximum number of AI requests permitted per minute.
+        max_concurrent_requests: Maximum number of AI requests executed concurrently.
         dry_run: Whether to list files that would be scanned without running the model or API.
         exclude_patterns: List of glob patterns to exclude from the scan.
         extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
+        fail_threshold: Stop with an error if a file threat level is at or above this limit (0-100).
         modified_since: A timestamp. If provided, only files modified after this time are scanned.
 
     Yields:
@@ -5339,9 +5341,14 @@ def run_scan(
         scan_targets: Folder path or list of files to scan.
         deep_scan: Whether to evaluate all 1024-byte windows.
         show_all: Whether to display all results regardless of threat level.
-        use_gpt: Whether to enrich suspicious files with GPT output.
-        rate_limit: Maximum allowed GPT requests per minute.
+        use_gpt: Whether to enrich suspicious files with AI analysis output.
+        cancel_event: An event to trigger and signal scan cancellation.
+        rate_limit: Maximum allowed AI requests per minute.
         dry_run: Whether to simulate the scan.
+        exclude_patterns: List of glob patterns to exclude from the scan.
+        extra_snippets: List of (name, content) tuples to scan as in-memory buffers.
+        fail_threshold: Stop with an error if a file threat level is at or above this limit (0-100).
+        modified_since: A timestamp. If provided, only files modified after this time are scanned.
     """
     event_gen = scan_files(
         scan_targets,


### PR DESCRIPTION
This PR improves the API docstrings of the core functions `scan_files` and `run_scan` in `gptscan.py`. Specifically, it adds documentation for several parameters that were previously omitted (e.g. `cancel_event`, `fail_threshold`, `exclude_patterns`, `extra_snippets`, and `modified_since`), and standardizes terminology to use "AI" instead of "GPT" to be more inclusive of other AI backend providers such as Ollama and OpenRouter. All unit tests have been run and passed successfully.

---
*PR created automatically by Jules for task [6167545859586144884](https://jules.google.com/task/6167545859586144884) started by @RainRat*