### PR TITLE
Remove redundant list conversion in get_env_file_paths

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -1455,7 +1455,7 @@ def get_env_file_paths() -> List[str]:
             except Exception:
                 pass
 
-    return sorted(list(set(paths)))
+    return sorted(set(paths))
 
 
 def get_running_process_commands() -> List[Tuple[str, bytes]]:


### PR DESCRIPTION
This pull request removes a redundant `list()` constructor call from the `get_env_file_paths()` function in `gptscan.py`. 

The original code called `sorted(list(set(paths)))`. Since the `sorted()` function takes any iterable and returns a new list, converting the set to a list prior to sorting is completely redundant and creates an unnecessary intermediate list object. 

By refactoring this to `sorted(set(paths))`, we improve code idiomaticity, readability, and execution efficiency. All unit tests have been run and pass successfully.

---
*PR created automatically by Jules for task [7439461236556020920](https://jules.google.com/task/7439461236556020920) started by @RainRat*