### PR TITLE
Auto-enable CLI mode on specialized flags and fallback gracefully to CLI on headless environments

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -8602,7 +8602,27 @@ def main():
 
     scan_target = args.target or args.path
 
-    if args.cli:
+    cli_targets_or_flags = [
+        args.stdin, args.import_results,
+        args.env_vars, args.file_list, args.git_changes, args.git_diff, args.git_hooks, args.git_config,
+        args.git_stash, args.git_conflicts, args.git_history, args.git_reflog, args.shell_profiles, args.shell_history, args.system_path,
+        args.running_processes, args.scheduled_tasks, args.startup_items,
+        args.system_services, args.audit, args.modified, args.downloads, args.desktop,
+        args.python_packages, args.nodejs_packages, args.ruby_gems, args.php_packages,
+        args.rust_packages, args.go_packages, args.java_packages, args.dotnet_packages,
+        args.browser_extensions, args.editor_extensions, args.ssh_config, args.network_config, args.temp, args.documents
+    ]
+    cli_mode = args.cli or any(cli_targets_or_flags)
+
+    if not cli_mode:
+        try:
+            app_root = create_gui(initial_path=scan_target)
+            app_root.mainloop()
+        except tk.TclError as e:
+            print(f"Warning: Failed to initialize GUI ({e}). Falling back to terminal (CLI) mode.", file=sys.stderr)
+            cli_mode = True
+
+    if cli_mode:
         scan_targets = []
         if args.target:
             scan_targets.append(args.target)
@@ -8909,9 +8929,6 @@ def main():
         )
         if args.fail_threshold is not None and threats > 0:
             sys.exit(1)
-    else:
-        app_root = create_gui(initial_path=scan_target)
-        app_root.mainloop()
 
 if __name__ == "__main__":
     main()

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -70,3 +70,64 @@ def test_version_alias():
             with pytest.raises(SystemExit) as excinfo:
                 main()
             assert excinfo.value.code == 0
+
+
+def test_auto_cli_mode_with_flags(monkeypatch):
+    """Test that CLI mode is automatically enabled when a CLI-centric flag like --audit is provided."""
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+
+    test_args = ["gptscan.py", "--audit"]
+    with patch.object(sys, "argv", test_args):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    # Verify run_cli was called even though --cli was NOT specified!
+    assert mock_run_cli.called
+
+
+def test_auto_cli_mode_with_git_changes(monkeypatch):
+    """Test that CLI mode is automatically enabled when --git-changes is provided."""
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+    monkeypatch.setattr("gptscan.get_git_changed_files", MagicMock(return_value=["some_changed_file.py"]))
+
+    test_args = ["gptscan.py", "--git-changes"]
+    with patch.object(sys, "argv", test_args):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    assert mock_run_cli.called
+
+
+def test_gui_tcl_error_fallback(monkeypatch, capsys):
+    """Test that the application gracefully falls back to CLI mode if GUI initialization raises a TclError."""
+    import tkinter as tk
+
+    mock_run_cli = MagicMock(return_value=0)
+    monkeypatch.setattr("gptscan.run_cli", mock_run_cli)
+
+    # Mock create_gui to raise TclError
+    def mock_create_gui(initial_path=None):
+        raise tk.TclError("no display name and no $DISPLAY environment variable")
+
+    monkeypatch.setattr("gptscan.create_gui", mock_create_gui)
+
+    test_args = ["gptscan.py"]
+    with patch.object(sys, "argv", test_args):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    # Verify run_cli was called (graceful fallback)
+    assert mock_run_cli.called
+
+    # Verify the warning was printed to stderr
+    captured = capsys.readouterr()
+    assert "Warning: Failed to initialize GUI" in captured.err
+    assert "Falling back to terminal (CLI) mode" in captured.err


### PR DESCRIPTION
Automatically switch to CLI mode when CLI-centric arguments are specified or when GUI initialization fails with a TclError.

---
*PR created automatically by Jules for task [3914804535305701386](https://jules.google.com/task/3914804535305701386) started by @RainRat*