### PR TITLE
[FEAT] Add console triage report import and export symmetry (.txt format)

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5988,6 +5988,124 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
     return res
 
 
+def parse_triage_report(content: str) -> List[Dict[str, Any]]:
+    """Parse a plain-text or colorized console triage report into standardized result dicts.
+
+    Args:
+        content: The raw text of the triage report.
+
+    Returns:
+        A list of parsed findings ready to be standardized.
+    """
+    # Strip ANSI escape codes
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    clean_content = ansi_escape.sub('', content)
+
+    lines = clean_content.splitlines()
+    findings = []
+    current_item = None
+    state = "FINDING_START"  # FINDING_START, METADATA, CONTENT
+    content_mode = None      # ADMIN, USER, SNIPPET
+
+    header_re = re.compile(r'^\[\d+\]\s+(?:HIGH|MEDIUM|LOW)\s+RISK\s+-\s+(.+)$', re.IGNORECASE)
+
+    for line in lines:
+        line_stripped = line.strip()
+
+        # Check if this line is a new finding header
+        header_match = header_re.match(line_stripped)
+        if header_match:
+            # Save the previous finding if it exists
+            if current_item:
+                findings.append(current_item)
+
+            # Extract location
+            location = header_match.group(1).strip()
+            path = location
+            line_num = "-"
+            if ":" in location:
+                # Handle path:line_num
+                parts = location.rsplit(":", 1)
+                if parts[1].isdigit():
+                    path = parts[0]
+                    line_num = parts[1]
+
+            current_item = {
+                "path": path,
+                "line": line_num,
+                "own_conf": "",
+                "gpt_conf": "",
+                "admin_desc_list": [],
+                "end-user_desc_list": [],
+                "snippet_list": []
+            }
+            state = "METADATA"
+            content_mode = None
+            continue
+
+        if state == "METADATA":
+            if "Local:" in line_stripped:
+                # e.g., Local: 85%  AI: 90%
+                local_match = re.search(r'Local:\s*(\d+%)', line_stripped)
+                if local_match:
+                    current_item["own_conf"] = local_match.group(1)
+                ai_match = re.search(r'AI:\s*(\d+%)', line_stripped)
+                if ai_match:
+                    current_item["gpt_conf"] = ai_match.group(1)
+                state = "CONTENT"
+            continue
+
+        if state == "CONTENT":
+            # Check for Admin, User, Snippet indicators
+            if "Admin:" in line_stripped:
+                content_mode = "ADMIN"
+                idx = line_stripped.find("Admin:")
+                text = line_stripped[idx + 6:].strip()
+                if text:
+                    current_item["admin_desc_list"].append(text)
+            elif "User:" in line_stripped:
+                content_mode = "USER"
+                idx = line_stripped.find("User:")
+                text = line_stripped[idx + 5:].strip()
+                if text:
+                    current_item["end-user_desc_list"].append(text)
+            elif line_stripped.startswith(">"):
+                content_mode = "SNIPPET"
+                text = line_stripped[1:]
+                if text.startswith(" "):
+                    text = text[1:]
+                current_item["snippet_list"].append(text)
+            elif line.startswith("    ") and content_mode:
+                # Continuation of the current content mode
+                if content_mode == "ADMIN":
+                    current_item["admin_desc_list"].append(line_stripped)
+                elif content_mode == "USER":
+                    current_item["end-user_desc_list"].append(line_stripped)
+                elif content_mode == "SNIPPET":
+                    text = line[4:]
+                    if text.startswith(">"):
+                        text = text[1:]
+                        if text.startswith(" "):
+                            text = text[1:]
+                    current_item["snippet_list"].append(text)
+
+    if current_item:
+        findings.append(current_item)
+
+    # Post-process lists into strings
+    final_findings = []
+    for item in findings:
+        item["admin_desc"] = "\n".join(item["admin_desc_list"]).strip()
+        item["end-user_desc"] = "\n".join(item["end-user_desc_list"]).strip()
+        item["snippet"] = "\n".join(item["snippet_list"]).strip()
+        del item["admin_desc_list"]
+        del item["end-user_desc_list"]
+        del item["snippet_list"]
+        final_findings.append(item)
+
+    return final_findings
+
+
 def parse_report_content(content: str, filename_hint: Optional[str] = None) -> List[Dict[str, Any]]:
     """Parse report content in JSON, SARIF, or CSV format.
 
@@ -6006,13 +6124,23 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
     if filename_hint:
         ext = os.path.splitext(filename_hint)[1].lower()
 
-    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml'):
+    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt'):
         raise ValueError(f"Unsupported file extension: {ext}")
 
     data_to_import = []
 
+    # Strip ANSI codes for checking triage report signature
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    stripped_for_check = ansi_escape.sub('', content)
+    lines_for_check = stripped_for_check.splitlines()
+    has_triage_header = any("--- GPT SCAN - " in line and "TRIAGE REPORT" in line for line in lines_for_check)
+    has_triage_finding = any(re.match(r'^\[\d+\]\s+(?:HIGH|MEDIUM|LOW)\s+RISK\s+-\s+.+$', line.strip(), re.IGNORECASE) for line in lines_for_check)
+
     # Auto-detection logic
-    if (content.strip().startswith('<') and ('<table' in content.lower() or '<tr' in content.lower())) or ext in ('.html', '.htm', '.xhtml'):
+    if ext == '.txt' or has_triage_header or has_triage_finding:
+        # Parse Triage Report
+        data_to_import = parse_triage_report(content)
+    elif (content.strip().startswith('<') and ('<table' in content.lower() or '<tr' in content.lower())) or ext in ('.html', '.htm', '.xhtml'):
         # HTML report format
         # Use regex to find rows, ignoring the header row
         rows = re.findall(r'<tr\b[^>]*>(.*?)</tr>', content, re.DOTALL | re.IGNORECASE)
@@ -6271,12 +6399,13 @@ def import_results(event: Optional[tk.Event] = None) -> None:
 
     file_path = filedialog.askopenfilename(
         filetypes=[
-            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml"),
+            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml;*.txt"),
             ("JSON files", "*.json;*.jsonl;*.ndjson"),
             ("SARIF files", "*.sarif"),
             ("CSV files", "*.csv"),
             ("Markdown files", "*.md;*.markdown"),
             ("HTML files", "*.html;*.htm;*.xhtml"),
+            ("Text / Triage files", "*.txt"),
             ("All files", "*.*")
         ],
         title="Import Scan Results",
@@ -6406,7 +6535,7 @@ def _get_tree_results_as_dicts(item_ids: Iterable[str]) -> List[Dict[str, Any]]:
 def export_results(event: Optional[tk.Event] = None) -> None:
     """Save the current Treeview contents to a file chosen by the user.
 
-    Supports CSV, HTML, JSON, and SARIF formats.
+    Supports CSV, HTML, JSON, SARIF, and Text/Triage formats.
 
     Returns
     -------
@@ -6424,6 +6553,7 @@ def export_results(event: Optional[tk.Event] = None) -> None:
             ("HTML files", "*.html"),
             ("JSON files", "*.json"),
             ("SARIF files", "*.sarif"),
+            ("Text / Triage files", "*.txt"),
             ("All files", "*.*")
         ],
         title="Export Scan Results",
@@ -6449,6 +6579,9 @@ def export_results(event: Optional[tk.Event] = None) -> None:
         elif ext == '.md':
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(generate_markdown(results))
+        elif ext == '.txt':
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(generate_console_report(results, use_color=False))
         else: # Default to CSV
             with open(file_path, "w", newline="", encoding="utf-8") as csv_file:
                 writer = csv.writer(csv_file)

--- a/tests/test_import_html.py
+++ b/tests/test_import_html.py
@@ -129,4 +129,4 @@ def test_parse_html_report_multiline_notes():
 def test_parse_html_unsupported_extension():
     """Test that unsupported extensions raise ValueError if hinted."""
     with pytest.raises(ValueError, match="Unsupported file extension"):
-        parse_report_content("<html></html>", filename_hint="report.txt")
+        parse_report_content("<html></html>", filename_hint="report.unsupported")

--- a/tests/test_import_logic.py
+++ b/tests/test_import_logic.py
@@ -163,10 +163,10 @@ def test_import_results_invalid_json(monkeypatch, tmp_path):
 
 def test_import_results_unsupported_ext(monkeypatch, tmp_path):
     """Test error handling for unsupported file extensions."""
-    txt_file = tmp_path / "test.txt"
-    txt_file.write_text("some text")
+    unsupported_file = tmp_path / "test.unsupported"
+    unsupported_file.write_text("some text")
 
-    monkeypatch.setattr(gptscan.tkinter.filedialog, "askopenfilename", lambda **kwargs: str(txt_file))
+    monkeypatch.setattr(gptscan.tkinter.filedialog, "askopenfilename", lambda **kwargs: str(unsupported_file))
     monkeypatch.setattr(gptscan, "tree", MagicMock())
 
     mock_messagebox = MagicMock()
@@ -174,7 +174,7 @@ def test_import_results_unsupported_ext(monkeypatch, tmp_path):
 
     gptscan.import_results()
 
-    mock_messagebox.showerror.assert_called_with("Import Failed", "Could not load results:\nUnsupported file extension: .txt")
+    mock_messagebox.showerror.assert_called_with("Import Failed", "Could not load results:\nUnsupported file extension: .unsupported")
 
 def test_import_results_single_object_json(tmp_path):
     """Test importing a pretty-printed single JSON object result."""

--- a/tests/test_import_triage.py
+++ b/tests/test_import_triage.py
@@ -1,0 +1,124 @@
+import pytest
+import os
+import tempfile
+from gptscan import parse_report_content, generate_console_report, load_report_file
+
+def test_import_plain_triage_report():
+    triage_content = """
+--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---
+
+[1] HIGH RISK - /home/user/malicious.py:42
+    Local: 85%  AI: 95%  VT: https://virustotal.com/
+
+    Admin: Suspicious file execution.
+    Contains dangerous calls.
+
+    User: Potential threat found.
+
+    > import os
+    > os.system("rm -rf /")
+
+[2] LOW RISK - src/safe.js
+    Local: 15%
+
+    Admin: Safe file.
+
+    > console.log("hello");
+"""
+
+    results = parse_report_content(triage_content, filename_hint="report.txt")
+    assert len(results) == 2
+
+    # Verification for finding 1
+    assert results[0]["path"] == "/home/user/malicious.py"
+    assert results[0]["line"] == "42"
+    assert results[0]["own_conf"] == "85%"
+    assert results[0]["gpt_conf"] == "95%"
+    assert results[0]["admin_desc"] == "Suspicious file execution.\nContains dangerous calls."
+    assert results[0]["end-user_desc"] == "Potential threat found."
+    assert results[0]["snippet"] == 'import os\nos.system("rm -rf /")'
+
+    # Verification for finding 2
+    assert results[1]["path"] == "src/safe.js"
+    assert results[1]["line"] == "-"
+    assert results[1]["own_conf"] == "15%"
+    assert results[1]["gpt_conf"] == ""
+    assert results[1]["admin_desc"] == "Safe file."
+    assert results[1]["end-user_desc"] == ""
+    assert results[1]["snippet"] == 'console.log("hello");'
+
+
+def test_import_colorized_triage_report():
+    # Colored with ANSI escape sequences
+    triage_content = (
+        "\033[1m--- GPT SCAN - CONSOLE TRIAGE REPORT (1 finding) ---\033[0m\n\n"
+        "\033[0;90m[1]\033[0m \033[1;91mHIGH RISK\033[0m - \033[1m/path/to/script.py:10\033[0m\n"
+        "    \033[0;90mLocal:\033[0m \033[1;91m90%\033[0m  \033[0;90mAI:\033[0m \033[1;91m95%\033[0m\n\n"
+        "    \033[0;90mAdmin:\033[0m Dangerous code\n\n"
+        "    \033[0;90m>\033[0m payload = 'evil'\n"
+    )
+
+    results = parse_report_content(triage_content, filename_hint="report.txt")
+    assert len(results) == 1
+    assert results[0]["path"] == "/path/to/script.py"
+    assert results[0]["line"] == "10"
+    assert results[0]["own_conf"] == "90%"
+    assert results[0]["gpt_conf"] == "95%"
+    assert results[0]["admin_desc"] == "Dangerous code"
+    assert results[0]["snippet"] == "payload = 'evil'"
+
+
+def test_triage_report_symmetry():
+    # Verify that generating a console report and then importing it results in the same data
+    original_results = [
+        {
+            "path": "test_file.py",
+            "own_conf": "80%",
+            "gpt_conf": "90%",
+            "admin_desc": "Admin note line 1.\nAdmin note line 2.",
+            "end-user_desc": "User note.",
+            "snippet": "line 1\nline 2",
+            "line": "15"
+        }
+    ]
+
+    # Generate triage report (plain-text)
+    report_text = generate_console_report(original_results, use_color=False)
+
+    # Import triage report
+    imported_results = parse_report_content(report_text, filename_hint="results.txt")
+    assert len(imported_results) == 1
+
+    assert imported_results[0]["path"] == original_results[0]["path"]
+    assert imported_results[0]["line"] == original_results[0]["line"]
+    assert imported_results[0]["own_conf"] == original_results[0]["own_conf"]
+    assert imported_results[0]["gpt_conf"] == original_results[0]["gpt_conf"]
+    assert imported_results[0]["admin_desc"] == original_results[0]["admin_desc"]
+    assert imported_results[0]["end-user_desc"] == original_results[0]["end-user_desc"]
+
+    # Note: the snippet printed in the triage report has a limit of 3 lines, which our snippet matches.
+    # The snippet line headers are stripped and restored.
+    assert imported_results[0]["snippet"] == original_results[0]["snippet"]
+
+
+def test_import_triage_file_loading():
+    triage_content = """
+[1] HIGH RISK - script.py:1
+    Local: 100%
+
+    Admin: Critical threat.
+
+    > print("harm")
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = os.path.join(tmpdir, "report.txt")
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(triage_content)
+
+        results = load_report_file(file_path)
+        assert len(results) == 1
+        assert results[0]["path"] == "script.py"
+        assert results[0]["line"] == "1"
+        assert results[0]["own_conf"] == "100%"
+        assert results[0]["admin_desc"] == "Critical threat."
+        assert results[0]["snippet"] == 'print("harm")'


### PR DESCRIPTION
Added console triage report importing and exporting symmetry in .txt format. Included parser logic, Whitelisted txt extensions, updated import/export file types dialogs, and comprehensive test suite.

---
*PR created automatically by Jules for task [10657789970405286863](https://jules.google.com/task/10657789970405286863) started by @RainRat*