### PR TITLE
[TEST] Add targeted test coverage for gptscan error and boundary paths

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+import gptscan
+from gptscan import parse_report_content, Config, _get_initial_dir
+
+def test_parse_report_content_undecipherable():
+    invalid_content = "completely random non-json plain text with no structure"
+    with pytest.raises(ValueError, match="Could not determine report format."):
+        parse_report_content(invalid_content)
+
+def test_config_save_cache_error(monkeypatch, capsys):
+    mock_open = MagicMock(side_effect=OSError("Disk full"))
+    monkeypatch.setattr("builtins.open", mock_open)
+
+    Config.save_cache()
+
+    captured = capsys.readouterr()
+    assert "Warning: Could not save AI cache:" in captured.err
+    assert "Disk full" in captured.err
+
+def test_config_load_cache_error(monkeypatch, capsys):
+    monkeypatch.setattr(os.path, "exists", lambda x: True)
+
+    mock_open = MagicMock(side_effect=OSError("Permission denied"))
+    monkeypatch.setattr("builtins.open", mock_open)
+
+    Config.load_cache()
+
+    captured = capsys.readouterr()
+    assert "Warning: Could not load AI cache:" in captured.err
+    assert "Permission denied" in captured.err
+
+def test_get_initial_dir_shlex_empty(monkeypatch):
+    mock_textbox = MagicMock()
+    mock_textbox.get.return_value = " # comment only "
+    monkeypatch.setattr(gptscan, "textbox", mock_textbox)
+
+    assert _get_initial_dir() is None
+
+def test_is_supported_file_os_error(tmp_path):
+    non_file_path = tmp_path / "test_directory"
+    non_file_path.mkdir()
+
+    assert Config.is_supported_file(non_file_path) is False


### PR DESCRIPTION
This pull request introduces robust and focused unit tests in a new test suite (`tests/test_coverage_gaps.py`) to systematically address previously uncovered error handling and boundary branches within `gptscan.py`. Specifically, it covers the following gaps:

- `parse_report_content` falling back to raise `ValueError("Could not determine report format.")` when the report content cannot be auto-detected and is not valid JSON.
- Exception handlers in `Config.save_cache` and `Config.load_cache` which write warning messages to `sys.stderr` when experiencing I/O errors (e.g. permission issues or disk full).
- `_get_initial_dir` returning `None` when a non-empty textbox input (such as comment-only text `# comments`) results in an empty parsed list of paths.
- `Config.is_supported_file` returning `False` gracefully when an `OSError` (such as a directory path or restricted permissions) occurs on open/read.

All 1071 unit tests in the codebase pass cleanly, and the missing statements count in `gptscan.py` has successfully decreased.

---
*PR created automatically by Jules for task [2336004976483606850](https://jules.google.com/task/2336004976483606850) started by @RainRat*