### PR TITLE
Refactor duplicated target path fetching logic into _get_target_path helper

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -804,6 +804,12 @@ def _generic_scan_click(get_data_func: Callable[[], Union[List[str], List[Tuple[
         messagebox.showwarning(error_title, f"Could not scan {title.lower()}: {e}")
 
 
+def _get_target_path() -> str:
+    """Get the target path from the textbox or default to '.' if empty or None."""
+    path = textbox.get().strip() if textbox else "."
+    return path if path else "."
+
+
 def _get_initial_dir() -> Optional[str]:
     """Find a starting folder for file dialogs based on what is currently entered."""
     path_str = ""
@@ -3092,10 +3098,7 @@ def scan_clipboard_click():
 def scan_git_diff_click():
     """Scan current Git diff (staged and unstaged changes)."""
     try:
-        # Get path from textbox or default to current folder
-        target_path = textbox.get().strip() if textbox else "."
-        if not target_path:
-            target_path = "."
+        target_path = _get_target_path()
 
         diff_content = get_git_diff(target_path)
         if diff_content:
@@ -3109,10 +3112,7 @@ def scan_git_diff_click():
 def scan_git_hooks_click():
     """Scan local and global Git hooks."""
     try:
-        # Get path from textbox or default to current folder
-        target_path = textbox.get().strip() if textbox else "."
-        if not target_path:
-            target_path = "."
+        target_path = _get_target_path()
 
         hook_paths = get_git_hooks_paths(target_path)
         if hook_paths:
@@ -3139,10 +3139,7 @@ def scan_git_config_click():
 def scan_git_stash_click():
     """Scan all Git stashes."""
     try:
-        # Get path from textbox or default to current directory
-        target_path = textbox.get().strip() if textbox else "."
-        if not target_path:
-            target_path = "."
+        target_path = _get_target_path()
 
         snippets = get_git_stash_snippets(target_path)
         if snippets:
@@ -3156,10 +3153,7 @@ def scan_git_stash_click():
 def scan_git_conflicts_click():
     """Scan files with Git merge conflicts."""
     try:
-        # Get path from textbox or default to current directory
-        target_path = textbox.get().strip() if textbox else "."
-        if not target_path:
-            target_path = "."
+        target_path = _get_target_path()
 
         snippets = get_git_conflict_snippets(target_path)
         if snippets:
@@ -3348,9 +3342,7 @@ def scan_git_reflog_click(count=None):
 def scan_git_revision_click():
     """Scan files changed in a specific Git revision."""
     try:
-        target_path = textbox.get().strip() if textbox else "."
-        if not target_path:
-            target_path = "."
+        target_path = _get_target_path()
 
         toplevel, _ = _get_git_info(target_path)
         if toplevel is None:

--- a/tests/test_git_and_services_gui_clicks.py
+++ b/tests/test_git_and_services_gui_clicks.py
@@ -218,3 +218,22 @@ def test_scan_system_services_click_error(monkeypatch):
     args, _ = mock_showwarning.call_args
     assert args[0] == "System Services Error"
     assert "Services scan error" in args[1]
+
+
+def test_get_target_path_with_value(monkeypatch):
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "   /some/path/to/scan   "
+    monkeypatch.setattr(gptscan, "textbox", mock_textbox, raising=False)
+    assert gptscan._get_target_path() == "/some/path/to/scan"
+
+
+def test_get_target_path_empty(monkeypatch):
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = "   "
+    monkeypatch.setattr(gptscan, "textbox", mock_textbox, raising=False)
+    assert gptscan._get_target_path() == "."
+
+
+def test_get_target_path_no_textbox(monkeypatch):
+    monkeypatch.setattr(gptscan, "textbox", None, raising=False)
+    assert gptscan._get_target_path() == "."


### PR DESCRIPTION
This PR introduces the `_get_target_path() -> str` helper function to extract and fallback target path logic, removing duplication across five Git-related click handler functions (`scan_git_diff_click`, `scan_git_hooks_click`, `scan_git_stash_click`, `scan_git_conflicts_click`, and `scan_git_revision_click`). Additionally, robust unit tests have been added to verify its correctness.

---
*PR created automatically by Jules for task [12870829626972736334](https://jules.google.com/task/12870829626972736334) started by @RainRat*