### PR TITLE
[UI/UX] Enable bulk additions in exclusions and extensions GUI dialogs

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3886,13 +3886,18 @@ def manage_exclusions() -> None:
     btn_frame.pack(fill=tk.X)
 
     def add_pattern():
-        pattern = simpledialog.askstring("Add Pattern", "Enter a file or folder pattern to exclude (e.g., *.log, temp/):", parent=manage_win)
-        if pattern:
-            pattern = pattern.strip()
-            if pattern and pattern not in Config.ignore_patterns:
+        pattern_str = simpledialog.askstring("Add Pattern", "Enter one or more file/folder patterns to exclude (separated by commas, e.g., *.log, temp/):", parent=manage_win)
+        if pattern_str:
+            patterns = [p.strip() for p in pattern_str.split(',') if p.strip()]
+            if not patterns:
+                return
+            new_patterns = [p for p in patterns if p not in Config.ignore_patterns]
+            if new_patterns:
                 try:
-                    add_to_ignore_file(pattern)
-                    Config.ignore_patterns.append(pattern)
+                    for p in new_patterns:
+                        add_to_ignore_file(p)
+                        if p not in Config.ignore_patterns:
+                            Config.ignore_patterns.append(p)
                     refresh_list()
                     _apply_filter()
                 except Exception as e:
@@ -3971,14 +3976,22 @@ def manage_extensions() -> None:
     btn_frame.pack(fill=tk.X)
 
     def add_extension():
-        ext = simpledialog.askstring("Add Extension", "Enter a file extension (e.g., .py, .js):", parent=manage_win)
-        if ext:
-            ext = ext.strip().lower()
-            if not ext.startswith('.'):
-                ext = f".{ext}"
-            if ext and ext not in Config.extensions_set:
+        ext_str = simpledialog.askstring("Add Extension", "Enter one or more file extensions (separated by commas or whitespace, e.g., .py, .js):", parent=manage_win)
+        if ext_str:
+            import re
+            parts = re.split(r'[\s,]+', ext_str)
+            added_any = False
+            for p in parts:
+                p = p.strip().lower()
+                if not p:
+                    continue
+                if not p.startswith('.'):
+                    p = f".{p}"
+                if p not in Config.extensions_set:
+                    Config.extensions_set.add(p)
+                    added_any = True
+            if added_any:
                 try:
-                    Config.extensions_set.add(ext)
                     Config.save_extensions()
                     refresh_list()
                 except Exception as e:

--- a/tests/test_extension_management.py
+++ b/tests/test_extension_management.py
@@ -117,6 +117,25 @@ def test_manage_extensions_add(mock_gui_env, monkeypatch):
     assert ".rb" in captured['listbox'].items
     Config.save_extensions.assert_called()
 
+def test_manage_extensions_add_bulk(mock_gui_env, monkeypatch):
+    captured, mock_sd, mock_mb, mock_top = mock_gui_env
+    Config.extensions_set = {".py"}
+    mock_sd.askstring.return_value = "rb,   .go,  js"
+
+    monkeypatch.setattr(Config, "save_extensions", MagicMock())
+
+    manage_extensions()
+    add_btn, add_cmd = captured['buttons']['Add...']
+    add_cmd()
+
+    assert ".rb" in Config.extensions_set
+    assert ".go" in Config.extensions_set
+    assert ".js" in Config.extensions_set
+    assert ".rb" in captured['listbox'].items
+    assert ".go" in captured['listbox'].items
+    assert ".js" in captured['listbox'].items
+    Config.save_extensions.assert_called()
+
 def test_manage_extensions_remove(mock_gui_env, monkeypatch):
     captured, mock_sd, mock_mb, mock_top = mock_gui_env
     Config.extensions_set = {".py", ".js"}

--- a/tests/test_manage_exclusions_ui.py
+++ b/tests/test_manage_exclusions_ui.py
@@ -90,6 +90,22 @@ def test_manage_exclusions_add_pattern(mock_gui_env):
     assert "*.log" in captured['listbox'].items
     assert gptscan._apply_filter.called
 
+def test_manage_exclusions_add_pattern_bulk(mock_gui_env):
+    captured, mock_sd, mock_fd, mock_mb, mock_top = mock_gui_env
+    mock_sd.askstring.return_value = "*.log,  temp/,   build/ "
+
+    manage_exclusions()
+    add_btn, add_cmd = captured['buttons']['Add Pattern...']
+    add_cmd()
+
+    assert "*.log" in Config.ignore_patterns
+    assert "temp/" in Config.ignore_patterns
+    assert "build/" in Config.ignore_patterns
+    assert "*.log" in captured['listbox'].items
+    assert "temp/" in captured['listbox'].items
+    assert "build/" in captured['listbox'].items
+    assert gptscan._apply_filter.called
+
 def test_manage_exclusions_add_folder(mock_gui_env, monkeypatch):
     captured, mock_sd, mock_fd, mock_mb, mock_top = mock_gui_env
     # Mock os.path.relpath to return a predictable relative path


### PR DESCRIPTION
Implements a highly intuitive friction reduction improvement in the 'Manage Exclusions' and 'Manage Extensions' GUI dialog inputs. Users can now input multiple exclusion patterns or file extensions in a single dialog prompt by separating them with commas (or commas/whitespace for extensions). Normalization, deduplication, and file updates are performed cleanly in bulk.

---
*PR created automatically by Jules for task [13549364630772251723](https://jules.google.com/task/13549364630772251723) started by @RainRat*