### PR TITLE
Deduplicate report importing finalization logic in gptscan.py

### DIFF
--- a/gptscan.py
+++ b/gptscan.py
@@ -6593,10 +6593,10 @@ def import_results_generator(file_path: str) -> Generator[Tuple[str, Any], None,
         return
 
 
-def _finalize_import(data_to_import: List[Dict[str, Any]], source_name: str) -> None:
-    """Clear results and populate the Treeview with imported data."""
-    # Clear existing results
-    clear_results()
+def _finalize_import(data_to_import: List[Dict[str, Any]], source_name: str, append: bool = False) -> None:
+    """Clear or append results and populate the Treeview with imported data."""
+    if not append:
+        clear_results()
 
     count = 0
     for item in data_to_import:
@@ -6614,6 +6614,8 @@ def _finalize_import(data_to_import: List[Dict[str, Any]], source_name: str) -> 
         count += 1
 
     msg = f"Imported {count} results from {source_name}"
+    if append:
+        msg = f"Appended {count} results to current list from {source_name}"
     global _last_scan_summary
     _last_scan_summary = msg
     update_status(msg)
@@ -6685,35 +6687,11 @@ def import_results(event: Optional[tk.Event] = None) -> None:
             messagebox.showwarning("Import Warning", "No data found in the selected files.")
         return
 
-    if not append_existing:
-        clear_results()
-
-    count = 0
-    for item in all_imported_data:
-        values = (
-            item.get("path", ""),
-            item.get("own_conf", ""),
-            item.get("admin_desc", ""),
-            item.get("end-user_desc", ""),
-            item.get("gpt_conf", ""),
-            item.get("snippet", ""),
-            item.get("line", "-")
-        )
-        insert_tree_row(values)
-        count += 1
-
     source_names = ", ".join(loaded_files)
     if len(loaded_files) > 3:
         source_names = f"{len(loaded_files)} files"
 
-    msg = f"Imported {count} results from {source_names}"
-    if append_existing:
-        msg = f"Appended {count} results to current list from {source_names}"
-    global _last_scan_summary
-    _last_scan_summary = msg
-    update_status(msg)
-    update_tree_columns()
-    _auto_select_best_result()
+    _finalize_import(all_imported_data, source_names, append=append_existing)
 
 
 def import_from_clipboard(event: Optional[tk.Event] = None) -> Optional[str]:


### PR DESCRIPTION
### What:
Refactored `_finalize_import` to accept an optional `append` boolean argument (defaulting to `False`) to support both overwriting and appending treeview data. Then, replaced the duplicate result-population, status-updating, and column-refreshing logic in the main `import_results` function with a clean delegation call to `_finalize_import`.

### Why:
Eliminates code duplication and reduces file size by about 25 lines. This improves maintainability and ensures that importing files via standard menus, clipboard, or URLs share the identical, robust results-rendering and status-updating logic. All 1066 tests pass, confirming no breaking changes were introduced.

---
*PR created automatically by Jules for task [4130424146633279061](https://jules.google.com/task/4130424146633279061) started by @RainRat*