### PR TITLE
[UI/UX] Suppress optional API key and task warnings for non-GPT CLI scans

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -497,10 +497,24 @@ class Config:
             # Fallback to environment variables if apikey.txt is missing or empty
             cls.apikey = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY") or ""
 
-        if not cls.apikey:
-            print(cls.apikey_missing_message, file=sys.stderr)
-        if not cls.taskdesc:
-            print(cls.task_missing_message, file=sys.stderr)
+        is_help_or_version = any(arg in sys.argv for arg in ['-h', '--help', '-v', '--version'])
+        is_cli_without_gpt = ('--cli' in sys.argv or any(arg in sys.argv for arg in [
+            '--audit', '--git-changes', '--git-diff', '--git-hooks', '--git-config',
+            '--git-stash', '--git-conflicts', '--git-history', '--git-reflog',
+            '--shell-profiles', '--shell-history', '--system-path', '--running-processes',
+            '--scheduled-tasks', '--startup-items', '--system-services', '--python-packages',
+            '--browser-bookmarks', '--nodejs-packages', '--browser-extensions', '--editor-extensions',
+            '--ssh-config', '--network-config', '--env-vars', '--env-files', '--ruby-gems',
+            '--php-packages', '--rust-packages', '--go-packages', '--java-packages',
+            '--dotnet-packages', '--documents', '--temp', '--downloads', '--desktop',
+            '--modified', '--file-list', '--stdin', '--import-results', '--import'
+        ])) and not any(arg in sys.argv for arg in ['-g', '--use-gpt'])
+
+        if not is_help_or_version:
+            if not cls.apikey and not is_cli_without_gpt:
+                print(cls.apikey_missing_message, file=sys.stderr)
+            if not cls.taskdesc and not is_cli_without_gpt:
+                print(cls.task_missing_message, file=sys.stderr)
 
         # Enable GPT if task description is present.
         # Specific provider requirements (like API key) are checked at runtime.
@@ -509,7 +523,8 @@ class Config:
         loaded_extensions = load_file('extensions.txt', mode='multi_line')
         if not loaded_extensions:
             cls.set_extensions(cls.DEFAULT_EXTENSIONS, missing=True)
-            print(cls.extensions_missing_message, file=sys.stderr)
+            if not is_help_or_version:
+                print(cls.extensions_missing_message, file=sys.stderr)
         else:
             cls.set_extensions(loaded_extensions)
 

--- a/tests/test_config_initialization.py
+++ b/tests/test_config_initialization.py
@@ -111,3 +111,36 @@ def test_initialize_loads_ignore_patterns():
     # Ensure comments/empty lines are gone
     assert not any(p.startswith("#") for p in Config.ignore_patterns)
     assert "" not in Config.ignore_patterns
+
+
+def test_initialize_suppress_warnings_on_help(capsys):
+    """Test that Config.initialize() suppresses warnings when help or version is requested."""
+    import sys
+    Config.apikey = ""
+    Config.taskdesc = ""
+
+    # Simulate passing help option
+    with patch.object(sys, 'argv', ['gptscan.py', '--help']):
+        with patch('gptscan.load_file', return_value=[]):
+            Config.initialize()
+
+    captured = capsys.readouterr()
+    assert Config.apikey_missing_message not in captured.err
+    assert Config.task_missing_message not in captured.err
+    assert Config.extensions_missing_message not in captured.err
+
+
+def test_initialize_suppress_warnings_on_cli_without_gpt(capsys):
+    """Test that Config.initialize() suppresses api/task warnings on CLI run without GPT requested."""
+    import sys
+    Config.apikey = ""
+    Config.taskdesc = ""
+
+    # Simulate passing --cli option without GPT flag
+    with patch.object(sys, 'argv', ['gptscan.py', '--cli', '/some/path']):
+        with patch('gptscan.load_file', return_value=[".py"]):
+            Config.initialize()
+
+    captured = capsys.readouterr()
+    assert Config.apikey_missing_message not in captured.err
+    assert Config.task_missing_message not in captured.err


### PR DESCRIPTION
Improve CLI UX by suppressing optional API key and task file warnings in Config.initialize() when running CLI scans that do not request GPT, or during help/version commands. This reduces console clutter and provides a cleaner terminal interface. This is fully verified by the pytest suite (1016 passing tests), with specific test cases added to test_config_initialization.py.

---
*PR created automatically by Jules for task [11972157264607164826](https://jules.google.com/task/11972157264607164826) started by @RainRat*