### PR TITLE
[UI/UX] Automatic URL Normalization and Validation

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -818,12 +818,47 @@ def browse_dir_click() -> None:
         button_click()
 
 
+def normalize_and_validate_url(url_str: str) -> Optional[str]:
+    """Normalize and validate user-inputted URLs for web scanning/importing.
+
+    Prepends 'https://' if a protocol is missing but the string looks like a web address,
+    and returns None if the URL is empty or completely invalid.
+    """
+    url_str = url_str.strip()
+    if not url_str:
+        return None
+
+    # Check if there is an existing scheme (e.g. http:// or file://)
+    match = re.match(r'^([a-zA-Z][a-zA-Z0-9+.-]*)://', url_str)
+    if match:
+        scheme = match.group(1).lower()
+        if scheme not in ("http", "https"):
+            messagebox.showerror(
+                "Unsupported Protocol",
+                f"Unsupported protocol '{scheme}://'. Only 'http://' and 'https://' are supported."
+            )
+            return None
+        return url_str
+
+    # No scheme found. Check if it looks like a web host or local address
+    if "." in url_str or url_str.lower().startswith("localhost"):
+        return f"https://{url_str}"
+
+    messagebox.showerror(
+        "Invalid Web Link",
+        f"The entered string '{url_str}' does not appear to be a valid web link (http/https)."
+    )
+    return None
+
+
 def select_url_click() -> None:
     """Handle the web link input dialog and populate the textbox."""
     url_selected = simpledialog.askstring("Scan Web Link", "Enter a script web link to scan (http/https):")
-    if url_selected:
-        _set_scan_target(url_selected.strip())
-        button_click()
+    if url_selected is not None:
+        normalized_url = normalize_and_validate_url(url_selected)
+        if normalized_url:
+            _set_scan_target(normalized_url)
+            button_click()
 
 
 def toggle_dry_run() -> None:
@@ -6337,22 +6372,25 @@ def import_from_url() -> None:
         return
 
     url = simpledialog.askstring("Import from Web Link", "Enter the web link of the scan results to import:")
-    if not url:
+    if url is None:
         return
 
-    url = url.strip()
+    normalized_url = normalize_and_validate_url(url)
+    if not normalized_url:
+        return
+
     try:
-        update_status(f"Fetching results from {url}...")
-        content_bytes = fetch_url_content(url)
+        update_status(f"Fetching results from {normalized_url}...")
+        content_bytes = fetch_url_content(normalized_url)
         content = content_bytes.decode('utf-8', errors='ignore')
 
-        data_to_import = parse_report_content(content, filename_hint=url)
+        data_to_import = parse_report_content(content, filename_hint=normalized_url)
 
         if not data_to_import:
             messagebox.showwarning("Import Warning", "No valid scan results found at the provided web link.")
             return
 
-        _finalize_import(data_to_import, url)
+        _finalize_import(data_to_import, normalized_url)
 
     except Exception as err:
         messagebox.showerror("Import Failed", f"Could not import results from web link:\n{err}")

--- a/tests/test_import_results_url.py
+++ b/tests/test_import_results_url.py
@@ -41,6 +41,45 @@ def test_import_from_url_success(monkeypatch):
     assert args[0][0]["path"] == "test.py"
     assert args[1] == mock_url
 
+def test_import_from_url_schemeless(monkeypatch):
+    """Test importing scan results from a scheme-less URL successfully after auto-normalization."""
+    input_url = "example.com/results.json"
+    normalized_url = "https://example.com/results.json"
+    data = [
+        {
+            "path": "test.py",
+            "own_conf": "85%",
+            "admin_desc": "Suspicious",
+            "end-user_desc": "Don't run",
+            "gpt_conf": "90%",
+            "snippet": "print('hello')",
+            "line": "10"
+        }
+    ]
+    content = json.dumps(data).encode('utf-8')
+
+    # Mock GUI components
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree)
+    monkeypatch.setattr(gptscan.tkinter.simpledialog, "askstring", lambda *args, **kwargs: input_url)
+
+    # Mock network call
+    mock_fetch = MagicMock(return_value=content)
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    # Mock internal helpers
+    mock_finalize = MagicMock()
+    monkeypatch.setattr(gptscan, "_finalize_import", mock_finalize)
+    monkeypatch.setattr(gptscan, "update_status", MagicMock())
+
+    gptscan.import_from_url()
+
+    mock_fetch.assert_called_once_with(normalized_url)
+    mock_finalize.assert_called_once()
+    args, _ = mock_finalize.call_args
+    assert args[0][0]["path"] == "test.py"
+    assert args[1] == normalized_url
+
 def test_import_from_url_cancelled(monkeypatch):
     """Test that cancelling the URL dialog does nothing."""
     monkeypatch.setattr(gptscan, "tree", MagicMock())
@@ -51,6 +90,24 @@ def test_import_from_url_cancelled(monkeypatch):
 
     gptscan.import_from_url()
     mock_fetch.assert_not_called()
+
+def test_import_from_url_invalid(monkeypatch):
+    """Test that an invalid URL input is rejected immediately without fetching."""
+    monkeypatch.setattr(gptscan, "tree", MagicMock())
+    monkeypatch.setattr(gptscan.tkinter.simpledialog, "askstring", lambda *args, **kwargs: "file:///etc/passwd")
+
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
+
+    mock_fetch = MagicMock()
+    monkeypatch.setattr(gptscan, "fetch_url_content", mock_fetch)
+
+    gptscan.import_from_url()
+    mock_fetch.assert_not_called()
+    mock_msgbox.showerror.assert_called_with(
+        "Unsupported Protocol",
+        "Unsupported protocol 'file://'. Only 'http://' and 'https://' are supported."
+    )
 
 def test_import_from_url_error(monkeypatch):
     """Test error handling when fetching from URL fails."""

--- a/tests/test_url_button_ux.py
+++ b/tests/test_url_button_ux.py
@@ -21,11 +21,47 @@ def mock_gui(monkeypatch):
     gptscan.textbox = mock_textbox
     gptscan.scan_button = MagicMock()
 
-    yield
+    # Mock messagebox to avoid tkinter dialogs in headless environments
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
+
+    yield mock_msgbox
 
     gptscan.root = None
     gptscan.textbox = None
     gptscan.scan_button = None
+
+def test_normalize_and_validate_url_valid_schemes(mock_gui):
+    """Test normalize_and_validate_url preserves valid schemes."""
+    assert gptscan.normalize_and_validate_url("https://example.com") == "https://example.com"
+    assert gptscan.normalize_and_validate_url("http://localhost:8000") == "http://localhost:8000"
+
+def test_normalize_and_validate_url_no_scheme(mock_gui):
+    """Test normalize_and_validate_url prepends https:// to scheme-less addresses."""
+    assert gptscan.normalize_and_validate_url("github.com/user/repo") == "https://github.com/user/repo"
+    assert gptscan.normalize_and_validate_url("localhost") == "https://localhost"
+
+def test_normalize_and_validate_url_invalid_scheme(mock_gui):
+    """Test normalize_and_validate_url rejects invalid schemes."""
+    assert gptscan.normalize_and_validate_url("file:///etc/passwd") is None
+    mock_gui.showerror.assert_called_with(
+        "Unsupported Protocol",
+        "Unsupported protocol 'file://'. Only 'http://' and 'https://' are supported."
+    )
+
+def test_normalize_and_validate_url_completely_invalid(mock_gui):
+    """Test normalize_and_validate_url rejects non-web-address inputs."""
+    assert gptscan.normalize_and_validate_url("invalid_input_without_dots") is None
+    mock_gui.showerror.assert_called_with(
+        "Invalid Web Link",
+        "The entered string 'invalid_input_without_dots' does not appear to be a valid web link (http/https)."
+    )
+
+def test_normalize_and_validate_url_empty(mock_gui):
+    """Test normalize_and_validate_url returns None for empty or whitespace inputs."""
+    assert gptscan.normalize_and_validate_url("") is None
+    assert gptscan.normalize_and_validate_url("   ") is None
+    mock_gui.showerror.assert_not_called()
 
 def test_select_url_click_updates_textbox(mock_gui, monkeypatch):
     """Test that select_url_click prompts for a URL and updates the textbox."""
@@ -52,14 +88,14 @@ def test_select_url_click_cancel(mock_gui, monkeypatch):
         assert gptscan.textbox.get() == "previous_value"
         mock_button_click.assert_not_called()
 
-def test_select_url_click_strips_whitespace(mock_gui, monkeypatch):
-    """Test that select_url_click strips whitespace from the entered URL."""
-    test_url = "  https://example.com/clean.py  "
+def test_select_url_click_strips_and_normalizes(mock_gui, monkeypatch):
+    """Test that select_url_click strips and normalizes entered URLs."""
+    test_url = "  github.com/user/repo  "
     mock_button_click = MagicMock()
     monkeypatch.setattr(gptscan, "button_click", mock_button_click)
 
     with patch("gptscan.simpledialog.askstring", return_value=test_url):
         gptscan.select_url_click()
 
-        assert gptscan.textbox.get() == "https://example.com/clean.py"
+        assert gptscan.textbox.get() == "https://github.com/user/repo"
         mock_button_click.assert_called_once()


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** When entering web links for scanning or importing results, users often paste addresses without the protocol prefix (e.g., pasting `github.com/...` instead of `https://github.com/...`), which leads to scan failures or local file path resolution errors. Additionally, typing an unsupported protocol (e.g. `file://`) can lead to unexpected errors or SSRF vulnerabilities.
* **Solution:** Added a helper function `normalize_and_validate_url` to automatically prepend `https://` to valid web addresses entered without a scheme, reject invalid or non-http/https protocols with a clear warning, and ignore empty entries. This is integrated into `select_url_click` and `import_from_url` dialogs to drastically reduce friction and improve safety.

---
*PR created automatically by Jules for task [17366347331779955357](https://jules.google.com/task/17366347331779955357) started by @RainRat*