### PR TITLE
[FEAT] Symmetric Console Triage Report Export Support (.txt/.log)

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6651,7 +6651,7 @@ def _get_tree_results_as_dicts(item_ids: Iterable[str]) -> List[Dict[str, Any]]:
 def export_results(event: Optional[tk.Event] = None) -> None:
     """Save the current Treeview contents to a file chosen by the user.
 
-    Supports CSV, HTML, JSON, and SARIF formats.
+    Supports CSV, HTML, JSON, SARIF, and Console Triage Report formats.
 
     Returns
     -------
@@ -6669,6 +6669,7 @@ def export_results(event: Optional[tk.Event] = None) -> None:
             ("HTML files", "*.html"),
             ("JSON files", "*.json"),
             ("SARIF files", "*.sarif"),
+            ("Triage reports", "*.txt;*.log"),
             ("All files", "*.*")
         ],
         title="Export Scan Results",
@@ -6694,6 +6695,9 @@ def export_results(event: Optional[tk.Event] = None) -> None:
         elif ext == '.md':
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(generate_markdown(results))
+        elif ext in ('.txt', '.log'):
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(generate_console_report(results, use_color=False))
         else: # Default to CSV
             with open(file_path, "w", newline="", encoding="utf-8") as csv_file:
                 writer = csv.writer(csv_file)
@@ -9014,6 +9018,8 @@ def main():
                 output_format = 'markdown'
             elif ext == '.csv':
                 output_format = 'csv'
+            elif ext in ('.txt', '.log'):
+                output_format = 'report'
 
         final_excludes = list(set((Config.ignore_patterns or []) + (args.exclude or [])))
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -67,3 +67,40 @@ def test_export_results_handles_error(monkeypatch):
     args, _ = mock_msgbox.showerror.call_args
     assert args[0] == "Export Failed"
     assert "Disk full" in args[1]
+
+
+def test_export_results_triage_report(monkeypatch, tmp_path):
+    """Verify that results are correctly saved as a Console Triage Report when exporting to .txt or .log."""
+    file_path = tmp_path / "export.txt"
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'asksaveasfilename', lambda **k: str(file_path))
+
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree, raising=False)
+
+    sample_results = [
+        {
+            "path": "test.py",
+            "line": "123",
+            "own_conf": "95%",
+            "gpt_conf": "85%",
+            "admin_desc": "Highly suspicious eval instruction.",
+            "end-user_desc": "This file evaluates untrusted input.",
+            "snippet": "eval(user_input)"
+        }
+    ]
+    monkeypatch.setattr(gptscan, "_get_tree_results_as_dicts", lambda item_ids: sample_results)
+
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
+
+    gptscan.export_results()
+
+    assert file_path.exists()
+    content = file_path.read_text(encoding="utf-8")
+    assert "--- GPT SCAN - CONSOLE TRIAGE REPORT" in content
+    assert "test.py:123" in content
+    assert "Local: 95%" in content
+    assert "AI: 85%" in content
+    assert "Admin: Highly suspicious eval instruction." in content
+    assert "User: This file evaluates untrusted input." in content
+    assert "> eval(user_input)" in content

--- a/tests/test_output_flag.py
+++ b/tests/test_output_flag.py
@@ -73,3 +73,39 @@ def test_inference_logic_csv(monkeypatch, tmp_path):
     gptscan.main()
 
     assert recorded_args['output_format'] == 'csv'
+
+
+def test_inference_logic_txt(monkeypatch, tmp_path):
+    import gptscan
+    import sys
+
+    output_file = tmp_path / "results.txt"
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--cli", "-o", str(output_file), "gptscan.py", "--dry-run"])
+
+    recorded_args = {}
+    def mock_run_cli(*args, **kwargs):
+        recorded_args['output_format'] = kwargs.get('output_format')
+        return 0
+
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+    gptscan.main()
+
+    assert recorded_args['output_format'] == 'report'
+
+
+def test_inference_logic_log(monkeypatch, tmp_path):
+    import gptscan
+    import sys
+
+    output_file = tmp_path / "results.log"
+    monkeypatch.setattr(sys, "argv", ["gptscan.py", "--cli", "-o", str(output_file), "gptscan.py", "--dry-run"])
+
+    recorded_args = {}
+    def mock_run_cli(*args, **kwargs):
+        recorded_args['output_format'] = kwargs.get('output_format')
+        return 0
+
+    monkeypatch.setattr(gptscan, "run_cli", mock_run_cli)
+    gptscan.main()
+
+    assert recorded_args['output_format'] == 'report'


### PR DESCRIPTION
This PR implements fully symmetric Console Triage Report exporting:
1. Adds `("Triage reports", "*.txt;*.log")` to GUI's `export_results` file dialog.
2. Formats and saves results using the existing `generate_console_report(results, use_color=False)` when exporting to `.txt` or `.log` files in the GUI.
3. Automatically infers `'report'` format when saving scanning results via CLI `-o` / `--output` to `.txt` or `.log` files.
4. Adds new pytest unit tests to `tests/test_export.py` and `tests/test_output_flag.py` to ensure complete coverage of both GUI and CLI enhancements.

---
*PR created automatically by Jules for task [5445746989091605330](https://jules.google.com/task/5445746989091605330) started by @RainRat*