### PR TITLE
refactor: extract duplicated input focus checking in view_details

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -7254,15 +7254,18 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
 
         load_display_code(path, line, snippet, silent_fallback=True)
 
-    def on_prev():
+    def is_input_focused() -> bool:
         focused = details_win.focus_get()
         if focused:
             try:
-                widget_class = focused.winfo_class()
-                if widget_class in ("Text", "Entry", "TEntry"):
-                    return
+                return focused.winfo_class() in ("Text", "Entry", "TEntry")
             except Exception:
                 pass
+        return False
+
+    def on_prev():
+        if is_input_focused():
+            return
         all_visible = tree.get_children()
         try:
             idx = all_visible.index(current_item_id)
@@ -7275,14 +7278,8 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
             pass
 
     def on_next():
-        focused = details_win.focus_get()
-        if focused:
-            try:
-                widget_class = focused.winfo_class()
-                if widget_class in ("Text", "Entry", "TEntry"):
-                    return
-            except Exception:
-                pass
+        if is_input_focused():
+            return
         all_visible = tree.get_children()
         try:
             idx = all_visible.index(current_item_id)


### PR DESCRIPTION
Eliminated duplication of keyboard navigation focus-checking logic in `view_details` by introducing a local helper function `is_input_focused()`. Both `on_prev` and `on_next` now call this helper, making the code much cleaner and self-documenting.

---
*PR created automatically by Jules for task [11844861448522854018](https://jules.google.com/task/11844861448522854018) started by @RainRat*