### PR TITLE
[DOCS] Add Python 3.12 support and installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Scan your files for dangerous code with AI. This tool uses a quick scan model to
 ## Installation
 
 ### Prerequisites
-*   **Python:** Install **Python 3.9, 3.10, or 3.11**. Newer versions like 3.12 are not yet supported.
+*   **Python:** Install **Python 3.9, 3.10, 3.11, or 3.12**.
 *   **Data files:** The repository already includes the `scripts.h5` model and `task.txt` instruction files. Keep these in the project folder.
 
 ### Setup
@@ -41,9 +41,17 @@ Scan your files for dangerous code with AI. This tool uses a quick scan model to
     cd gpt-virus-scanner
     ```
 2.  **Install mandatory packages:**
-    ```bash
-    python3 -m pip install "tensorflow<2.16" openai numpy
-    ```
+
+    Choose the command that matches your Python version:
+
+    *   **For Python 3.9 to 3.11:**
+        ```bash
+        python3 -m pip install "tensorflow<2.16" openai numpy
+        ```
+    *   **For Python 3.12:**
+        ```bash
+        python3 -m pip install tensorflow openai numpy
+        ```
 3.  **Install optional packages (if needed):**
     *   **python3-tk:** Install this if you use Linux and want the window (GUI) interface.
     *   **PyYAML:** Install this if you want to train your own models.

--- a/train.md
+++ b/train.md
@@ -13,11 +13,17 @@ Train the local model (the detection model) for the GPT Virus Scanner. It learns
 
 ## Installation
 
-1.  **Install Python:** You need **Python 3.9, 3.10, or 3.11**. Newer versions (like 3.12) are not supported yet because of model compatibility.
-2.  **Install requirements:** Open your terminal and run:
-    ```bash
-    python3 -m pip install "tensorflow<2.16" numpy pyyaml
-    ```
+1.  **Install Python:** Install **Python 3.9, 3.10, 3.11, or 3.12**.
+2.  **Install requirements:** Open your terminal and choose the command that matches your Python version:
+
+    *   **For Python 3.9 to 3.11:**
+        ```bash
+        python3 -m pip install "tensorflow<2.16" numpy pyyaml
+        ```
+    *   **For Python 3.12:**
+        ```bash
+        python3 -m pip install tensorflow numpy pyyaml
+        ```
 
 ## Configuration
 


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated prerequisites and package installation steps in `readme.md` and `train.md`.
* **Why:** Clarified the installation instructions so users with Python 3.12 can successfully install the required packages (specifically standard `tensorflow` instead of pinning to `<2.16` which lacks Python 3.12 support).

---
*PR created automatically by Jules for task [2127916039723219329](https://jules.google.com/task/2127916039723219329) started by @RainRat*