### PR TITLE
Refactor scan_network_config_click to use _generic_scan_click helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3358,15 +3358,7 @@ def scan_ssh_config_click():
 
 def scan_network_config_click():
     """Scan all common network configuration files (hosts, resolv.conf, etc.)."""
-    try:
-        paths = get_network_config_paths()
-        if paths:
-            _set_scan_target(paths)
-            button_click()
-        else:
-            messagebox.showinfo("Network Configuration", "No network configuration files were found to scan.")
-    except Exception as e:
-        messagebox.showwarning("Network Configuration Error", f"Could not scan network configuration: {e}")
+    _generic_scan_click(get_network_config_paths, "Network Configuration", "No network configuration files were found to scan.", "Network Configuration Error")
 
 
 def scan_python_packages_click():

--- a/tests/test_generic_scan_click.py
+++ b/tests/test_generic_scan_click.py
@@ -96,3 +96,17 @@ def test_refactored_scan_env_vars_click(mocker):
         "Environment Variables Error",
         is_snippets=True
     )
+
+def test_refactored_scan_network_config_click(mocker):
+    """Verify that scan_network_config_click correctly calls the _generic_scan_click helper."""
+    mock_get_paths = mocker.patch("gptscan.get_network_config_paths", return_value=["/etc/hosts"])
+    mock_generic = mocker.patch("gptscan._generic_scan_click")
+
+    gptscan.scan_network_config_click()
+
+    mock_generic.assert_called_once_with(
+        gptscan.get_network_config_paths,
+        "Network Configuration",
+        "No network configuration files were found to scan.",
+        "Network Configuration Error"
+    )


### PR DESCRIPTION
This pull request refactors `scan_network_config_click` in `gptscan.py` to use the unified `_generic_scan_click` helper, successfully reducing duplicated boilerplate code. It also includes comprehensive unit tests in `tests/test_generic_scan_click.py` to assert that the refactored function integrates correctly.

---
*PR created automatically by Jules for task [9081259849851673063](https://jules.google.com/task/9081259849851673063) started by @RainRat*