### PR TITLE
[TEST] Add unified diff content detection coverage for is_container

### DIFF
--- a/tests/test_is_container.py
+++ b/tests/test_is_container.py
@@ -65,3 +65,8 @@ def test_is_container_negative_cases():
 def test_is_container_path_object():
     assert Config.is_container(Path("package.json")) is True
     assert Config.is_container(Path("test.zip")) is True
+
+def test_is_container_unified_diff_by_content():
+    assert Config.is_container("unknown_file", content=b"--- a/file.py\n+++ b/file.py") is True
+    assert Config.is_container("unknown_file", content=b"Index: file.py\n==========================") is True
+    assert Config.is_container("unknown_file", content=b"diff --git a/file.py b/file.py") is True


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Adds test coverage for Unified Diff content patterns (such as b'--- ', b'Index: ', and b'diff --git ') in `Config.is_container` when analyzing content.
* **Why:** Fixes a coverage gap where line 368 of `gptscan.py` lacked tests. Adheres to code hygiene, formatting, and isolation principles.

---
*PR created automatically by Jules for task [15713461266862922827](https://jules.google.com/task/15713461266862922827) started by @RainRat*