### PR TITLE
[UI/UX] Enhance keyboard shortcuts and accessibility for Manage Exclusions and Manage Extensions dialogs

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -3974,7 +3974,7 @@ def manage_exclusions() -> None:
             except Exception as e:
                 messagebox.showerror("Error", f"Could not add folder: {e}", parent=manage_win)
 
-    def remove_selected():
+    def remove_selected(event=None):
         selection = ignore_listbox.curselection()
         if not selection:
             return
@@ -3989,6 +3989,17 @@ def manage_exclusions() -> None:
             _apply_filter()
         except Exception as e:
             messagebox.showerror("Error", f"Could not update .gptscanignore: {e}", parent=manage_win)
+
+    def select_all(event=None):
+        ignore_listbox.select_set(0, tk.END)
+        return "break"
+
+    # Keyboard Bindings
+    ignore_listbox.bind("<Delete>", remove_selected)
+    ignore_listbox.bind("<BackSpace>", remove_selected)
+    ignore_listbox.bind("<Control-a>", select_all)
+    ignore_listbox.bind("<Command-a>", select_all)
+    manage_win.bind("<Escape>", lambda e: manage_win.destroy())
 
     ttk.Button(btn_frame, text="Add Pattern...", command=add_pattern).pack(side=tk.LEFT, padx=(0, 5), ipady=5)
     ttk.Button(btn_frame, text="Add Folder...", command=add_folder).pack(side=tk.LEFT, padx=5, ipady=5)
@@ -4055,7 +4066,7 @@ def manage_extensions() -> None:
                 except Exception as e:
                     messagebox.showerror("Error", f"Could not update extensions: {e}", parent=manage_win)
 
-    def remove_selected():
+    def remove_selected(event=None):
         selection = ext_listbox.curselection()
         if not selection:
             return
@@ -4082,6 +4093,17 @@ def manage_extensions() -> None:
             refresh_list()
         except Exception as e:
             messagebox.showerror("Error", f"Could not reset extensions: {e}", parent=manage_win)
+
+    def select_all(event=None):
+        ext_listbox.select_set(0, tk.END)
+        return "break"
+
+    # Keyboard Bindings
+    ext_listbox.bind("<Delete>", remove_selected)
+    ext_listbox.bind("<BackSpace>", remove_selected)
+    ext_listbox.bind("<Control-a>", select_all)
+    ext_listbox.bind("<Command-a>", select_all)
+    manage_win.bind("<Escape>", lambda e: manage_win.destroy())
 
     ttk.Button(btn_frame, text="Add...", command=add_extension).pack(side=tk.LEFT, padx=(0, 5), ipady=5)
     ttk.Button(btn_frame, text="Remove Selected", command=remove_selected).pack(side=tk.LEFT, padx=5, ipady=5)

--- a/tests/test_extension_management.py
+++ b/tests/test_extension_management.py
@@ -19,6 +19,7 @@ def mock_gui_env(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.items = []
             self.selection = []
+            self.bindings = {}
         def insert(self, idx, item):
             if idx == gptscan.tk.END:
                 self.items.append(item)
@@ -36,6 +37,15 @@ def mock_gui_env(monkeypatch):
         def pack(self, **kwargs): pass
         def config(self, **kwargs): pass
         def yview(self, *args): pass
+        def bind(self, sequence, func, add=None):
+            self.bindings[sequence] = func
+        def select_set(self, first, last=None):
+            if last == tk.END or last == "end":
+                self.selection = list(range(first, len(self.items)))
+            elif last is not None:
+                self.selection = list(range(first, last + 1))
+            else:
+                self.selection = [first]
 
     monkeypatch.setattr(gptscan.tk, 'Listbox', MockListbox)
 
@@ -168,3 +178,46 @@ def test_manage_extensions_reset(mock_gui_env, monkeypatch):
     assert ".py" in Config.extensions_set
     assert ".custom" not in Config.extensions_set
     Config.save_extensions.assert_called()
+
+def test_manage_extensions_keyboard_bindings(mock_gui_env):
+    captured, mock_sd, mock_mb, mock_top = mock_gui_env
+    manage_extensions()
+    lb = captured['listbox']
+
+    # Check that bindings exist
+    assert "<Delete>" in lb.bindings
+    assert "<BackSpace>" in lb.bindings
+    assert "<Control-a>" in lb.bindings
+    assert "<Command-a>" in lb.bindings
+    assert mock_top.bind.called  # Esc is bound to mock_top Toplevel window
+
+def test_manage_extensions_keyboard_select_all(mock_gui_env):
+    captured, mock_sd, mock_mb, mock_top = mock_gui_env
+    Config.extensions_set = {".py", ".js"}
+    manage_extensions()
+    lb = captured['listbox']
+
+    # Trigger Select All
+    select_all_func = lb.bindings["<Control-a>"]
+    res = select_all_func(None)
+
+    assert res == "break"
+    assert lb.selection == [0, 1]
+
+def test_manage_extensions_keyboard_remove(mock_gui_env, monkeypatch):
+    captured, mock_sd, mock_mb, mock_top = mock_gui_env
+    Config.extensions_set = {".py", ".js"}
+    mock_mb.askyesno.return_value = True
+    monkeypatch.setattr(Config, "save_extensions", MagicMock())
+
+    manage_extensions()
+    lb = captured['listbox']
+    # .js is index 0 because sorted
+    lb.selection = [0]
+
+    # Trigger Delete
+    delete_func = lb.bindings["<Delete>"]
+    delete_func(None)
+
+    assert ".js" not in Config.extensions_set
+    assert ".py" in Config.extensions_set

--- a/tests/test_manage_exclusions_ui.py
+++ b/tests/test_manage_exclusions_ui.py
@@ -23,6 +23,7 @@ def mock_gui_env(monkeypatch, tmp_path):
         def __init__(self, *args, **kwargs):
             self.items = []
             self.selection = []
+            self.bindings = {}
         def insert(self, idx, item):
             if idx == "end":
                 self.items.append(item)
@@ -40,6 +41,15 @@ def mock_gui_env(monkeypatch, tmp_path):
         def pack(self, **kwargs): pass
         def config(self, **kwargs): pass
         def yview(self, *args): pass
+        def bind(self, sequence, func, add=None):
+            self.bindings[sequence] = func
+        def select_set(self, first, last=None):
+            if last == tk.END or last == "end":
+                self.selection = list(range(first, len(self.items)))
+            elif last is not None:
+                self.selection = list(range(first, last + 1))
+            else:
+                self.selection = [first]
 
     monkeypatch.setattr(gptscan.tk, 'Listbox', MockListbox)
 
@@ -214,3 +224,44 @@ def test_manage_exclusions_remove_error(mock_gui_env, monkeypatch):
     remove_cmd()
 
     mock_mb.showerror.assert_called_with("Error", "Could not update .gptscanignore: IO Error", parent=mock_top)
+
+def test_manage_exclusions_keyboard_bindings(mock_gui_env):
+    captured, mock_sd, mock_fd, mock_mb, mock_top = mock_gui_env
+    manage_exclusions()
+    lb = captured['listbox']
+
+    # Check that bindings exist
+    assert "<Delete>" in lb.bindings
+    assert "<BackSpace>" in lb.bindings
+    assert "<Control-a>" in lb.bindings
+    assert "<Command-a>" in lb.bindings
+    assert mock_top.bind.called  # Esc is bound to mock_top Toplevel window
+
+def test_manage_exclusions_keyboard_select_all(mock_gui_env):
+    captured, mock_sd, mock_fd, mock_mb, mock_top = mock_gui_env
+    Config.ignore_patterns = ["p1", "p2"]
+    manage_exclusions()
+    lb = captured['listbox']
+
+    # Trigger Select All
+    select_all_func = lb.bindings["<Control-a>"]
+    res = select_all_func(None)
+
+    assert res == "break"
+    assert lb.selection == [0, 1]
+
+def test_manage_exclusions_keyboard_remove(mock_gui_env):
+    captured, mock_sd, mock_fd, mock_mb, mock_top = mock_gui_env
+    Config.ignore_patterns = ["p1", "p2"]
+    mock_mb.askyesno.return_value = True
+
+    manage_exclusions()
+    lb = captured['listbox']
+    lb.selection = [0]
+
+    # Trigger Delete
+    delete_func = lb.bindings["<Delete>"]
+    delete_func(None)
+
+    assert "p1" not in Config.ignore_patterns
+    assert "p2" in Config.ignore_patterns


### PR DESCRIPTION
Add Delete/BackSpace keybindings to listboxes for item removal, select-all with Control-a/Command-a, and Escape key handling to close the top-level windows, with comprehensive tests verified.

---
*PR created automatically by Jules for task [3090192461463394664](https://jules.google.com/task/3090192461463394664) started by @RainRat*