### PR TITLE
[UI/UX] Add dedicated snippet toolbar and direct Copy Code button in Details view

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6839,6 +6839,9 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     snippet_frame = ttk.LabelFrame(paned_window, text="Code Snippet", padding=5)
     paned_window.add(snippet_frame, weight=1)
 
+    snippet_toolbar = ttk.Frame(snippet_frame)
+    snippet_toolbar.pack(fill=tk.X, pady=(0, 5))
+
     snippet_text = scrolledtext.ScrolledText(snippet_frame, height=8, font='TkFixedFont', wrap=tk.NONE)
     snippet_text.pack(fill=tk.BOTH, expand=True)
     snippet_text.tag_configure("highlight", background="yellow", foreground="black")
@@ -7138,12 +7141,14 @@ def view_details(event: Optional[tk.Event] = None, item_id: Optional[str] = None
     copy_menu.add_command(label="Copy Code", command=copy_code, accelerator="Ctrl+S")
     copy_menu_btn["menu"] = copy_menu
 
-    ttk.Separator(btn_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, padx=5, fill=tk.Y)
-
-    # Group: View
-    source_toggle_btn = ttk.Button(btn_frame, text="Show Full Source", width=18, command=toggle_source)
-    source_toggle_btn.pack(side=tk.LEFT, padx=2, ipady=5)
+    # Group: Code View Actions (Toolbar)
+    source_toggle_btn = ttk.Button(snippet_toolbar, text="Show Full Source", width=18, command=toggle_source)
+    source_toggle_btn.pack(side=tk.RIGHT, padx=2)
     bind_hover_message(source_toggle_btn, "Toggle between the suspicious snippet and the full file content. (Ctrl+U)", label=status_bar)
+
+    copy_code_btn = ttk.Button(snippet_toolbar, text="Copy Code", command=copy_code)
+    copy_code_btn.pack(side=tk.RIGHT, padx=2)
+    bind_hover_message(copy_code_btn, "Copy the currently displayed code to the clipboard. (Ctrl+S)", label=status_bar)
 
     # Group: System
     close_btn = ttk.Button(btn_frame, text="Close", command=details_win.destroy)

--- a/tests/test_view_details.py
+++ b/tests/test_view_details.py
@@ -436,3 +436,23 @@ def test_view_details_rescan(mock_view_details_env, monkeypatch):
     # Verify button states were toggled
     rescan_btn_mock.config.assert_any_call(state='disabled', text='Rescanning...')
     rescan_btn_mock.config.assert_any_call(state='normal', text='Rescan')
+
+
+def test_view_details_copy_code_button(mock_view_details_env):
+    captured, mock_msgbox, mock_tree, mock_toplevel = mock_view_details_env
+    setup_details(mock_view_details_env, "item1", "test.py", snippet="print('hello, world')")
+    from gptscan import root as mock_root
+
+    # Verify the "Copy Code" button is in captured buttons
+    assert "btn_Copy Code" in captured
+    copy_code_btn, copy_code_cmd = captured["btn_Copy Code"]
+
+    # Trigger click command
+    copy_code_cmd()
+
+    mock_root.clipboard_clear.assert_called()
+    mock_root.clipboard_append.assert_called_with("print('hello, world')")
+
+    # Verify local status feedback
+    status_bar = captured['labels'][0]
+    assert status_bar.config_data.get('text') == "Code copied to clipboard."


### PR DESCRIPTION
Added a dedicated horizontal toolbar `snippet_toolbar` at the top of the Code Snippet label frame within the Result Details modal.
Relocated the 'Show Full Source' toggle button to this toolbar and added a direct, prominent 'Copy Code' button. This drastically reduces clicks/friction for security analysts who copy code snippets for verification, and improves visual hierarchy by aligning the view/copy controls with the text frame they act upon. Included a new unit test for the Copy Code button.

---
*PR created automatically by Jules for task [15335326224328057002](https://jules.google.com/task/15335326224328057002) started by @RainRat*