### PR TITLE
[TEST] Add platform-specific tests for browser bookmark scanning on Windows and macOS

### DIFF
--- a/tests/test_browser_bookmarks.py
+++ b/tests/test_browser_bookmarks.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import sqlite3
 import tempfile
 from pathlib import Path
@@ -119,3 +120,107 @@ def test_get_browser_bookmarks_snippets_firefox(tmp_path):
             assert "[Firefox Bookmark] FF Data" in titles
             assert "data:text/plain,secret" in contents
             assert len(snippets) == 2
+
+def test_get_browser_bookmarks_snippets_windows(tmp_path, monkeypatch):
+    local_appdata = tmp_path / "LocalAppData"
+    appdata = tmp_path / "AppData"
+    local_appdata.mkdir(parents=True)
+    appdata.mkdir(parents=True)
+
+    # 1. Chrome Bookmarks
+    chrome_bookmarks = local_appdata / "Google" / "Chrome" / "User Data" / "Default" / "Bookmarks"
+    chrome_bookmarks.parent.mkdir(parents=True)
+    bookmarks_data = {
+        "roots": {
+            "bookmark_bar": {
+                "type": "folder",
+                "children": [
+                    {
+                        "name": "Windows Chrome Bookmarklet",
+                        "type": "url",
+                        "url": "javascript:alert('WinChrome')"
+                    }
+                ]
+            }
+        }
+    }
+    chrome_bookmarks.write_text(json.dumps(bookmarks_data), encoding="utf-8")
+
+    # 2. Firefox bookmarks (places.sqlite)
+    ff_profile = appdata / "Mozilla" / "Firefox" / "Profiles" / "test.profile"
+    ff_profile.mkdir(parents=True)
+    db_path = ff_profile / "places.sqlite"
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE moz_places (id INTEGER PRIMARY KEY, url TEXT)")
+    cursor.execute("CREATE TABLE moz_bookmarks (id INTEGER PRIMARY KEY, fk INTEGER, title TEXT)")
+    cursor.execute("INSERT INTO moz_places (url) VALUES ('javascript:alert(\"WinFF\")')")
+    cursor.execute("INSERT INTO moz_bookmarks (fk, title) VALUES (1, 'WinFF Script')")
+    conn.commit()
+    conn.close()
+
+    # Apply patches
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    snippets = get_browser_bookmarks_snippets()
+
+    titles = [s[0] for s in snippets]
+    contents = [s[1].decode('utf-8') for s in snippets]
+
+    assert "[Chrome Bookmark] Windows Chrome Bookmarklet" in titles
+    assert "javascript:alert('WinChrome')" in contents
+    assert "[Firefox Bookmark] WinFF Script" in titles
+    assert "javascript:alert(\"WinFF\")" in contents
+
+def test_get_browser_bookmarks_snippets_darwin(tmp_path, monkeypatch):
+    lib_support = tmp_path / "Library" / "Application Support"
+    lib_support.mkdir(parents=True)
+
+    # 1. Edge Bookmarks
+    edge_bookmarks = lib_support / "Microsoft Edge" / "Default" / "Bookmarks"
+    edge_bookmarks.parent.mkdir(parents=True)
+    bookmarks_data = {
+        "roots": {
+            "bookmark_bar": {
+                "type": "folder",
+                "children": [
+                    {
+                        "name": "Mac Edge Bookmarklet",
+                        "type": "url",
+                        "url": "javascript:alert('MacEdge')"
+                    }
+                ]
+            }
+        }
+    }
+    edge_bookmarks.write_text(json.dumps(bookmarks_data), encoding="utf-8")
+
+    # 2. Firefox bookmarks (places.sqlite)
+    ff_profile = lib_support / "Firefox" / "Profiles" / "mac.profile"
+    ff_profile.mkdir(parents=True)
+    db_path = ff_profile / "places.sqlite"
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE moz_places (id INTEGER PRIMARY KEY, url TEXT)")
+    cursor.execute("CREATE TABLE moz_bookmarks (id INTEGER PRIMARY KEY, fk INTEGER, title TEXT)")
+    cursor.execute("INSERT INTO moz_places (url) VALUES ('javascript:alert(\"MacFF\")')")
+    cursor.execute("INSERT INTO moz_bookmarks (fk, title) VALUES (1, 'MacFF Script')")
+    conn.commit()
+    conn.close()
+
+    # Apply patches
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    snippets = get_browser_bookmarks_snippets()
+
+    titles = [s[0] for s in snippets]
+    contents = [s[1].decode('utf-8') for s in snippets]
+
+    assert "[Edge Bookmark] Mac Edge Bookmarklet" in titles
+    assert "javascript:alert('MacEdge')" in contents
+    assert "[Firefox Bookmark] MacFF Script" in titles
+    assert "javascript:alert(\"MacFF\")" in contents


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added tests to cover Windows (`win32`) and macOS (`darwin`) directory paths and sqlite/JSON processing inside the `get_browser_bookmarks_snippets` bookmark discovery function.
* **Why:** Extends unit test coverage for browser bookmark discovery to previously untested Windows and macOS branches, resolving a critical platform path coverage gap.

---
*PR created automatically by Jules for task [13996471376657166425](https://jules.google.com/task/13996471376657166425) started by @RainRat*