### PR TITLE
[FEAT] Add support for importing console triage reports

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -5988,6 +5988,95 @@ def standardize_result_dict(item: Any) -> Dict[str, Any]:
     return res
 
 
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    return ansi_escape.sub('', text)
+
+
+def parse_triage_report(content: str) -> List[Dict[str, Any]]:
+    """Parse a console triage report text and extract findings.
+
+    Args:
+        content: The raw string content of the triage report.
+
+    Returns:
+        A list of standardized result dictionaries.
+    """
+    content = strip_ansi(content)
+    lines = content.splitlines()
+
+    results = []
+    current_item = None
+
+    # We match item start: [1] HIGH RISK - path:line or [1] HIGH RISK - path
+    item_pattern = re.compile(r'^\[\d+\]\s+(?:HIGH|MEDIUM|LOW)\s+RISK\s+-\s+(.+)$')
+
+    for line in lines:
+        match = item_pattern.match(line.strip())
+        if match:
+            # Save previous item if any
+            if current_item:
+                results.append(current_item)
+
+            location = match.group(1).strip()
+
+            # Split location into path and line from the right
+            path = location
+            line_num = "-"
+            if ":" in location:
+                parts = location.rsplit(":", 1)
+                if parts[1].isdigit():
+                    path = parts[0]
+                    line_num = parts[1]
+
+            current_item = {
+                "path": path,
+                "line": line_num,
+                "own_conf": "0%",
+                "gpt_conf": "",
+                "admin_desc": [],
+                "end-user_desc": [],
+                "snippet": []
+            }
+        elif current_item is not None:
+            if "Local:" in line:
+                local_match = re.search(r'Local:\s*(\d+%)', line)
+                if local_match:
+                    current_item["own_conf"] = local_match.group(1)
+                ai_match = re.search(r'AI:\s*(\d+%)', line)
+                if ai_match:
+                    current_item["gpt_conf"] = ai_match.group(1)
+            elif "Admin:" in line:
+                parts = line.split("Admin:", 1)
+                if len(parts) > 1:
+                    current_item["admin_desc"].append(parts[1].strip())
+            elif "User:" in line:
+                parts = line.split("User:", 1)
+                if len(parts) > 1:
+                    current_item["end-user_desc"].append(parts[1].strip())
+            elif line.startswith("    >"):
+                parts = line.split('>', 1)
+                if len(parts) > 1:
+                    sl_raw = parts[1]
+                    if sl_raw.startswith(' '):
+                        sl_raw = sl_raw[1:]
+                    current_item["snippet"].append(sl_raw)
+
+    if current_item:
+        results.append(current_item)
+
+    # Post-process lists to strings and standardize
+    final_results = []
+    for item in results:
+        item["admin_desc"] = "\n".join(item["admin_desc"]).strip()
+        item["end-user_desc"] = "\n".join(item["end-user_desc"]).strip()
+        item["snippet"] = "\n".join(item["snippet"]).rstrip()
+        final_results.append(standardize_result_dict(item))
+
+    return final_results
+
+
 def parse_report_content(content: str, filename_hint: Optional[str] = None) -> List[Dict[str, Any]]:
     """Parse report content in JSON, SARIF, or CSV format.
 
@@ -6006,7 +6095,7 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
     if filename_hint:
         ext = os.path.splitext(filename_hint)[1].lower()
 
-    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml'):
+    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt', '.log'):
         raise ValueError(f"Unsupported file extension: {ext}")
 
     data_to_import = []
@@ -6139,6 +6228,9 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
 
                         data_to_import.append(item)
                 break
+    elif ext in ('.txt', '.log') or '--- GPT SCAN - CONSOLE TRIAGE REPORT' in content:
+        # Triage Report format
+        data_to_import = parse_triage_report(content)
     else:
         # Last resort: try JSON parsing anyway
         try:
@@ -6271,12 +6363,13 @@ def import_results(event: Optional[tk.Event] = None) -> None:
 
     file_path = filedialog.askopenfilename(
         filetypes=[
-            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml"),
+            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml;*.txt;*.log"),
             ("JSON files", "*.json;*.jsonl;*.ndjson"),
             ("SARIF files", "*.sarif"),
             ("CSV files", "*.csv"),
             ("Markdown files", "*.md;*.markdown"),
             ("HTML files", "*.html;*.htm;*.xhtml"),
+            ("Triage reports", "*.txt;*.log"),
             ("All files", "*.*")
         ],
         title="Import Scan Results",

--- a/tests/test_import_html.py
+++ b/tests/test_import_html.py
@@ -129,4 +129,4 @@ def test_parse_html_report_multiline_notes():
 def test_parse_html_unsupported_extension():
     """Test that unsupported extensions raise ValueError if hinted."""
     with pytest.raises(ValueError, match="Unsupported file extension"):
-        parse_report_content("<html></html>", filename_hint="report.txt")
+        parse_report_content("<html></html>", filename_hint="report.xyz")

--- a/tests/test_import_logic.py
+++ b/tests/test_import_logic.py
@@ -163,7 +163,7 @@ def test_import_results_invalid_json(monkeypatch, tmp_path):
 
 def test_import_results_unsupported_ext(monkeypatch, tmp_path):
     """Test error handling for unsupported file extensions."""
-    txt_file = tmp_path / "test.txt"
+    txt_file = tmp_path / "test.xyz"
     txt_file.write_text("some text")
 
     monkeypatch.setattr(gptscan.tkinter.filedialog, "askopenfilename", lambda **kwargs: str(txt_file))
@@ -174,7 +174,7 @@ def test_import_results_unsupported_ext(monkeypatch, tmp_path):
 
     gptscan.import_results()
 
-    mock_messagebox.showerror.assert_called_with("Import Failed", "Could not load results:\nUnsupported file extension: .txt")
+    mock_messagebox.showerror.assert_called_with("Import Failed", "Could not load results:\nUnsupported file extension: .xyz")
 
 def test_import_results_single_object_json(tmp_path):
     """Test importing a pretty-printed single JSON object result."""

--- a/tests/test_import_triage.py
+++ b/tests/test_import_triage.py
@@ -1,0 +1,103 @@
+import pytest
+from gptscan import parse_triage_report, parse_report_content, strip_ansi
+
+def test_strip_ansi():
+    text_with_ansi = "\033[1;91mHIGH RISK\033[0m"
+    assert strip_ansi(text_with_ansi) == "HIGH RISK"
+
+    plain_text = "Just some standard text."
+    assert strip_ansi(plain_text) == "Just some standard text."
+
+def test_parse_plain_triage_report():
+    report_content = """
+--- GPT SCAN - CONSOLE TRIAGE REPORT (2 findings) ---
+
+[1] HIGH RISK - test.py:123
+    Local: 95%  AI: 85%  VT: https://virustotal.com/
+
+    Admin: Highly suspicious eval instruction.
+
+    User: This file evaluates untrusted input.
+
+    > eval(user_input)
+
+[2] MEDIUM RISK - script.sh
+    Local: 60%
+
+    Admin: Command execution found.
+
+    > os.system("ls")
+"""
+    results = parse_triage_report(report_content)
+    assert len(results) == 2
+
+    # Check first finding
+    f1 = results[0]
+    assert f1["path"] == "test.py"
+    assert f1["line"] == "123"
+    assert f1["own_conf"] == "95%"
+    assert f1["gpt_conf"] == "85%"
+    assert f1["admin_desc"] == "Highly suspicious eval instruction."
+    assert f1["end-user_desc"] == "This file evaluates untrusted input."
+    assert f1["snippet"] == "eval(user_input)"
+
+    # Check second finding
+    f2 = results[1]
+    assert f2["path"] == "script.sh"
+    assert f2["line"] == "-"
+    assert f2["own_conf"] == "60%"
+    assert f2["gpt_conf"] == ""
+    assert f2["admin_desc"] == "Command execution found."
+    assert f2["end-user_desc"] == ""
+    assert f2["snippet"] == 'os.system("ls")'
+
+
+def test_parse_colorized_triage_report():
+    # Use ANSI escape sequences
+    report_content = """
+\033[1m--- GPT SCAN - CONSOLE TRIAGE REPORT (1 finding) ---\033[0m
+
+\033[0;90m[1]\033[0m \033[1;91mHIGH RISK\033[0m - \033[1mtest.py:10\033[0m
+    \033[0;90mLocal:\033[0m \033[1;91m90%\033[0m  \033[0;90mAI:\033[0m \033[1;91m85%\033[0m
+
+    \033[0;90mAdmin:\033[0m Line 1 of admin
+    \033[0;90mAdmin:\033[0m Line 2 of admin
+
+    \033[0;90mUser:\033[0m Line 1 of user
+
+    \033[0;90m>\033[0m   preserved_spaces(x)
+"""
+    results = parse_triage_report(report_content)
+    assert len(results) == 1
+
+    f = results[0]
+    assert f["path"] == "test.py"
+    assert f["line"] == "10"
+    assert f["own_conf"] == "90%"
+    assert f["gpt_conf"] == "85%"
+    assert f["admin_desc"] == "Line 1 of admin\nLine 2 of admin"
+    assert f["end-user_desc"] == "Line 1 of user"
+    assert f["snippet"] == "  preserved_spaces(x)"
+
+
+def test_parse_report_content_integration():
+    # Test text / log auto-detection
+    report_content = """--- GPT SCAN - CONSOLE TRIAGE REPORT (1 finding) ---
+[1] LOW RISK - safe.py
+    Local: 10%
+
+    > print("Hello")
+"""
+
+    # 1. Via filename hint .txt
+    results_txt = parse_report_content(report_content, filename_hint="my_report.txt")
+    assert len(results_txt) == 1
+    assert results_txt[0]["path"] == "safe.py"
+
+    # 2. Via filename hint .log
+    results_log = parse_report_content(report_content, filename_hint="my_report.log")
+    assert len(results_log) == 1
+
+    # 3. Via auto-detection (no hint, but header present)
+    results_auto = parse_report_content(report_content)
+    assert len(results_auto) == 1


### PR DESCRIPTION
### Technical description:
- **What**: Added `parse_triage_report` and `strip_ansi` to `gptscan.py` to enable importing and parsing of console triage reports in `.txt` or `.log` formats (or pasted from the clipboard).
- **Why**: Since the codebase already generates and copies Console Triage Reports to the clipboard / console, adding the ability to import/parse them back creates a beautifully symmetric user experience.
- **Verification**: Created a comprehensive test file `tests/test_import_triage.py` verifying full parser functionality (ANSI stripping, multi-line notes, snippet extraction, etc.) and updated dummy `.txt` tests to `.xyz` since `.txt` is now a fully supported format. Full suite of 973 tests passes cleanly.

---
*PR created automatically by Jules for task [18265519456970393832](https://jules.google.com/task/18265519456970393832) started by @RainRat*