### PR TITLE
[TEST] Increase coverage for exception handling in env file discovery

### DIFF
--- a/tests/test_env_files.py
+++ b/tests/test_env_files.py
@@ -54,3 +54,20 @@ def test_is_container_env():
     assert Config.is_container(".env.local") is True
     assert Config.is_container(".env.development.local") is True
     assert Config.is_container("env.txt") is False
+
+def test_get_env_file_paths_handles_exception_during_glob(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    original_glob = Path.glob
+
+    def mock_glob(self, pattern):
+        if str(self) == str(home):
+            raise OSError("Access denied")
+        return original_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", mock_glob)
+
+    paths = get_env_file_paths()
+    assert isinstance(paths, list)


### PR DESCRIPTION
### **PR Title:** [TEST] Increase coverage for exception handling in env file discovery

**Description:**
* **Type:** New Coverage
* **What:** Add `test_get_env_file_paths_handles_exception_during_glob` to `tests/test_env_files.py` to cover exception handling inside `get_env_file_paths()`.
* **Why:** To improve robustness and address untested exception branches (lines 1455-1456 in `gptscan.py`) when directory globbing raises OS/permission errors.

---
*PR created automatically by Jules for task [14258078957009609133](https://jules.google.com/task/14258078957009609133) started by @RainRat*