### PR TITLE
[FEAT] XML Export and Import support for Scan Results

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6021,6 +6021,32 @@ def generate_markdown(results: List[Dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def generate_xml(results: List[Dict[str, Any]]) -> str:
+    """Generate an XML report from the scan results.
+
+    Args:
+        results: List of standardized result dictionaries.
+
+    Returns:
+        The XML report as a string.
+    """
+    import xml.etree.ElementTree as ET
+    root_el = ET.Element("findings")
+    for r in results:
+        finding_el = ET.SubElement(root_el, "finding")
+        for key in ["path", "line", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet"]:
+            child_el = ET.SubElement(finding_el, key)
+            child_el.text = str(r.get(key, ""))
+
+    try:
+        ET.indent(root_el, space="  ")
+    except AttributeError:
+        pass
+
+    raw_bytes = ET.tostring(root_el, encoding="utf-8")
+    return '<?xml version="1.0" encoding="utf-8"?>\n' + raw_bytes.decode("utf-8")
+
+
 def run_cli(targets: Union[str, List[str]], deep: bool, show_all: bool, use_gpt: bool, rate_limit: int, output_format: str = 'csv', dry_run: bool = False, exclude_patterns: Optional[List[str]] = None, fail_threshold: Optional[int] = None, output_file: Optional[str] = None, extra_snippets: Optional[List[Tuple[str, bytes]]] = None, import_file: Optional[str] = None, modified_since: Optional[float] = None) -> int:
     """Run scans and show results in the terminal or save them to a file.
 
@@ -6112,7 +6138,7 @@ def run_cli(targets: Union[str, List[str]], deep: bool, show_all: bool, use_gpt:
             record = dict(zip(keys, data))
             if output_format == 'json':
                 print(json.dumps(record), file=out_stream)
-            elif output_format in ('sarif', 'html', 'markdown', 'report'):
+            elif output_format in ('sarif', 'html', 'markdown', 'report', 'xml'):
                 result_buffer.append(record)
             else:
                 writer.writerow(data)
@@ -6164,6 +6190,8 @@ def run_cli(targets: Union[str, List[str]], deep: bool, show_all: bool, use_gpt:
         print(generate_html(result_buffer), file=out_stream)
     elif output_format == 'markdown':
         print(generate_markdown(result_buffer), file=out_stream)
+    elif output_format == 'xml':
+        print(generate_xml(result_buffer), file=out_stream)
     elif output_format == 'report':
         # Sort results by effective threat level (highest first)
         result_buffer.sort(
@@ -6308,12 +6336,39 @@ def parse_triage_report(content: str) -> List[Dict[str, Any]]:
     return final_results
 
 
+def parse_xml_content(content: str) -> List[Dict[str, Any]]:
+    """Parse scan findings from an XML string.
+
+    Args:
+        content: The raw XML string content.
+
+    Returns:
+        A list of result dictionaries.
+    """
+    import xml.etree.ElementTree as ET
+    try:
+        root_el = ET.fromstring(content)
+        if root_el.tag != "findings":
+            return []
+
+        data = []
+        for finding_el in root_el.findall("finding"):
+            item = {}
+            for key in ["path", "line", "own_conf", "admin_desc", "end-user_desc", "gpt_conf", "snippet"]:
+                child = finding_el.find(key)
+                item[key] = child.text if child is not None and child.text is not None else ""
+            data.append(item)
+        return data
+    except Exception as e:
+        raise ValueError(f"Failed to parse XML content: {e}")
+
+
 def parse_report_content(content: str, filename_hint: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Parse report content in JSON, SARIF, or CSV format.
+    """Parse report content in JSON, SARIF, XML, or CSV format.
 
     Args:
         content: The raw string content of the report.
-        filename_hint: Optional filename or extension hint (e.g., '.json', '.csv').
+        filename_hint: Optional filename or extension hint (e.g., '.json', '.csv', '.xml').
 
     Returns:
         A list of standardized result dictionaries.
@@ -6326,7 +6381,7 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
     if filename_hint:
         ext = os.path.splitext(filename_hint)[1].lower()
 
-    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt', '.log'):
+    if ext and ext not in ('.json', '.jsonl', '.ndjson', '.sarif', '.csv', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt', '.log', '.xml'):
         raise ValueError(f"Unsupported file extension: {ext}")
 
     data_to_import = []
@@ -6365,6 +6420,9 @@ def parse_report_content(content: str, filename_hint: Optional[str] = None) -> L
                     "snippet": html.unescape(snippet_raw.strip())
                 }
                 data_to_import.append(item)
+    elif (content.strip().startswith('<') and ('<findings' in content.lower() or content.startswith('<?xml'))) or ext == '.xml':
+        # XML report format
+        data_to_import = parse_xml_content(content)
     elif content.startswith('[') or (ext in ('.json', '.jsonl', '.ndjson')):
         if content.startswith('['):
             # Standard JSON list
@@ -6543,7 +6601,7 @@ def import_results_generator(file_path: str) -> Generator[Tuple[str, Any], None,
                 raise ValueError("Web link content is empty.")
             yield from import_results_from_content_generator(content, filename_hint=file_path)
         elif os.path.isdir(file_path):
-            supported_exts = ('.json', '.jsonl', '.ndjson', '.csv', '.sarif', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt', '.log')
+            supported_exts = ('.json', '.jsonl', '.ndjson', '.csv', '.sarif', '.md', '.markdown', '.html', '.htm', '.xhtml', '.txt', '.log', '.xml')
             files = []
             for r_dir, _, filenames in os.walk(file_path):
                 for filename in filenames:
@@ -6636,12 +6694,13 @@ def import_results(event: Optional[tk.Event] = None) -> None:
 
     file_paths = filedialog.askopenfilenames(
         filetypes=[
-            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml;*.txt;*.log"),
+            ("All supported formats", "*.json;*.jsonl;*.ndjson;*.csv;*.sarif;*.md;*.markdown;*.html;*.htm;*.xhtml;*.txt;*.log;*.xml"),
             ("JSON files", "*.json;*.jsonl;*.ndjson"),
             ("SARIF files", "*.sarif"),
             ("CSV files", "*.csv"),
             ("Markdown files", "*.md;*.markdown"),
             ("HTML files", "*.html;*.htm;*.xhtml"),
+            ("XML files", "*.xml"),
             ("Triage reports", "*.txt;*.log"),
             ("All files", "*.*")
         ],
@@ -6845,6 +6904,7 @@ def export_results(event: Optional[tk.Event] = None) -> None:
             ("HTML files", "*.html"),
             ("JSON files", "*.json"),
             ("SARIF files", "*.sarif"),
+            ("XML files", "*.xml"),
             ("Triage reports", "*.txt;*.log"),
             ("All files", "*.*")
         ],
@@ -6871,6 +6931,9 @@ def export_results(event: Optional[tk.Event] = None) -> None:
         elif ext == '.md':
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(generate_markdown(results))
+        elif ext == '.xml':
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(generate_xml(results))
         elif ext in ('.txt', '.log'):
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(generate_console_report(results, use_color=False))
@@ -9026,6 +9089,7 @@ def main():
     output_group.add_argument('--sarif', action='store_true', help='Save results in SARIF format.')
     output_group.add_argument('--html', action='store_true', help='Create an HTML report.')
     output_group.add_argument('--md', '--markdown', action='store_true', dest='markdown', help='Create a Markdown report.')
+    output_group.add_argument('--xml', action='store_true', help='Create an XML report.')
     output_group.add_argument('--report', action='store_true', help='Output a report to the terminal.')
 
     args = parser.parse_args()
@@ -9186,6 +9250,8 @@ def main():
             output_format = 'html'
         elif args.markdown:
             output_format = 'markdown'
+        elif args.xml:
+            output_format = 'xml'
         elif args.report:
             output_format = 'report'
         elif args.output:
@@ -9201,6 +9267,8 @@ def main():
                 output_format = 'markdown'
             elif ext == '.csv':
                 output_format = 'csv'
+            elif ext == '.xml':
+                output_format = 'xml'
             elif ext in ('.txt', '.log'):
                 output_format = 'report'
 

--- a/tests/test_xml_import_export.py
+++ b/tests/test_xml_import_export.py
@@ -1,0 +1,194 @@
+import os
+import pytest
+from unittest.mock import MagicMock
+import tkinter.filedialog
+import gptscan
+
+def test_generate_xml_basic():
+    """Verify that generate_xml correctly outputs standard structures."""
+    sample_results = [
+        {
+            "path": "test_script.py",
+            "line": "12",
+            "own_conf": "75%",
+            "admin_desc": "Suspicious reverse shell script.",
+            "end-user_desc": "Threat detected.",
+            "gpt_conf": "90%",
+            "snippet": "import socket,subprocess,os\ns=socket.socket()"
+        }
+    ]
+    xml_output = gptscan.generate_xml(sample_results)
+    assert '<?xml version="1.0" encoding="utf-8"?>' in xml_output
+    assert '<findings>' in xml_output
+    assert '<finding>' in xml_output
+    assert '<path>test_script.py</path>' in xml_output
+    assert '<line>12</line>' in xml_output
+    assert '<own_conf>75%</own_conf>' in xml_output
+    assert '<admin_desc>Suspicious reverse shell script.</admin_desc>' in xml_output
+    assert '<end-user_desc>Threat detected.</end-user_desc>' in xml_output
+    assert '<gpt_conf>90%</gpt_conf>' in xml_output
+    assert '<snippet>import socket,subprocess,os\ns=socket.socket()</snippet>' in xml_output
+
+def test_generate_xml_escaping():
+    """Verify that generate_xml correctly escapes special XML characters."""
+    sample_results = [
+        {
+            "path": "dangerous_<script>&_file.py",
+            "line": "42",
+            "own_conf": "99%",
+            "admin_desc": "If admin_conf < 50% ignore",
+            "end-user_desc": "Dangerous & harmful",
+            "gpt_conf": "100%",
+            "snippet": "if a < b and c > d:"
+        }
+    ]
+    xml_output = gptscan.generate_xml(sample_results)
+    assert 'dangerous_&lt;script&gt;&amp;_file.py' in xml_output
+    assert 'admin_conf &lt; 50%' in xml_output
+    assert 'Dangerous &amp; harmful' in xml_output
+    assert 'if a &lt; b and c &gt; d:' in xml_output
+
+def test_parse_xml_content_valid():
+    """Verify that parse_xml_content reconstructs dictionaries correctly."""
+    xml_input = """<?xml version="1.0" encoding="utf-8"?>
+<findings>
+  <finding>
+    <path>a.py</path>
+    <line>1</line>
+    <own_conf>15%</own_conf>
+    <admin_desc>Clean file</admin_desc>
+    <end-user_desc>Safe</end-user_desc>
+    <gpt_conf>0%</gpt_conf>
+    <snippet>print("hello")</snippet>
+  </finding>
+</findings>
+"""
+    results = gptscan.parse_xml_content(xml_input)
+    assert len(results) == 1
+    assert results[0]["path"] == "a.py"
+    assert results[0]["line"] == "1"
+    assert results[0]["own_conf"] == "15%"
+    assert results[0]["admin_desc"] == "Clean file"
+    assert results[0]["end-user_desc"] == "Safe"
+    assert results[0]["gpt_conf"] == "0%"
+    assert results[0]["snippet"] == 'print("hello")'
+
+def test_parse_xml_content_invalid():
+    """Verify that parse_xml_content handles invalid or non-findings XML safely."""
+    # Invalid root tag
+    bad_xml_root = "<different_root><finding></finding></different_root>"
+    assert gptscan.parse_xml_content(bad_xml_root) == []
+
+    # Malformed XML syntax raises ValueError
+    malformed_xml = "<findings><finding>unclosed</findings>"
+    with pytest.raises(ValueError, match="Failed to parse XML content"):
+        gptscan.parse_xml_content(malformed_xml)
+
+def test_parse_report_content_auto_detect_xml():
+    """Verify that parse_report_content correctly auto-detects and parses XML."""
+    xml_input = """<?xml version="1.0" encoding="utf-8"?>
+<findings>
+  <finding>
+    <path>detected.py</path>
+    <line>12</line>
+    <own_conf>85%</own_conf>
+    <admin_desc>Admin explanation</admin_desc>
+    <end-user_desc>User explanation</end-user_desc>
+    <gpt_conf>95%</gpt_conf>
+    <snippet>dangerous_code()</snippet>
+  </finding>
+</findings>
+"""
+    # 1. Auto-detect from <?xml header prefix
+    res1 = gptscan.parse_report_content(xml_input)
+    assert len(res1) == 1
+    assert res1[0]["path"] == "detected.py"
+
+    # 2. Auto-detect from <findings tag prefix
+    xml_no_header = "<findings><finding><path>detected2.py</path></finding></findings>"
+    res2 = gptscan.parse_report_content(xml_no_header)
+    assert len(res2) == 1
+    assert res2[0]["path"] == "detected2.py"
+
+    # 3. Detection based on .xml extension hint
+    res3 = gptscan.parse_report_content(xml_no_header, filename_hint="results.xml")
+    assert len(res3) == 1
+    assert res3[0]["path"] == "detected2.py"
+
+def test_export_results_xml_success(monkeypatch, tmp_path):
+    """Verify that results are correctly saved in XML format when exporting."""
+    file_path = tmp_path / "export.xml"
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'asksaveasfilename', lambda **k: str(file_path))
+
+    mock_tree = MagicMock()
+    monkeypatch.setattr(gptscan, "tree", mock_tree, raising=False)
+
+    sample_results = [
+        {
+            "path": "test_export.py",
+            "line": "5",
+            "own_conf": "60%",
+            "gpt_conf": "70%",
+            "admin_desc": "Admin check",
+            "end-user_desc": "User check",
+            "snippet": "some_func()"
+        }
+    ]
+    monkeypatch.setattr(gptscan, "_get_tree_results_as_dicts", lambda item_ids: sample_results)
+
+    mock_msgbox = MagicMock()
+    monkeypatch.setattr(gptscan, "messagebox", mock_msgbox)
+
+    gptscan.export_results()
+
+    assert file_path.exists()
+    content = file_path.read_text(encoding="utf-8")
+    assert '<?xml version="1.0" encoding="utf-8"?>' in content
+    assert "<path>test_export.py</path>" in content
+    assert "<admin_desc>Admin check</admin_desc>" in content
+
+def test_import_results_xml_success(monkeypatch, tmp_path):
+    """Verify that importing an XML file correctly populates the UI tree."""
+    file_path = tmp_path / "import.xml"
+    xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<findings>
+  <finding>
+    <path>imported_script.py</path>
+    <line>10</line>
+    <own_conf>45%</own_conf>
+    <gpt_conf>55%</gpt_conf>
+    <admin_desc>Admin note</admin_desc>
+    <end-user_desc>User note</end-user_desc>
+    <snippet>print("hello")</snippet>
+  </finding>
+</findings>
+"""
+    file_path.write_text(xml_content, encoding="utf-8")
+
+    monkeypatch.setattr(gptscan.tkinter.filedialog, 'askopenfilenames', lambda **k: [str(file_path)])
+
+    mock_tree = MagicMock()
+    # Empty at first
+    mock_tree.get_children.return_value = []
+    monkeypatch.setattr(gptscan, "tree", mock_tree, raising=False)
+
+    inserted_rows = []
+    def mock_insert_row(values):
+        inserted_rows.append(values)
+
+    monkeypatch.setattr(gptscan, "insert_tree_row", mock_insert_row)
+    monkeypatch.setattr(gptscan, "_auto_select_best_result", lambda: None)
+    monkeypatch.setattr(gptscan, "update_tree_columns", lambda: None)
+
+    gptscan.import_results()
+
+    assert len(inserted_rows) == 1
+    # Check that standard fields are imported correctly
+    # values structure: (path, own_conf, admin_desc, end-user_desc, gpt_conf, snippet, line)
+    assert inserted_rows[0][0] == "imported_script.py"
+    assert inserted_rows[0][1] == "45%"
+    assert inserted_rows[0][2] == "Admin note"
+    assert inserted_rows[0][3] == "User note"
+    assert inserted_rows[0][4] == "55%"
+    assert inserted_rows[0][5] == "print(\"hello\")"
+    assert inserted_rows[0][6] == "10"


### PR DESCRIPTION
This pull request implements comprehensive XML export and import functionality for scan results in both the GUI and CLI modes. It provides a standard, robust, zero-configuration and symmetric XML file format for findings.

What:
- Added `generate_xml(results: List[Dict[str, Any]]) -> str` using Python's standard library `xml.etree.ElementTree` to export scan results.
- Added `parse_xml_content(content: str) -> List[Dict[str, Any]]` to parse XML findings back into standard result dictionaries.
- Integrated the XML format into `parse_report_content` auto-detection logic, allowing `.xml` files or `<?xml` strings to be automatically parsed on import.
- Updated GUI filters for both Import and Export dialogs to natively support `.xml` files.
- Added `--xml` command-line argument to support XML report generation in the terminal, including auto-inference of the format for `.xml` output files.
- Added comprehensive unit tests in `tests/test_xml_import_export.py` ensuring full coverage of XML encoding, escaping of special characters, valid/invalid parsing, auto-detection, and UI import/export flow.

Why:
- Completes the symmetry of structured formats (JSON, CSV, SARIF, Markdown, HTML) by adding XML support, which is heavily used in DevOps and compliance integrations (e.g. CI/CD pipelines).
- Provides a clean, zero-configuration solution without external dependencies.

---
*PR created automatically by Jules for task [12624884476264593288](https://jules.google.com/task/12624884476264593288) started by @RainRat*