### PR TITLE
[FEAT] Export Scan Results to Plain Text and Log Triage Reports

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6669,6 +6669,8 @@ def export_results(event: Optional[tk.Event] = None) -> None:
             ("HTML files", "*.html"),
             ("JSON files", "*.json"),
             ("SARIF files", "*.sarif"),
+            ("Plain Text Triage Report", "*.txt"),
+            ("Log Triage Report", "*.log"),
             ("All files", "*.*")
         ],
         title="Export Scan Results",
@@ -6694,6 +6696,9 @@ def export_results(event: Optional[tk.Event] = None) -> None:
         elif ext == '.md':
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(generate_markdown(results))
+        elif ext in ('.txt', '.log'):
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(generate_console_report(results, use_color=False))
         else: # Default to CSV
             with open(file_path, "w", newline="", encoding="utf-8") as csv_file:
                 writer = csv.writer(csv_file)
@@ -9014,6 +9019,8 @@ def main():
                 output_format = 'markdown'
             elif ext == '.csv':
                 output_format = 'csv'
+            elif ext in ('.txt', '.log'):
+                output_format = 'report'
 
         final_excludes = list(set((Config.ignore_patterns or []) + (args.exclude or [])))
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -67,3 +67,52 @@ def test_export_results_handles_error(monkeypatch):
     args, _ = mock_msgbox.showerror.call_args
     assert args[0] == "Export Failed"
     assert "Disk full" in args[1]
+
+
+def test_export_results_triage_report_txt(monkeypatch, tmp_path):
+    """Verify that treeview contents can be exported to a plain text triage report."""
+    file_path = tmp_path / "export_report.txt"
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'asksaveasfilename', lambda **k: str(file_path))
+
+    mock_tree = MagicMock()
+    # Treeview columns for Zip
+    cols = ("path", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet", "line")
+    mock_tree.__getitem__.return_value = cols
+    mock_tree.get_children.return_value = ("item1",)
+
+    # Mock _get_item_raw_values or tree.item
+    def get_item(iid, option=None):
+        vals = ("my_script.py", "90%", "Suspicious eval instruction", "Evaluates untrusted input", "85%", "eval(input())", "10")
+        if option == "values":
+            return vals
+        return {"values": vals}
+    mock_tree.item.side_effect = get_item
+
+    monkeypatch.setattr(gptscan, "tree", mock_tree, raising=False)
+
+    # Mock messagebox so that showinfo doesn't pop up a real GUI window
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
+
+    gptscan.export_results()
+
+    assert file_path.exists()
+    content = file_path.read_text(encoding="utf-8")
+    assert "--- GPT SCAN - CONSOLE TRIAGE REPORT" in content
+    assert "[1] HIGH RISK - my_script.py:10" in content
+    assert "Local: 90%" in content
+    assert "AI: 85%" in content
+    assert "Admin: Suspicious eval instruction" in content
+    assert "User: Evaluates untrusted input" in content
+    assert "> eval(input())" in content
+
+    # Test round-trip: import back using parse_triage_report or parse_report_content!
+    imported = gptscan.parse_triage_report(content)
+    assert len(imported) == 1
+    assert imported[0]["path"] == "my_script.py"
+    assert imported[0]["line"] == "10"
+    assert imported[0]["own_conf"] == "90%"
+    assert imported[0]["gpt_conf"] == "85%"
+    assert imported[0]["admin_desc"] == "Suspicious eval instruction"
+    assert imported[0]["end-user_desc"] == "Evaluates untrusted input"
+    assert imported[0]["snippet"] == "eval(input())"

--- a/tests/test_output_flag.py
+++ b/tests/test_output_flag.py
@@ -73,3 +73,21 @@ def test_inference_logic_csv(monkeypatch, tmp_path):
     gptscan.main()
 
     assert recorded_args['output_format'] == 'csv'
+
+
+def test_inference_logic_triage_txt(monkeypatch, tmp_path):
+    import gptscan
+    import sys
+
+    output_file = tmp_path / "report.txt"
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--cli", "-o", str(output_file), "gptscan.py", "--dry-run"])
+
+    recorded_args = {}
+    def mock_run_cli(*args, **kwargs):
+        recorded_args['output_format'] = kwargs.get('output_format')
+        return 0
+
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+    gptscan.main()
+
+    assert recorded_args['output_format'] == 'report'


### PR DESCRIPTION
This pull request implements the export and CLI auto-inference functionality for Plain Text and Log Console Triage Reports, establishing full symmetry with the existing importing capabilities.

---
*PR created automatically by Jules for task [5935675155055132141](https://jules.google.com/task/5935675155055132141) started by @RainRat*